### PR TITLE
Fix image scaling

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -25,3 +25,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Resolve error due to missing QAction attribute from QtWidgets by importing QAction from QtGui and updating usage.
 
 **Summary:** Updated `gui/main_window.py` to import `QAction` from `PySide6.QtGui` and replaced references to QtWidgets with direct class imports. All tests pass.
+
+## Entry 5 - Display Image at Native Size
+
+**Task:** Adjust the GUI so loaded images are shown at their original dimensions instead of being fit to the view.
+
+**Summary:** Modified `load_image` in `gui/main_window.py` to reset the view transform and set the scene rectangle to the pixmap's bounds. Added a corresponding unit test to verify the image dimensions and transform. All tests pass (GUI tests skipped if PySide6 unavailable).

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -99,7 +99,8 @@ class MainWindow(QMainWindow):
         pixmap = QPixmap.fromImage(rgb)
         self.graphics_scene.clear()
         self.pixmap_item = self.graphics_scene.addPixmap(pixmap)
-        self.graphics_view.fitInView(self.pixmap_item, Qt.KeepAspectRatio)
+        self.graphics_view.resetTransform()
+        self.graphics_view.setSceneRect(self.pixmap_item.boundingRect())
 
     def process_image(self) -> None:
         """Run segmentation on the loaded image and overlay the mask."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -28,3 +28,29 @@ def test_main_window_instantiation():
     assert window.algorithm_combo.count() >= 2
     window.close()
     app.quit()
+
+
+def test_load_image_retains_size(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+
+    img = np.zeros((20, 30, 3), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+
+    pixmap = window.pixmap_item.pixmap()
+    assert pixmap.width() == 30
+    assert pixmap.height() == 20
+    transform = window.graphics_view.transform()
+    assert transform.m11() == 1
+    assert transform.m22() == 1
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- ensure images display at native size in the GUI
- test that image dimensions are retained when loaded
- log the change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863feffd054832ea5d82eb2f12f8b29