### PR TITLE
Enhance GUI and calibration utilities

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -13,3 +13,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Add a new "CODEXLOG" agent description in AGENTS.md so that CODEX appends to CODEXLOG.md after each task.
 
 **Summary:** Updated AGENTS.md with a dedicated CODEXLOG agent section describing how the log should be maintained. Appended this entry to record the update.
+
+## Entry 3 - Continue working with the PLAN
+
+**Task:** Continue implementing features from PLAN.md, focusing on the GUI skeleton and calibration utilities.
+
+**Summary:** Added basic image loading and segmentation controls to `gui/main_window.py`, implemented calibration utilities under `src/utils`, updated the CLI entry point, and expanded tests accordingly.

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version="0.1.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
+    py_modules=["main"],
     install_requires=[
         "numpy>=1.24.0",
         "scipy>=1.10.0",

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,6 +1,11 @@
-"""Main Window module for Menipy GUI."""
+"""Main window module for Menipy GUI."""
 
-from PySide6 import QtWidgets
+from pathlib import Path
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from ..processing.reader import load_image
+from ..processing import segmentation
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -12,22 +17,101 @@ class MainWindow(QtWidgets.QMainWindow):
         self._setup_ui()
 
     def _setup_ui(self) -> None:
-        """Create widgets and layouts."""
+        """Create widgets, menus, and layouts."""
         splitter = QtWidgets.QSplitter()
 
         # Image display area
         self.graphics_view = QtWidgets.QGraphicsView()
+        self.graphics_scene = QtWidgets.QGraphicsScene(self)
+        self.graphics_view.setScene(self.graphics_scene)
         splitter.addWidget(self.graphics_view)
 
         # Control panel
         control_widget = QtWidgets.QWidget()
         control_layout = QtWidgets.QVBoxLayout(control_widget)
+
+        self.algorithm_combo = QtWidgets.QComboBox()
+        self.algorithm_combo.addItems(["Otsu", "Adaptive"])
+        control_layout.addWidget(self.algorithm_combo)
+
         self.process_button = QtWidgets.QPushButton("Process")
+        self.process_button.clicked.connect(self.process_image)
         control_layout.addWidget(self.process_button)
+
         control_layout.addStretch()
         splitter.addWidget(control_widget)
 
         self.setCentralWidget(splitter)
+
+        # Menu actions
+        open_action = QtWidgets.QAction("Open Image", self)
+        open_action.triggered.connect(self.open_image)
+        file_menu = self.menuBar().addMenu("File")
+        file_menu.addAction(open_action)
+
+        calib_action = QtWidgets.QAction("Calibration", self)
+        calib_action.triggered.connect(self.open_calibration)
+        tools_menu = self.menuBar().addMenu("Tools")
+        tools_menu.addAction(calib_action)
+
+        self.mask_item = None
+
+    def open_image(self) -> None:
+        """Open an image file and display it."""
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open Image", str(Path.home()), "Images (*.png *.jpg *.bmp)"
+        )
+        if path:
+            self.load_image(Path(path))
+
+    def load_image(self, path: Path) -> None:
+        self.image = load_image(path)
+        if self.image.ndim == 3:
+            rgb = QtGui.QImage(
+                self.image.data,
+                self.image.shape[1],
+                self.image.shape[0],
+                self.image.strides[0],
+                QtGui.QImage.Format_BGR888,
+            )
+        else:
+            rgb = QtGui.QImage(
+                self.image.data,
+                self.image.shape[1],
+                self.image.shape[0],
+                self.image.strides[0],
+                QtGui.QImage.Format_Grayscale8,
+            )
+        pixmap = QtGui.QPixmap.fromImage(rgb)
+        self.graphics_scene.clear()
+        self.pixmap_item = self.graphics_scene.addPixmap(pixmap)
+        self.graphics_view.fitInView(self.pixmap_item, QtCore.Qt.KeepAspectRatio)
+
+    def process_image(self) -> None:
+        """Run segmentation on the loaded image and overlay the mask."""
+        if getattr(self, "image", None) is None:
+            return
+        algo = self.algorithm_combo.currentText()
+        if algo == "Otsu":
+            mask = segmentation.otsu_threshold(self.image)
+        else:
+            mask = segmentation.adaptive_threshold(self.image)
+        mask_img = QtGui.QImage(
+            mask.data,
+            mask.shape[1],
+            mask.shape[0],
+            mask.strides[0],
+            QtGui.QImage.Format_Grayscale8,
+        )
+        mask_pix = QtGui.QPixmap.fromImage(mask_img)
+        if self.mask_item is not None:
+            self.graphics_scene.removeItem(self.mask_item)
+        self.mask_item = self.graphics_scene.addPixmap(mask_pix)
+        self.mask_item.setOpacity(0.4)
+
+    def open_calibration(self) -> None:
+        """Display a placeholder calibration dialog."""
+        QtWidgets.QMessageBox.information(self, "Calibration", "Not implemented")
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,16 @@
 """Entry point for the Menipy application."""
 
+from PySide6 import QtWidgets
 
-def main():
-    """CLI stub that will launch the GUI application."""
-    pass
+from .gui.main_window import MainWindow
+
+
+def main() -> None:
+    """Launch the Menipy GUI application."""
+    app = QtWidgets.QApplication([])
+    window = MainWindow()
+    window.show()
+    app.exec()
 
 
 if __name__ == "__main__":

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for Menipy."""
+
+from .calibration import Calibration, get_calibration, set_calibration
+
+__all__ = ["Calibration", "get_calibration", "set_calibration"]

--- a/src/utils/calibration.py
+++ b/src/utils/calibration.py
@@ -1,0 +1,23 @@
+"""Calibration utilities for pixel to physical units."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Calibration:
+    """Simple calibration data container."""
+
+    pixels_per_mm: float
+
+
+_default_calibration = Calibration(pixels_per_mm=1.0)
+
+
+def set_calibration(pixels_per_mm: float) -> None:
+    """Set the global calibration value."""
+    _default_calibration.pixels_per_mm = pixels_per_mm
+
+
+def get_calibration() -> Calibration:
+    """Return the current calibration data."""
+    return _default_calibration

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -25,5 +25,6 @@ def test_main_window_instantiation():
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
     window = MainWindow()
     assert window.windowTitle() == "Menipy"
+    assert window.algorithm_combo.count() >= 2
     window.close()
     app.quit()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+from src.utils import set_calibration, get_calibration
+
+
+def test_calibration_roundtrip():
+    set_calibration(2.5)
+    cal = get_calibration()
+    assert cal.pixels_per_mm == 2.5
+    # Ensure getter returns updated value
+    assert get_calibration().pixels_per_mm == 2.5


### PR DESCRIPTION
## Summary
- expand GUI to load images and run segmentation
- add calibration utilities
- expose CLI entry point
- update package metadata
- extend tests for GUI and utilities
- log activity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f6368c50832eb1e9e0750588a771