### PR TITLE
Add calibration dialog and utilities

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -44,3 +44,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 
 **Summary:** Implemented `find_contours` in `segmentation.py` and updated `MainWindow` to draw contour overlays using `QPainterPath`. Added a "Save Annotated Image" action and method that render the scene to a file. Extended processing and GUI tests to cover these new capabilities.
 
+
+## Entry 8 - Calibration Dialog
+
+**Task:** Continue with the plan by adding calibration features to allow setting pixel-to-millimeter scaling from a reference line in the image.
+
+**Summary:** Implemented an interactive `CalibrationDialog` that lets the user draw a line on the image and enter its real-world length. The dialog computes pixels-per-millimeter using `calibrate_from_points` from updated `utils.calibration`. The main window now launches this dialog via the Tools menu. Utility functions for conversions were added along with new tests.

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,5 +1,6 @@
 """GUI package initialization."""
 
 from .main_window import MainWindow
+from .calibration_dialog import CalibrationDialog
 
-__all__ = ["MainWindow"]
+__all__ = ["MainWindow", "CalibrationDialog"]

--- a/src/gui/calibration_dialog.py
+++ b/src/gui/calibration_dialog.py
@@ -1,0 +1,103 @@
+"""Dialog for interactive calibration using a reference line."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from PySide6.QtCore import Qt, QLineF
+from PySide6.QtGui import QImage, QPixmap, QPen, QColor
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QGraphicsScene,
+    QGraphicsView,
+    QLabel,
+    QVBoxLayout,
+)
+
+from ..utils import calibrate_from_points
+
+
+@dataclass
+class _Point:
+    x: float
+    y: float
+
+
+class CalibrationDialog(QDialog):
+    """Interactive dialog to set image scale."""
+
+    def __init__(self, image, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Calibration")
+        self.points: list[_Point] = []
+        self.line_item = None
+        self.pixel_length = 0.0
+        self._setup_ui(image)
+
+    def _setup_ui(self, image) -> None:
+        layout = QVBoxLayout(self)
+
+        self.view = QGraphicsView()
+        self.scene = QGraphicsScene(self)
+        self.view.setScene(self.scene)
+        layout.addWidget(self.view)
+
+        if image.ndim == 3:
+            qimg = QImage(
+                image.data,
+                image.shape[1],
+                image.shape[0],
+                image.strides[0],
+                QImage.Format_BGR888,
+            )
+        else:
+            qimg = QImage(
+                image.data,
+                image.shape[1],
+                image.shape[0],
+                image.strides[0],
+                QImage.Format_Grayscale8,
+            )
+        pixmap = QPixmap.fromImage(qimg)
+        self.scene.addPixmap(pixmap)
+
+        self.info_label = QLabel("Click two points to measure reference length.")
+        layout.addWidget(self.info_label)
+
+        self.mm_input = QDoubleSpinBox()
+        self.mm_input.setSuffix(" mm")
+        self.mm_input.setDecimals(3)
+        self.mm_input.setValue(1.0)
+        layout.addWidget(self.mm_input)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.view.mousePressEvent = self._on_mouse_press  # type: ignore[assignment]
+
+    def _on_mouse_press(self, event):
+        pos = self.view.mapToScene(event.pos())
+        self.points.append(_Point(pos.x(), pos.y()))
+        if len(self.points) == 2:
+            if self.line_item:
+                self.scene.removeItem(self.line_item)
+            line = QLineF(self.points[0].x, self.points[0].y, self.points[1].x, self.points[1].y)
+            pen = QPen(QColor("red"))
+            pen.setWidth(2)
+            self.line_item = self.scene.addLine(line, pen)
+            self.pixel_length = line.length()
+            self.info_label.setText(f"Pixel length: {self.pixel_length:.1f} px")
+
+    def accept(self) -> None:  # type: ignore[override]
+        if len(self.points) == 2 and self.mm_input.value() > 0:
+            calibrate_from_points(
+                (self.points[0].x, self.points[0].y),
+                (self.points[1].x, self.points[1].y),
+                self.mm_input.value(),
+            )
+        super().accept()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -29,6 +29,8 @@ from PySide6.QtWidgets import (
 from ..processing.reader import load_image
 from ..processing import segmentation
 from ..processing.segmentation import morphological_cleanup, find_contours
+from ..utils import get_calibration
+from .calibration_dialog import CalibrationDialog
 
 
 class MainWindow(QMainWindow):
@@ -184,8 +186,18 @@ class MainWindow(QMainWindow):
         image.save(str(path))
 
     def open_calibration(self) -> None:
-        """Display a placeholder calibration dialog."""
-        QMessageBox.information(self, "Calibration", "Not implemented")
+        """Open a dialog to calibrate pixel size."""
+        if getattr(self, "image", None) is None:
+            QMessageBox.information(self, "Calibration", "Load an image first")
+            return
+        dialog = CalibrationDialog(self.image, self)
+        if dialog.exec():
+            cal = get_calibration()
+            QMessageBox.information(
+                self,
+                "Calibration",
+                f"Calibration set to {cal.pixels_per_mm:.2f} px/mm",
+            )
 
 
 def main():

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,19 @@
 """Utility helpers for Menipy."""
 
-from .calibration import Calibration, get_calibration, set_calibration
+from .calibration import (
+    Calibration,
+    calibrate_from_points,
+    get_calibration,
+    mm_to_pixels,
+    pixels_to_mm,
+    set_calibration,
+)
 
-__all__ = ["Calibration", "get_calibration", "set_calibration"]
+__all__ = [
+    "Calibration",
+    "get_calibration",
+    "set_calibration",
+    "pixels_to_mm",
+    "mm_to_pixels",
+    "calibrate_from_points",
+]

--- a/src/utils/calibration.py
+++ b/src/utils/calibration.py
@@ -21,3 +21,37 @@ def set_calibration(pixels_per_mm: float) -> None:
 def get_calibration() -> Calibration:
     """Return the current calibration data."""
     return _default_calibration
+
+
+def mm_to_pixels(mm: float) -> float:
+    """Convert a length in millimeters to pixels using current calibration."""
+    return mm * _default_calibration.pixels_per_mm
+
+
+def pixels_to_mm(pixels: float) -> float:
+    """Convert a pixel distance to millimeters using current calibration."""
+    return pixels / _default_calibration.pixels_per_mm
+
+
+def calibrate_from_points(p1: tuple[float, float], p2: tuple[float, float], length_mm: float) -> float:
+    """Set calibration based on two points and a known physical length.
+
+    Parameters
+    ----------
+    p1, p2:
+        Endpoints of the reference line in pixels.
+    length_mm:
+        The physical distance in millimeters corresponding to the line.
+
+    Returns
+    -------
+    float
+        The measured pixel length between the two points.
+    """
+    from math import hypot
+
+    pixel_length = hypot(p1[0] - p2[0], p1[1] - p2[1])
+    if length_mm <= 0:
+        raise ValueError("length_mm must be positive")
+    set_calibration(pixel_length / length_mm)
+    return pixel_length

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,10 @@
-from src.utils import set_calibration, get_calibration
+from src.utils import (
+    set_calibration,
+    get_calibration,
+    calibrate_from_points,
+    pixels_to_mm,
+    mm_to_pixels,
+)
 
 
 def test_calibration_roundtrip():
@@ -7,3 +13,13 @@ def test_calibration_roundtrip():
     assert cal.pixels_per_mm == 2.5
     # Ensure getter returns updated value
     assert get_calibration().pixels_per_mm == 2.5
+
+
+def test_calibration_from_points():
+    set_calibration(1.0)
+    px_len = calibrate_from_points((0, 0), (0, 10), 5.0)
+    assert px_len == 10
+    assert get_calibration().pixels_per_mm == 2.0
+    assert pixels_to_mm(10) == 5.0
+    assert mm_to_pixels(5.0) == 10
+


### PR DESCRIPTION
## Summary
- implement calibration utilities with pixel/mm conversions
- add interactive CalibrationDialog
- connect calibration dialog in GUI
- expose new utilities and export in `src/utils/__init__`
- update unit tests for calibration helpers
- log calibration dialog in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640a0fdba8832ebf056e86e2d71721