### PR TITLE
Add zoom control widget

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -68,3 +68,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Continue with the plan by adding an optional ML-based segmentation toggle in the GUI.
 
 **Summary:** Implemented a `Use ML Segmentation` checkable action in `MainWindow` and a placeholder `ml_segment` function. Processing now routes through this function when the action is enabled, and tests verify the new behavior.
+
+## Entry 12 - Zoom Control
+
+**Task:** Continue with the plan by adding a zoom slider to adjust the image view scale.
+
+**Summary:** Created `ZoomControl` widget in `src/gui/controls.py` and integrated it into `MainWindow`. The slider emits a `zoomChanged` signal connected to a new `set_zoom` method that scales the `QGraphicsView`. Added unit test `test_zoom_control` verifying the zoom factor. All tests pass.

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -2,5 +2,6 @@
 
 from .main_window import MainWindow
 from .calibration_dialog import CalibrationDialog
+from .controls import ZoomControl
 
-__all__ = ["MainWindow", "CalibrationDialog"]
+__all__ = ["MainWindow", "CalibrationDialog", "ZoomControl"]

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -1,0 +1,25 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QWidget, QSlider, QVBoxLayout, QLabel
+
+
+class ZoomControl(QWidget):
+    """Widget with a slider to control image zoom."""
+
+    zoomChanged = Signal(float)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.label = QLabel("Zoom:")
+        self.slider = QSlider(Qt.Horizontal)
+        self.slider.setRange(10, 400)  # percent
+        self.slider.setValue(100)
+        self.slider.valueChanged.connect(self._on_value_changed)
+        layout.addWidget(self.label)
+        layout.addWidget(self.slider)
+
+    def _on_value_changed(self, value: int) -> None:
+        self.zoomChanged.emit(value / 100.0)
+
+    def set_zoom(self, factor: float) -> None:
+        self.slider.setValue(int(factor * 100))

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -26,6 +26,8 @@ from PySide6.QtWidgets import (
     QPushButton,
 )
 
+from .controls import ZoomControl
+
 from ..processing.reader import load_image
 from ..processing import segmentation
 from ..processing.segmentation import (
@@ -62,6 +64,10 @@ class MainWindow(QMainWindow):
         self.algorithm_combo = QComboBox()
         self.algorithm_combo.addItems(["Otsu", "Adaptive"])
         control_layout.addWidget(self.algorithm_combo)
+
+        self.zoom_control = ZoomControl()
+        self.zoom_control.zoomChanged.connect(self.set_zoom)
+        control_layout.addWidget(self.zoom_control)
 
         self.process_button = QPushButton("Process")
         self.process_button.clicked.connect(self.process_image)
@@ -129,6 +135,7 @@ class MainWindow(QMainWindow):
         self.graphics_view.setSceneRect(rect)
         self.graphics_view.setFixedSize(int(rect.width()), int(rect.height()))
         self.adjustSize()
+        self.set_zoom(self.zoom_control.slider.value() / 100.0)
 
 
     def process_image(self) -> None:
@@ -209,6 +216,11 @@ class MainWindow(QMainWindow):
                 "Calibration",
                 f"Calibration set to {cal.pixels_per_mm:.2f} px/mm",
             )
+
+    def set_zoom(self, factor: float) -> None:
+        """Scale the graphics view by ``factor``."""
+        self.graphics_view.resetTransform()
+        self.graphics_view.scale(factor, factor)
 
 
 def main():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -107,3 +107,27 @@ def test_ml_segmentation_toggle(tmp_path):
 
     window.close()
     app.quit()
+
+
+def test_zoom_control(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+
+    window.zoom_control.slider.setValue(200)
+    transform = window.graphics_view.transform()
+    assert transform.m11() == pytest.approx(2.0, rel=0.01)
+    assert transform.m22() == pytest.approx(2.0, rel=0.01)
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- add `ZoomControl` widget for adjusting zoom
- integrate zoom slider in `MainWindow`
- expose `ZoomControl` in gui package
- test zoom behavior
- log the new feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641c807e54832eb4ab4953e4790b54