### PR TITLE
Implement calculate and draw buttons

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -158,3 +158,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Revise the droplet volume function and fix the apex detection logic in the GUI.
 
 **Summary:** Rewrote `droplet_volume` to compute the solid-of-revolution integral from a binary mask, returning volume in cubic millimetres. Updated `MainWindow.process_image` to call the new API and corrected the apex selection to use the lowest point of the mask. Adjusted unit tests accordingly.
+
+## Entry 27 - Calculate & Draw Buttons
+
+**Task:** Continue with the plan by adding buttons to compute physical parameters and overlay a model contour.
+
+**Summary:** Introduced `Calculate` and `Draw Model` buttons in the control panel. These call new helper methods in `MainWindow` that estimate surface tension and contact angle then plot a fitted circle. Added simple estimation functions in `models.properties`, exported them, and expanded unit tests. Removed the redundant Calibration menu action. All tests pass.

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,7 +2,17 @@
 
 from .geometry import fit_circle
 from .physics import solve_young_laplace
-from .properties import droplet_volume
+from .properties import (
+    droplet_volume,
+    estimate_surface_tension,
+    contact_angle_from_mask,
+)
 
-__all__ = ["fit_circle", "solve_young_laplace", "droplet_volume"]
+__all__ = [
+    "fit_circle",
+    "solve_young_laplace",
+    "droplet_volume",
+    "estimate_surface_tension",
+    "contact_angle_from_mask",
+]
 

--- a/src/models/properties.py
+++ b/src/models/properties.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import numpy as np
 
 from ..utils import pixels_to_mm, get_calibration
+from ..processing.segmentation import find_contours
+from .geometry import fit_circle
 
 
 def droplet_volume(mask: np.ndarray) -> float:
@@ -36,5 +38,49 @@ def droplet_volume(mask: np.ndarray) -> float:
             volume += np.pi * radius_mm**2 * dy
 
     return float(volume)
+
+
+def estimate_surface_tension(
+    mask: np.ndarray, air_density: float, liquid_density: float
+) -> float:
+    """Estimate surface tension in mN/m from a binary droplet mask."""
+
+    delta_rho = liquid_density - air_density
+    if delta_rho <= 0:
+        return 0.0
+
+    contours = find_contours(mask)
+    if not contours:
+        return 0.0
+    contour = max(contours, key=lambda c: c.shape[0]).astype(float)
+    _, r0_px = fit_circle(contour)
+    r0_mm = pixels_to_mm(float(r0_px))
+    if r0_mm == 0:
+        return 0.0
+
+    ys, xs = np.nonzero(mask)
+    if ys.size < 2 or xs.size < 2:
+        return 0.0
+    diameter_px = xs.max() - xs.min()
+    r_max_mm = pixels_to_mm(float(diameter_px)) / 2.0
+
+    gamma = delta_rho * 9.81 * (r_max_mm**2) / (2.0 * r0_mm)
+    return float(gamma * 1000.0)
+
+
+def contact_angle_from_mask(mask: np.ndarray) -> float:
+    """Rough contact angle estimate from mask geometry."""
+
+    ys, xs = np.nonzero(mask)
+    if ys.size < 2 or xs.size < 2:
+        return 0.0
+
+    height_px = ys.max() - ys.min()
+    radius_px = (xs.max() - xs.min()) / 2.0
+    if radius_px == 0:
+        return 0.0
+
+    angle_rad = np.arctan2(height_px, radius_px)
+    return float(np.degrees(angle_rad))
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -362,3 +362,30 @@ def test_apex_and_contact_markers(tmp_path):
     window.close()
     app.quit()
 
+
+def test_calculate_and_draw(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+
+    img = np.zeros((20, 20), dtype=np.uint8)
+    img[8:18, 8:12] = 255
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+    window.process_image()
+
+    window.calculate_parameters()
+    assert float(window.metrics_panel.ift_label.text()) >= 0
+
+    window.draw_model()
+    assert window.model_item is not None
+
+    window.close()
+    app.quit()
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 from src.models.geometry import fit_circle
-from src.models.properties import droplet_volume
+from src.models.properties import (
+    droplet_volume,
+    estimate_surface_tension,
+    contact_angle_from_mask,
+)
 
 
 def test_fit_circle():
@@ -21,4 +25,14 @@ def test_droplet_volume():
     volume = droplet_volume(mask)
     expected = (4.0 / 3.0) * np.pi * r**3
     assert np.isclose(volume, expected, rtol=0.1)
+
+
+def test_estimate_surface_tension_and_contact_angle():
+    r = 10
+    y, x = np.ogrid[-r:r + 1, -r:r + 1]
+    mask = ((x ** 2 + y ** 2) <= r ** 2).astype(np.uint8)
+    gamma = estimate_surface_tension(mask, 1.0, 1000.0)
+    angle = contact_angle_from_mask(mask)
+    assert gamma > 0
+    assert 0 < angle < 90
 


### PR DESCRIPTION
## Summary
- add 'Calculate' and 'Draw Model' buttons to GUI
- remove redundant calibration menu action
- store last mask and offset for modeling overlay
- provide surface tension and contact angle estimation utilities
- update tests for new functions and GUI features
- log activity in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864826b1a5c832e9fc79e34c9783592