### PR TITLE
Fix manual calibration and add toggles

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -122,3 +122,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 
 **Summary:** Added calibration controls to the parameter panel with manual/automatic modes and reference length input. Updated `MainWindow.open_calibration` to crop the ROI and call a new `auto_calibrate` utility. Implemented `auto_calibrate` in `src/utils/calibration.py` and exposed it via `__init__`. Added tests for automatic calibration and new GUI controls, updated README with a Calibration Workflow section, and marked the plan step complete. All tests pass.
 
+## Entry 21 - Calibration UI Tweaks
+
+**Task:** Fix manual calibration and add calibration/measurement toggles.
+
+**Summary:** Replaced manual/automatic radio buttons with a single toggle and added a "Calibrate" button. Calibration mode now supports drawing either a line (manual) or a box (automatic). Updated `MainWindow` to handle both interactions and compute scale directly from the main view. Adjusted tests and documentation. All tests pass.
+

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ iterations of the tool.
 
 ## Calibration Workflow
 
-1. Enable **Calibration Mode** in the parameter panel and draw a blue box around
-   the calibration needle.
-2. Select **Manual** or **Automatic** method. Manual mode uses a user-drawn line
-   with a known length; automatic mode detects the two vertical needle edges.
-3. Use **Tools → Calibration** to compute the pixel-to-mm scale. The resulting
-   scale value is displayed in the parameter panel.
+1. Enable **Calibration Mode** in the parameter panel.
+2. Toggle **Manual Calibration** on to draw a line between two points, or off to
+   draw the needle region for automatic detection.
+3. Click **Calibrate** to compute the pixel-to-mm scale. The resulting value is
+   shown in the parameter panel.

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -7,8 +7,7 @@ from PySide6.QtWidgets import (
     QFormLayout,
     QDoubleSpinBox,
     QCheckBox,
-    QRadioButton,
-    QButtonGroup,
+    QPushButton,
 )
 
 
@@ -73,13 +72,12 @@ class ParameterPanel(QWidget):
         self.ref_length.setSuffix(" mm")
         layout.addRow("Ref length", self.ref_length)
 
-        self.manual_radio = QRadioButton("Manual")
-        self.auto_radio = QRadioButton("Automatic")
-        self.manual_radio.setChecked(True)
-        group = QButtonGroup(self)
-        group.addButton(self.manual_radio)
-        group.addButton(self.auto_radio)
-        layout.addRow(self.manual_radio, self.auto_radio)
+        self.manual_toggle = QCheckBox("Manual Calibration")
+        self.manual_toggle.setChecked(True)
+        layout.addRow(self.manual_toggle)
+
+        self.calibrate_button = QPushButton("Calibrate")
+        layout.addRow(self.calibrate_button)
 
         self.scale_label = QLabel("1.0")
         layout.addRow("Scale (px/mm)", self.scale_label)
@@ -96,7 +94,7 @@ class ParameterPanel(QWidget):
         return self.calibration_mode.isChecked()
 
     def calibration_method(self) -> str:
-        return "manual" if self.manual_radio.isChecked() else "automatic"
+        return "manual" if self.manual_toggle.isChecked() else "automatic"
 
     def calibration_length(self) -> float:
         return self.ref_length.value()


### PR DESCRIPTION
## Summary
- tweak ParameterPanel to use a manual calibration checkbox and add a Calibrate button
- add line/box drawing modes in MainWindow depending on calibration method
- update GUI tests for new calibration behaviour
- document new workflow in README
- log calibration UI tweaks in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864638b6fd0832eaeacce1c73e3c899