### PR TITLE
Implement pixel-to-mm calibration

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -116,3 +116,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 
 **Summary:** Inserted "<!-- Completed by Codex -->" comment under the Interactive Calibration Box section in PLAN.md and under Update Documentation. All tests pass.
 
+## Entry 20 - Pixel-to-mm Calibration
+
+**Task:** Implement manual and automatic pixel-to-mm calibration.
+
+**Summary:** Added calibration controls to the parameter panel with manual/automatic modes and reference length input. Updated `MainWindow.open_calibration` to crop the ROI and call a new `auto_calibrate` utility. Implemented `auto_calibrate` in `src/utils/calibration.py` and exposed it via `__init__`. Added tests for automatic calibration and new GUI controls, updated README with a Calibration Workflow section, and marked the plan step complete. All tests pass.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -184,6 +184,7 @@ Based on the â€œDevelopment Plan for a Python-Based Droplet Shape Analysis Toolâ
       -Immediately render the blue rectangle in the QGraphicsView overlay, editable by drag handles.
 
 16 **Pixel-to-mm Calibration**
+    <!-- Completed by Codex -->
     -Manual Mode
       -In Calibration Mode, allow drawing a line between two points inside the blue box.
       -Let the user enter the real length (mm) in the parameter panel.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Human involvement in this project is intentionally kept light. The main role of
 the user will be testing the GUI and submitting prompts as tasks to CODEX or as
 issues on GitHub. Feedback from these manual tests will guide further automated
 iterations of the tool.
+
+## Calibration Workflow
+
+1. Enable **Calibration Mode** in the parameter panel and draw a blue box around
+   the calibration needle.
+2. Select **Manual** or **Automatic** method. Manual mode uses a user-drawn line
+   with a known length; automatic mode detects the two vertical needle edges.
+3. Use **Tools → Calibration** to compute the pixel-to-mm scale. The resulting
+   scale value is displayed in the parameter panel.

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -7,6 +7,8 @@ from PySide6.QtWidgets import (
     QFormLayout,
     QDoubleSpinBox,
     QCheckBox,
+    QRadioButton,
+    QButtonGroup,
 )
 
 
@@ -65,6 +67,23 @@ class ParameterPanel(QWidget):
         self.calibration_mode = QCheckBox("Calibration Mode")
         layout.addRow(self.calibration_mode)
 
+        self.ref_length = QDoubleSpinBox()
+        self.ref_length.setRange(0.1, 100.0)
+        self.ref_length.setValue(1.0)
+        self.ref_length.setSuffix(" mm")
+        layout.addRow("Ref length", self.ref_length)
+
+        self.manual_radio = QRadioButton("Manual")
+        self.auto_radio = QRadioButton("Automatic")
+        self.manual_radio.setChecked(True)
+        group = QButtonGroup(self)
+        group.addButton(self.manual_radio)
+        group.addButton(self.auto_radio)
+        layout.addRow(self.manual_radio, self.auto_radio)
+
+        self.scale_label = QLabel("1.0")
+        layout.addRow("Scale (px/mm)", self.scale_label)
+
     def values(self) -> dict[str, float]:
         return {
             "air_density": self.air_density.value(),
@@ -75,6 +94,15 @@ class ParameterPanel(QWidget):
     def is_calibration_enabled(self) -> bool:
         """Return True if calibration mode is checked."""
         return self.calibration_mode.isChecked()
+
+    def calibration_method(self) -> str:
+        return "manual" if self.manual_radio.isChecked() else "automatic"
+
+    def calibration_length(self) -> float:
+        return self.ref_length.value()
+
+    def set_scale_display(self, px_per_mm: float) -> None:
+        self.scale_label.setText(f"{px_per_mm:.2f}")
 
 
 class MetricsPanel(QWidget):

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -7,6 +7,7 @@ from .calibration import (
     mm_to_pixels,
     pixels_to_mm,
     set_calibration,
+    auto_calibrate,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "pixels_to_mm",
     "mm_to_pixels",
     "calibrate_from_points",
+    "auto_calibrate",
 ]

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -207,3 +207,21 @@ def test_calibration_box(tmp_path):
     window.close()
     app.quit()
 
+
+def test_parameter_panel_calibration_controls():
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+
+    panel = window.parameter_panel
+    assert panel.calibration_method() == "manual"
+    panel.auto_radio.setChecked(True)
+    assert panel.calibration_method() == "automatic"
+    panel.set_scale_display(5.0)
+    assert panel.scale_label.text().startswith("5.0")
+
+    window.close()
+    app.quit()
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,12 @@
+import pytest
+
 from src.utils import (
     set_calibration,
     get_calibration,
     calibrate_from_points,
     pixels_to_mm,
     mm_to_pixels,
+    auto_calibrate,
 )
 
 
@@ -22,4 +25,17 @@ def test_calibration_from_points():
     assert get_calibration().pixels_per_mm == 2.0
     assert pixels_to_mm(10) == 5.0
     assert mm_to_pixels(5.0) == 10
+
+
+def test_auto_calibrate_detects_lines():
+    import numpy as np
+    import cv2
+
+    img = np.zeros((20, 20), dtype=np.uint8)
+    cv2.line(img, (5, 0), (5, 19), 255, 1)
+    cv2.line(img, (15, 0), (15, 19), 255, 1)
+
+    sep = auto_calibrate(cv2.cvtColor(img, cv2.COLOR_GRAY2BGR), (0, 0, 20, 20), 1.0)
+    assert sep == pytest.approx(10, abs=1)
+    assert get_calibration().pixels_per_mm == pytest.approx(10, abs=1)
 


### PR DESCRIPTION
## Summary
- add calibration workflow notes to README
- implement manual/automatic calibration controls in ParameterPanel
- update MainWindow to handle manual or automatic calibration
- add auto_calibrate utility to detect edges and compute scale
- update tests for new functionality
- mark Pixel-to-mm Calibration step complete in PLAN
- log progress in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645f1a8cf4832e9d33e474f2e233f9