### PR TITLE
Add parameter panel widget

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -74,3 +74,14 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Continue with the plan by adding a zoom slider to adjust the image view scale.
 
 **Summary:** Created `ZoomControl` widget in `src/gui/controls.py` and integrated it into `MainWindow`. The slider emits a `zoomChanged` signal connected to a new `set_zoom` method that scales the `QGraphicsView`. Added unit test `test_zoom_control` verifying the zoom factor. All tests pass.
+## Entry 13 - Parameter Panel
+
+**Task:** Continue with the plan by adding a panel to edit physical parameters in the GUI.
+
+**Summary:** Implemented `ParameterPanel` widget in `src/gui/controls.py` with fields for air density, liquid density, and surface tension. Integrated the panel into `MainWindow` and exported it from the GUI package. Added `test_parameter_panel_defaults` ensuring default values are accessible. All tests pass.
+
+## Entry 14 - Address Feedback
+
+**Task:** Review the previous work and mark completed stages in `PLAN.md`.
+
+**Summary:** Added "Completed by Codex" markers for the Zoom Control and Parameter Panel steps in `PLAN.md` to reflect the finished features. No code changes were required. All tests still pass.

--- a/PLAN.md
+++ b/PLAN.md
@@ -152,8 +152,10 @@ Based on the â€œDevelopment Plan for a Python-Based Droplet Shape Analysis Toolâ
     - Analyze if /src/models/geometry.py, /src/models/physics.py and /src/models/properties.py need to be modified
     - Analyze if image processing need to be updated or exended
 14.2 **Zoom Control**
+    <!-- Completed by Codex -->
     - In `gui/controls.py`, implement a **zoom slider** that adjusts the scale of the image view (QGraphicsView or Matplotlib canvas) and its overlays.
 14.3 **Parameter Panel**
+    <!-- Completed by Codex -->
     - Add a **Parameter Panel** in `gui/main_window.py` or `gui/controls.py` for user inputs:
       - Air density
       - Liquid density

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -2,6 +2,6 @@
 
 from .main_window import MainWindow
 from .calibration_dialog import CalibrationDialog
-from .controls import ZoomControl
+from .controls import ZoomControl, ParameterPanel
 
-__all__ = ["MainWindow", "CalibrationDialog", "ZoomControl"]
+__all__ = ["MainWindow", "CalibrationDialog", "ZoomControl", "ParameterPanel"]

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -1,5 +1,12 @@
 from PySide6.QtCore import Qt, Signal
-from PySide6.QtWidgets import QWidget, QSlider, QVBoxLayout, QLabel
+from PySide6.QtWidgets import (
+    QWidget,
+    QSlider,
+    QVBoxLayout,
+    QLabel,
+    QFormLayout,
+    QDoubleSpinBox,
+)
 
 
 class ZoomControl(QWidget):
@@ -23,3 +30,40 @@ class ZoomControl(QWidget):
 
     def set_zoom(self, factor: float) -> None:
         self.slider.setValue(int(factor * 100))
+
+
+class ParameterPanel(QWidget):
+    """Widget for entering physical parameters."""
+
+    parametersChanged = Signal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QFormLayout(self)
+        self.air_density = QDoubleSpinBox()
+        self.air_density.setRange(0.0, 10.0)
+        self.air_density.setValue(1.2)
+        self.air_density.setSuffix(" kg/m³")
+        self.air_density.valueChanged.connect(self.parametersChanged.emit)
+        layout.addRow("Air density", self.air_density)
+
+        self.liquid_density = QDoubleSpinBox()
+        self.liquid_density.setRange(0.0, 5000.0)
+        self.liquid_density.setValue(1000.0)
+        self.liquid_density.setSuffix(" kg/m³")
+        self.liquid_density.valueChanged.connect(self.parametersChanged.emit)
+        layout.addRow("Liquid density", self.liquid_density)
+
+        self.surface_tension = QDoubleSpinBox()
+        self.surface_tension.setRange(0.0, 500.0)
+        self.surface_tension.setValue(72.8)
+        self.surface_tension.setSuffix(" mN/m")
+        self.surface_tension.valueChanged.connect(self.parametersChanged.emit)
+        layout.addRow("Surface tension", self.surface_tension)
+
+    def values(self) -> dict[str, float]:
+        return {
+            "air_density": self.air_density.value(),
+            "liquid_density": self.liquid_density.value(),
+            "surface_tension": self.surface_tension.value(),
+        }

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
     QPushButton,
 )
 
-from .controls import ZoomControl
+from .controls import ZoomControl, ParameterPanel
 
 from ..processing.reader import load_image
 from ..processing import segmentation
@@ -68,6 +68,9 @@ class MainWindow(QMainWindow):
         self.zoom_control = ZoomControl()
         self.zoom_control.zoomChanged.connect(self.set_zoom)
         control_layout.addWidget(self.zoom_control)
+
+        self.parameter_panel = ParameterPanel()
+        control_layout.addWidget(self.parameter_panel)
 
         self.process_button = QPushButton("Process")
         self.process_button.clicked.connect(self.process_image)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -131,3 +131,21 @@ def test_zoom_control(tmp_path):
 
     window.close()
     app.quit()
+
+
+def test_parameter_panel_defaults():
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+
+    panel = window.parameter_panel
+    values = panel.values()
+
+    assert "air_density" in values and values["air_density"] > 0
+    assert "liquid_density" in values and values["liquid_density"] > 0
+    assert "surface_tension" in values and values["surface_tension"] > 0
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- add `ParameterPanel` widget for editing air density, liquid density, and surface tension
- integrate panel into the main window and export from GUI package
- test default parameter panel values
- log the work in `CODEXLOG.md`
- mark plan steps for zoom control and parameter panel as completed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644e1faba8832e8a97bdfe18f64bc2