### PR TITLE
Add initial PySide6 GUI skeleton

### DIFF
--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,0 +1,5 @@
+"""GUI package initialization."""
+
+from .main_window import MainWindow
+
+__all__ = ["MainWindow"]

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,0 +1,42 @@
+"""Main Window module for Menipy GUI."""
+
+from PySide6 import QtWidgets
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Main application window with image view and control panel."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Menipy")
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Create widgets and layouts."""
+        splitter = QtWidgets.QSplitter()
+
+        # Image display area
+        self.graphics_view = QtWidgets.QGraphicsView()
+        splitter.addWidget(self.graphics_view)
+
+        # Control panel
+        control_widget = QtWidgets.QWidget()
+        control_layout = QtWidgets.QVBoxLayout(control_widget)
+        self.process_button = QtWidgets.QPushButton("Process")
+        control_layout.addWidget(self.process_button)
+        control_layout.addStretch()
+        splitter.addWidget(control_widget)
+
+        self.setCentralWidget(splitter)
+
+
+def main():
+    """Launch the Menipy GUI application."""
+    app = QtWidgets.QApplication([])
+    window = MainWindow()
+    window.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,5 +1,29 @@
-"""Placeholder tests for gui module."""
+"""Tests for gui module."""
+
+import pytest
+
+try:
+    from src.gui import MainWindow
+    from PySide6 import QtWidgets
+except Exception as exc:
+    MainWindow = None
+    QtWidgets = None
+    missing_dependency = exc
+else:
+    missing_dependency = None
 
 
-def test_dummy():
-    assert True
+def test_main_window_exists():
+    if MainWindow is None:
+        pytest.skip(f"PySide6 not available: {missing_dependency}")
+    assert MainWindow is not None
+
+
+def test_main_window_instantiation():
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    assert window.windowTitle() == "Menipy"
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- implement `MainWindow` in `src/gui/main_window.py`
- expose `MainWindow` in package init
- create tests that check PySide6 availability and instantiate `MainWindow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863efcac9d0832eb52157782d1785c8