### PR TITLE
Improve droplet volume and apex logic

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -152,3 +152,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Continue with the plan by ensuring only the outer droplet contour is used for processing.
 
 **Summary:** Added `external_contour_mask` in `segmentation.py` to keep only the largest external contour and fill interior holes. Integrated this step into `batch.py` and `MainWindow.process_image`. Updated processing tests with a new case for the function and marked the plan item complete.
+
+## Entry 26 - Correct Volume and Apex Calculations
+
+**Task:** Revise the droplet volume function and fix the apex detection logic in the GUI.
+
+**Summary:** Rewrote `droplet_volume` to compute the solid-of-revolution integral from a binary mask, returning volume in cubic millimetres. Updated `MainWindow.process_image` to call the new API and corrected the apex selection to use the lowest point of the mask. Adjusted unit tests accordingly.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -246,7 +246,7 @@ class MainWindow(QMainWindow):
 
         if mask.any():
             ys, xs = np.nonzero(mask)
-            idx = int(ys.argmin())
+            idx = int(ys.argmax())
             apex_x = xs[idx] + offset[0]
             apex_y = ys[idx] + offset[1]
             pen = QPen(QColor("yellow"))
@@ -288,7 +288,7 @@ class MainWindow(QMainWindow):
             diameter_px = xs.max() - xs.min()
             height = pixels_to_mm(float(height_px))
             diameter = pixels_to_mm(float(diameter_px))
-            volume = droplet_volume(diameter / 2.0, np.deg2rad(90.0))
+            volume = droplet_volume(mask)
         else:
             height = diameter = volume = 0.0
 

--- a/src/models/properties.py
+++ b/src/models/properties.py
@@ -1,11 +1,40 @@
 """Property calculation functions."""
 
+from __future__ import annotations
+
 import numpy as np
 
+from ..utils import pixels_to_mm, get_calibration
 
-def droplet_volume(radius: float, contact_angle: float) -> float:
-    """Approximate droplet volume using spherical cap formula."""
-    h = radius * (1 - np.cos(contact_angle))
-    volume = (np.pi * h**2 * (3 * radius - h)) / 3.0
-    return volume
+
+def droplet_volume(mask: np.ndarray) -> float:
+    """Compute droplet volume from a binary mask using solid of revolution.
+
+    Parameters
+    ----------
+    mask:
+        2D array where non-zero pixels define the droplet silhouette.
+
+    Returns
+    -------
+    float
+        Volume in cubic millimetres based on the current calibration.
+    """
+
+    if mask.ndim != 2:
+        raise ValueError("mask must be a 2D array")
+
+    cal = get_calibration()
+    dy = 1.0 / cal.pixels_per_mm  # pixel height in mm
+    volume = 0.0
+
+    for row in mask:
+        cols = np.where(row > 0)[0]
+        if cols.size >= 2:
+            width_px = cols[-1] - cols[0] + 1
+            radius_mm = pixels_to_mm(float(width_px)) / 2.0
+            volume += np.pi * radius_mm**2 * dy
+
+    return float(volume)
+
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,10 @@ def test_fit_circle():
 
 
 def test_droplet_volume():
-    volume = droplet_volume(2.0, np.deg2rad(60))
-    assert volume > 0
+    r = 10
+    y, x = np.ogrid[-r:r+1, -r:r+1]
+    mask = ((x**2 + y**2) <= r**2).astype(np.uint8)
+    volume = droplet_volume(mask)
+    expected = (4.0 / 3.0) * np.pi * r**3
+    assert np.isclose(volume, expected, rtol=0.1)
 


### PR DESCRIPTION
## Summary
- compute droplet volume from a binary mask using solid-of-revolution
- detect the apex as the lowest point in the mask
- update GUI metrics to use new volume calculation
- adjust unit tests for new volume function
- log the update in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647be6762c832eae0c7f5fade17fc9