### PR TITLE
Implement external contour filtering

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -146,3 +146,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Implement detection of the droplet apex and contact point with overlays.
 
 **Summary:** Added apex and contact point markers in `MainWindow.process_image` using a yellow ellipse and cyan line. Updated `ParameterPanel` integration to clear previous markers, wrote a GUI test verifying marker creation, and marked the plan step complete. All tests pass.
+
+## Entry 25 - External Contour Only
+
+**Task:** Continue with the plan by ensuring only the outer droplet contour is used for processing.
+
+**Summary:** Added `external_contour_mask` in `segmentation.py` to keep only the largest external contour and fill interior holes. Integrated this step into `batch.py` and `MainWindow.process_image`. Updated processing tests with a new case for the function and marked the plan item complete.

--- a/PLAN.md
+++ b/PLAN.md
@@ -217,6 +217,7 @@ Based on the â€œDevelopment Plan for a Python-Based Droplet Shape Analysis Toolâ
       -Any time the contour is re-computed (e.g. after ROI change), update these markers.
 
 19 **Improvement 1: External Contour Only**
+   <!-- Completed by Codex -->
    -Detect only the external droplet contour
      -Discard all internal contours (e.g., bright interior region) before volume and fitting routines.
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ iterations of the tool.
    shown in the parameter panel.
    Automatic mode detects the two vertical edges of the needle using Canny edge
    detection and a Hough transform to measure their separation.
+
+## Image Processing
+
+Segmented masks are cleaned with morphological operations and reduced to the largest external contour. This ensures internal artifacts do not affect volume or fitting calculations.

--- a/src/batch.py
+++ b/src/batch.py
@@ -11,6 +11,7 @@ from .processing.reader import load_image
 from .processing.segmentation import (
     otsu_threshold,
     morphological_cleanup,
+    external_contour_mask,
     find_contours,
 )
 
@@ -45,6 +46,7 @@ def run_batch(directory: str | Path, output_csv: str | Path | None = None) -> pd
         image = load_image(img_path, as_gray=True)
         mask = otsu_threshold(image)
         mask = morphological_cleanup(mask, kernel_size=3, iterations=1)
+        mask = external_contour_mask(mask)
         contours = find_contours(mask)
         area = int((mask > 0).sum())
         records.append(

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -34,6 +34,7 @@ from ..processing.reader import load_image
 from ..processing import segmentation
 from ..processing.segmentation import (
     morphological_cleanup,
+    external_contour_mask,
     find_contours,
     ml_segment,
 )
@@ -202,6 +203,7 @@ class MainWindow(QMainWindow):
                 mask = segmentation.adaptive_threshold(image)
 
         mask = morphological_cleanup(mask, kernel_size=3, iterations=1)
+        mask = external_contour_mask(mask)
         mask_img = QImage(
             mask.data,
             mask.shape[1],

--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -1,0 +1,19 @@
+from .reader import load_image
+from .segmentation import (
+    otsu_threshold,
+    adaptive_threshold,
+    morphological_cleanup,
+    external_contour_mask,
+    find_contours,
+    ml_segment,
+)
+
+__all__ = [
+    "load_image",
+    "otsu_threshold",
+    "adaptive_threshold",
+    "morphological_cleanup",
+    "external_contour_mask",
+    "find_contours",
+    "ml_segment",
+]

--- a/src/processing/segmentation.py
+++ b/src/processing/segmentation.py
@@ -34,6 +34,17 @@ def morphological_cleanup(mask: np.ndarray, kernel_size: int = 3, iterations: in
     return closed
 
 
+def external_contour_mask(mask: np.ndarray) -> np.ndarray:
+    """Return a mask containing only the largest external contour."""
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return np.zeros_like(mask)
+    largest = max(contours, key=cv2.contourArea)
+    ext = np.zeros_like(mask)
+    cv2.drawContours(ext, [largest], -1, 255, -1)
+    return ext
+
+
 def find_contours(mask: np.ndarray) -> list[np.ndarray]:
     """Return contours from a binary mask."""
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4,6 +4,7 @@ from src.processing.segmentation import (
     otsu_threshold,
     adaptive_threshold,
     morphological_cleanup,
+    external_contour_mask,
     find_contours,
     ml_segment,
 )
@@ -46,4 +47,16 @@ def test_ml_segment():
     img[10:30, 10:30] = 255
     mask = ml_segment(img)
     assert mask.sum() > 0
+
+
+def test_external_contour_mask():
+    cv2 = __import__('cv2')
+    mask = np.zeros((40, 40), dtype=np.uint8)
+    cv2.rectangle(mask, (5, 5), (35, 35), 255, -1)
+    cv2.rectangle(mask, (10, 10), (30, 30), 0, -1)  # hole
+    cleaned = external_contour_mask(mask)
+    contours = find_contours(cleaned)
+    assert len(contours) == 1
+    # hole should be filled
+    assert cleaned[20, 20] == 255
 


### PR DESCRIPTION
## Summary
- ensure only the outer droplet contour is kept
- provide `external_contour_mask` utility
- integrate the new mask step in GUI and batch mode
- document the behaviour and mark the plan item complete
- add regression test and log entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864740fa914832eb1360b5253cee734