### PR TITLE
Add ML segmentation toggle

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -62,3 +62,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Continue with the plan by adding continuous integration to run tests and build packages automatically.
 
 **Summary:** Created `.github/workflows/ci.yml` to set up Python 3.10 and 3.11, install dependencies, run pytest with coverage, and build source and wheel distributions.
+
+## Entry 11 - ML Segmentation Toggle
+
+**Task:** Continue with the plan by adding an optional ML-based segmentation toggle in the GUI.
+
+**Summary:** Implemented a `Use ML Segmentation` checkable action in `MainWindow` and a placeholder `ml_segment` function. Processing now routes through this function when the action is enabled, and tests verify the new behavior.

--- a/PLAN.md
+++ b/PLAN.md
@@ -100,10 +100,14 @@ Based on the “Development Plan for a Python-Based Droplet Shape Analysis Tool�
 
 7. **GUI Skeleton**
 
+   <!-- Completed by Codex -->
+
    - In `gui/main_window.py` build two‐panel layout: image view + controls using PySide6.
    - Stub controls: open file/folder, calibration dialog, model selector, “Process” button.
 
 8. **Integration & Overlays**
+
+   <!-- Completed by Codex -->
 
    - Hook processing modules into GUI actions.
    - Draw overlays (raw contour, model curve) using QGraphicsView or Matplotlib canvas.
@@ -111,23 +115,33 @@ Based on the “Development Plan for a Python-Based Droplet Shape Analysis Tool�
 
 9. **Calibration Features**
 
+   <!-- Completed by Codex -->
+
    - Implement `utils/calibration.py` for pixel-to-mm entry and on-image line measurement dialog.
 
 10. **Batch Mode**
 
+    <!-- Completed by Codex -->
+
     - In `batch.py`, iterate over directory, apply default segmentation + model(s), aggregate results into a pandas DataFrame and export to CSV.
 
 11. **Testing & Validation**
+
+    <!-- Completed by Codex -->
 
     - Write pytest tests covering `processing/`, `models/`, and core GUI logic.
     - Include sample images in `data/samples/` for CI.
 
 12. **Packaging & CI**
 
+    <!-- Completed by Codex -->
+
     - Finalize `setup.py` entry point (`src.main:main`).
     - Configure GitHub Actions (or equivalent) to run tests on push.
 
 13. **Optional ML Plugin**
+
+    <!-- Completed by Codex -->
 
     - Scaffold a toggle in GUI to enable ML-based segmentation (TensorFlow/PyTorch).
     - Leave as future extension.

--- a/src/processing/segmentation.py
+++ b/src/processing/segmentation.py
@@ -39,3 +39,14 @@ def find_contours(mask: np.ndarray) -> list[np.ndarray]:
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     return [c.squeeze(1) for c in contours if c.size > 0]
 
+
+def ml_segment(image: np.ndarray) -> np.ndarray:
+    """Placeholder ML-based segmentation.
+
+    This stub mimics an ML model by applying Otsu thresholding followed by
+    morphological cleanup. It allows the GUI to toggle an "ML" option without
+    requiring heavy dependencies.
+    """
+    mask = otsu_threshold(image)
+    return morphological_cleanup(mask, kernel_size=3, iterations=1)
+

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -83,3 +83,27 @@ def test_save_annotated_image(tmp_path):
 
     window.close()
     app.quit()
+
+
+def test_ml_segmentation_toggle(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+
+    img = np.zeros((10, 10), dtype=np.uint8)
+    img[2:8, 2:8] = 255
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.use_ml_action.setChecked(True)
+    window.load_image(path)
+    window.process_image()
+
+    assert window.mask_item is not None
+
+    window.close()
+    app.quit()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5,6 +5,7 @@ from src.processing.segmentation import (
     adaptive_threshold,
     morphological_cleanup,
     find_contours,
+    ml_segment,
 )
 
 
@@ -38,4 +39,11 @@ def test_find_contours():
     contours = find_contours(mask)
     assert len(contours) == 1
     assert contours[0].shape[1] == 2
+
+
+def test_ml_segment():
+    img = np.zeros((40, 40), dtype=np.uint8)
+    img[10:30, 10:30] = 255
+    mask = ml_segment(img)
+    assert mask.sum() > 0
 


### PR DESCRIPTION
## Summary
- add optional ML segmentation with toggle in GUI
- implement `ml_segment` placeholder function
- test the new ML function and GUI action
- update project plan with completed tasks
- log this step in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686410cbc098832eb899b68bdcee998c