### PR TITLE
Initial modules for image processing and modeling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="menipy",
+    version="0.1.0",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    install_requires=[
+        "numpy>=1.24.0",
+        "scipy>=1.10.0",
+        "pandas>=1.5.3",
+        "scikit-image>=0.19.3",
+        "opencv-python>=4.7.0.72",
+        "PySide6>=6.5.1",
+        "matplotlib>=3.7.1",
+    ],
+    entry_points={"console_scripts": ["menipy=main:main"]},
+)
+

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,8 @@
+"""Model utilities for Menipy."""
+
+from .geometry import fit_circle
+from .physics import solve_young_laplace
+from .properties import droplet_volume
+
+__all__ = ["fit_circle", "solve_young_laplace", "droplet_volume"]
+

--- a/src/models/geometry.py
+++ b/src/models/geometry.py
@@ -1,0 +1,32 @@
+"""Geometric fitting utilities."""
+
+from typing import Tuple
+
+import numpy as np
+from numpy.linalg import lstsq
+
+
+def fit_circle(points: np.ndarray) -> Tuple[np.ndarray, float]:
+    """Fit a circle to 2D points using linear least squares.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        Array of shape (N, 2) with x, y coordinates.
+
+    Returns
+    -------
+    center : np.ndarray
+        Circle center (x, y).
+    radius : float
+        Circle radius.
+    """
+    x = points[:, 0]
+    y = points[:, 1]
+    A = np.c_[2 * x, 2 * y, np.ones_like(x)]
+    b = x ** 2 + y ** 2
+    c, residuals, _, _ = lstsq(A, b, rcond=None)
+    center = c[:2]
+    radius = np.sqrt(c[2] + center.dot(center))
+    return center, radius
+

--- a/src/models/physics.py
+++ b/src/models/physics.py
@@ -1,0 +1,22 @@
+"""Physical modeling utilities."""
+
+from typing import Callable
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+
+def young_laplace_ode(r, y, gamma, delta_rho, g):
+    """Example ODE for the Young-Laplace equation (simplified)."""
+    z, phi = y
+    dzdr = np.tan(phi)
+    dphidr = (delta_rho * g * r / gamma) - (np.sin(phi) / r)
+    return [dzdr, dphidr]
+
+
+def solve_young_laplace(r_span, y0, gamma, delta_rho, g=9.81):
+    """Integrate the Young-Laplace ODE."""
+    sol = solve_ivp(young_laplace_ode, r_span, y0, args=(gamma, delta_rho, g),
+                    dense_output=True)
+    return sol
+

--- a/src/models/properties.py
+++ b/src/models/properties.py
@@ -1,0 +1,11 @@
+"""Property calculation functions."""
+
+import numpy as np
+
+
+def droplet_volume(radius: float, contact_angle: float) -> float:
+    """Approximate droplet volume using spherical cap formula."""
+    h = radius * (1 - np.cos(contact_angle))
+    volume = (np.pi * h**2 * (3 * radius - h)) / 3.0
+    return volume
+

--- a/src/processing/reader.py
+++ b/src/processing/reader.py
@@ -1,0 +1,30 @@
+"""Image reading utilities for Menipy."""
+from pathlib import Path
+from typing import Union
+
+import cv2
+import numpy as np
+
+
+def load_image(path: Union[str, Path], as_gray: bool = False) -> np.ndarray:
+    """Load an image from disk.
+
+    Parameters
+    ----------
+    path:
+        Path to the image file.
+    as_gray:
+        If ``True``, return a single-channel grayscale image.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded image array.
+    """
+    path = Path(path)
+    flag = cv2.IMREAD_GRAYSCALE if as_gray else cv2.IMREAD_COLOR
+    image = cv2.imread(str(path), flag)
+    if image is None:
+        raise FileNotFoundError(f"Could not read image: {path}")
+    return image
+

--- a/src/processing/segmentation.py
+++ b/src/processing/segmentation.py
@@ -1,0 +1,35 @@
+"""Segmentation routines for droplet images."""
+
+import cv2
+import numpy as np
+from skimage import filters, morphology
+
+
+def otsu_threshold(image: np.ndarray) -> np.ndarray:
+    """Segment image using Otsu's global threshold."""
+    if image.ndim == 3:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    else:
+        gray = image
+    thresh_val, mask = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    return mask
+
+
+def adaptive_threshold(image: np.ndarray, block_size: int = 51, offset: int = 10) -> np.ndarray:
+    """Segment image using adaptive mean thresholding."""
+    if image.ndim == 3:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    else:
+        gray = image
+    mask = cv2.adaptiveThreshold(gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C,
+                                 cv2.THRESH_BINARY, block_size, offset)
+    return mask
+
+
+def morphological_cleanup(mask: np.ndarray, kernel_size: int = 3, iterations: int = 1) -> np.ndarray:
+    """Clean up a binary mask using morphological opening and closing."""
+    kernel = np.ones((kernel_size, kernel_size), dtype=np.uint8)
+    opened = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel, iterations=iterations)
+    closed = cv2.morphologyEx(opened, cv2.MORPH_CLOSE, kernel, iterations=iterations)
+    return closed
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,20 @@
-"""Placeholder tests for models module."""
+import numpy as np
+
+from src.models.geometry import fit_circle
+from src.models.properties import droplet_volume
 
 
-def test_dummy():
-    assert True
+def test_fit_circle():
+    # Points on a circle centered at (1, 2) radius 3
+    theta = np.linspace(0, 2 * np.pi, 50)
+    x = 1 + 3 * np.cos(theta)
+    y = 2 + 3 * np.sin(theta)
+    center, radius = fit_circle(np.stack([x, y], axis=1))
+    assert np.allclose(center, [1, 2], atol=1e-1)
+    assert np.isclose(radius, 3, atol=1e-1)
+
+
+def test_droplet_volume():
+    volume = droplet_volume(2.0, np.deg2rad(60))
+    assert volume > 0
+

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,5 +1,31 @@
-"""Placeholder tests for processing module."""
+import numpy as np
+
+from src.processing.segmentation import (
+    otsu_threshold,
+    adaptive_threshold,
+    morphological_cleanup,
+)
 
 
-def test_dummy():
-    assert True
+def test_otsu_threshold():
+    img = np.zeros((50, 50), dtype=np.uint8)
+    img[20:30, 20:30] = 255
+    mask = otsu_threshold(img)
+    assert mask.sum() > 0
+
+
+def test_adaptive_threshold():
+    img = np.zeros((50, 50), dtype=np.uint8)
+    img[10:40, 10:40] = 255
+    mask = adaptive_threshold(img, block_size=11, offset=2)
+    assert mask.sum() > 0
+
+
+def test_morphological_cleanup():
+    mask = np.zeros((20, 20), dtype=np.uint8)
+    mask[5:15, 5:15] = 255
+    mask[0, 0] = 255  # noise pixel
+    cleaned = morphological_cleanup(mask, kernel_size=3, iterations=1)
+    assert cleaned[0, 0] == 0
+    assert cleaned.sum() >= mask[5:15, 5:15].sum()
+


### PR DESCRIPTION
## Summary
- add image reader and segmentation utilities
- implement basic geometric and physical models
- create setup.py for packaging
- write unit tests for new processing and model functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea80b714832e990a60c12e5d5c22