### PR TITLE
Add GUI metrics panel

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -85,3 +85,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Review the previous work and mark completed stages in `PLAN.md`.
 
 **Summary:** Added "Completed by Codex" markers for the Zoom Control and Parameter Panel steps in `PLAN.md` to reflect the finished features. No code changes were required. All tests still pass.
+
+## Entry 15 - Metrics Panel
+
+**Task:** Continue with the plan by adding a metrics panel to display calculated values.
+
+**Summary:** Created a `MetricsPanel` widget in `src/gui/controls.py` to show IFT, Wo number, volume, contact angle, height, and diameter. Integrated the panel into `MainWindow` and provided a simple metrics calculation in `process_image`. Exported the widget from the GUI package and added `test_metrics_panel_update` to verify updates. All tests pass.

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -2,6 +2,12 @@
 
 from .main_window import MainWindow
 from .calibration_dialog import CalibrationDialog
-from .controls import ZoomControl, ParameterPanel
+from .controls import ZoomControl, ParameterPanel, MetricsPanel
 
-__all__ = ["MainWindow", "CalibrationDialog", "ZoomControl", "ParameterPanel"]
+__all__ = [
+    "MainWindow",
+    "CalibrationDialog",
+    "ZoomControl",
+    "ParameterPanel",
+    "MetricsPanel",
+]

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -67,3 +67,53 @@ class ParameterPanel(QWidget):
             "liquid_density": self.liquid_density.value(),
             "surface_tension": self.surface_tension.value(),
         }
+
+
+class MetricsPanel(QWidget):
+    """Display calculated droplet metrics."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QFormLayout(self)
+
+        self.ift_label = QLabel("0.0")
+        layout.addRow("IFT (mN/m)", self.ift_label)
+
+        self.wo_label = QLabel("0.0")
+        layout.addRow("Wo number", self.wo_label)
+
+        self.volume_label = QLabel("0.0")
+        layout.addRow("Volume (\u00b5L)", self.volume_label)
+
+        self.angle_label = QLabel("0.0")
+        layout.addRow("Contact angle (\u00b0)", self.angle_label)
+
+        self.height_label = QLabel("0.0")
+        layout.addRow("Height", self.height_label)
+
+        self.diameter_label = QLabel("0.0")
+        layout.addRow("Diameter", self.diameter_label)
+
+    def set_metrics(
+        self,
+        *,
+        ift: float | None = None,
+        wo: float | None = None,
+        volume: float | None = None,
+        contact_angle: float | None = None,
+        height: float | None = None,
+        diameter: float | None = None,
+    ) -> None:
+        """Update displayed metric values."""
+        if ift is not None:
+            self.ift_label.setText(f"{ift:.2f}")
+        if wo is not None:
+            self.wo_label.setText(f"{wo:.2f}")
+        if volume is not None:
+            self.volume_label.setText(f"{volume:.2f}")
+        if contact_angle is not None:
+            self.angle_label.setText(f"{contact_angle:.2f}")
+        if height is not None:
+            self.height_label.setText(f"{height:.2f}")
+        if diameter is not None:
+            self.diameter_label.setText(f"{diameter:.2f}")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -149,3 +149,21 @@ def test_parameter_panel_defaults():
 
     window.close()
     app.quit()
+
+
+def test_metrics_panel_update():
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+
+    panel = window.metrics_panel
+    panel.set_metrics(ift=1.2, wo=0.5, volume=3.4, contact_angle=45.0, height=2.0, diameter=4.0)
+
+    assert panel.ift_label.text().startswith("1.2")
+    assert panel.volume_label.text().startswith("3.4")
+
+    window.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- show droplet metrics via new `MetricsPanel`
- integrate panel into `MainWindow`
- compute simple height/diameter/volume metrics in `process_image`
- export `MetricsPanel` and test updating it
- log metrics panel implementation in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645216a7a0832e98bee571e6b35c56