### PR TITLE
Implement contour overlays and save feature

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -38,3 +38,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 
 **Summary:** Updated `load_image` to set the graphics view size to the pixmap's bounding rectangle and call `adjustSize()` so the window expands. Extended the GUI test to confirm the view size matches the image.
 
+## Entry 7 - Overlay Contours and Save Image
+
+**Task:** Continue with the plan by integrating contour overlays after segmentation and adding a feature to save the annotated image.
+
+**Summary:** Implemented `find_contours` in `segmentation.py` and updated `MainWindow` to draw contour overlays using `QPainterPath`. Added a "Save Annotated Image" action and method that render the scene to a file. Extended processing and GUI tests to cover these new capabilities.
+

--- a/src/processing/segmentation.py
+++ b/src/processing/segmentation.py
@@ -33,3 +33,9 @@ def morphological_cleanup(mask: np.ndarray, kernel_size: int = 3, iterations: in
     closed = cv2.morphologyEx(opened, cv2.MORPH_CLOSE, kernel, iterations=iterations)
     return closed
 
+
+def find_contours(mask: np.ndarray) -> list[np.ndarray]:
+    """Return contours from a binary mask."""
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    return [c.squeeze(1) for c in contours if c.size > 0]
+

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -57,3 +57,29 @@ def test_load_image_retains_size(tmp_path):
 
     window.close()
     app.quit()
+
+
+def test_save_annotated_image(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+
+    img = np.zeros((10, 10), dtype=np.uint8)
+    img[2:8, 2:8] = 255
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+    window.process_image()
+
+    out_path = tmp_path / "annotated.png"
+    window.save_annotated_image(out_path)
+
+    assert out_path.exists()
+
+    window.close()
+    app.quit()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4,6 +4,7 @@ from src.processing.segmentation import (
     otsu_threshold,
     adaptive_threshold,
     morphological_cleanup,
+    find_contours,
 )
 
 
@@ -28,4 +29,13 @@ def test_morphological_cleanup():
     cleaned = morphological_cleanup(mask, kernel_size=3, iterations=1)
     assert cleaned[0, 0] == 0
     assert cleaned.sum() >= mask[5:15, 5:15].sum()
+
+
+def test_find_contours():
+    mask = np.zeros((30, 30), dtype=np.uint8)
+    cv2 = __import__('cv2')
+    cv2.rectangle(mask, (5, 5), (25, 25), 255, -1)
+    contours = find_contours(mask)
+    assert len(contours) == 1
+    assert contours[0].shape[1] == 2
 


### PR DESCRIPTION
## Summary
- enable contour extraction via new `find_contours` helper
- draw segmentation contours and allow saving annotated images from the GUI
- extend processing and GUI tests for these features
- log the work in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640624fc84832e9a55b104ed0e176c