### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install .
+      - name: Run tests
+        run: |
+          pytest --cov=src --cov-report=xml
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+

--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -56,3 +56,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Continue with the plan by implementing batch mode to process directories of images and export results.
 
 **Summary:** Added a functional `run_batch` in `src/batch.py` that loads each image, applies Otsu thresholding and morphological cleanup, counts contours, and collects basic stats into a pandas DataFrame. Results can be saved to CSV. Created `tests/test_batch.py` to verify batch processing and CSV output.
+
+## Entry 10 - CI Workflow
+
+**Task:** Continue with the plan by adding continuous integration to run tests and build packages automatically.
+
+**Summary:** Created `.github/workflows/ci.yml` to set up Python 3.10 and 3.11, install dependencies, run pytest with coverage, and build source and wheel distributions.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for testing and packaging
- log new CI entry in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640ec3aa04832e8c4649d537a5d58a