### PR TITLE
Implement ROI selection

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -134,3 +134,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 
 **Summary:** Reimplemented `auto_calibrate` to apply Canny edge detection and a Hough transform, measuring the separation of near-vertical lines. Updated the unit test to draw a dark needle on a light background and documented the new approach in the README. All tests pass.
 
+## Entry 23 - ROI Selection for Volume
+
+**Task:** Implement region-of-interest drawing and restrict processing to this area. Update PLAN.md to mark the step complete.
+
+**Summary:** Added an ROI Mode checkbox in `ParameterPanel` and new handlers in `MainWindow` to draw a green rectangle. Segmentation and contour overlays now operate on the cropped region, and metrics use the restricted mask. Updated tests with ROI drawing and processing cases, and marked the corresponding plan section complete.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -197,6 +197,7 @@ Based on the “Development Plan for a Python-Based Droplet Shape Analysis Tool�
       -Radio buttons to switch between Manual / Automatic calibration.
 
 17 **Region-of-Interest for Volume**
+   <!-- Completed by Codex -->
    -ROI Drawing
       -After calibration, enable an “ROI Mode” to draw a green box around the droplet’s shadow.
       -Store ROI coordinates and overlay in the scene.

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -66,6 +66,9 @@ class ParameterPanel(QWidget):
         self.calibration_mode = QCheckBox("Calibration Mode")
         layout.addRow(self.calibration_mode)
 
+        self.roi_mode = QCheckBox("ROI Mode")
+        layout.addRow(self.roi_mode)
+
         self.ref_length = QDoubleSpinBox()
         self.ref_length.setRange(0.1, 100.0)
         self.ref_length.setValue(1.0)
@@ -92,6 +95,10 @@ class ParameterPanel(QWidget):
     def is_calibration_enabled(self) -> bool:
         """Return True if calibration mode is checked."""
         return self.calibration_mode.isChecked()
+
+    def is_roi_enabled(self) -> bool:
+        """Return True if ROI mode is checked."""
+        return self.roi_mode.isChecked()
 
     def calibration_method(self) -> str:
         return "manual" if self.manual_toggle.isChecked() else "automatic"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -266,3 +266,71 @@ def test_parameter_panel_calibration_controls():
     window.close()
     app.quit()
 
+
+def test_roi_box(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+    from PySide6.QtCore import QPoint
+
+    img = np.zeros((20, 20, 3), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+
+    window.parameter_panel.roi_mode.setChecked(True)
+
+    class DummyEvent:
+        def __init__(self, x, y):
+            self._pos = QPoint(x, y)
+
+        def pos(self):
+            return self._pos
+
+        def accept(self):
+            pass
+
+    window._roi_press(DummyEvent(1, 1))
+    window._roi_move(DummyEvent(10, 10))
+    window._roi_release(DummyEvent(10, 10))
+
+    assert window.roi_rect is not None
+    x1, y1, x2, y2 = window.roi_rect
+    assert x2 > x1 and y2 > y1
+
+    window.close()
+    app.quit()
+
+
+def test_process_image_with_roi(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+
+    img = np.zeros((20, 30), dtype=np.uint8)
+    img[5:15, 10:20] = 255
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+
+    window.roi_rect = (10, 5, 20, 15)
+    window.process_image()
+
+    assert window.mask_item is not None
+    pixmap = window.mask_item.pixmap()
+    assert pixmap.width() == 10
+    assert pixmap.height() == 10
+
+    window.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- add ROI mode checkbox to the parameter panel
- support ROI drawing and ROI-based segmentation in the main window
- test ROI drawing and image processing on a region of interest
- mark the ROI section of the plan complete
- log the completed task

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646a3f39e4832e81c41acf53e3ae6c