### PR TITLE
Implement CSV export and update PLAN

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -164,3 +164,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Continue with the plan by adding buttons to compute physical parameters and overlay a model contour.
 
 **Summary:** Introduced `Calculate` and `Draw Model` buttons in the control panel. These call new helper methods in `MainWindow` that estimate surface tension and contact angle then plot a fitted circle. Added simple estimation functions in `models.properties`, exported them, and expanded unit tests. Removed the redundant Calibration menu action. All tests pass.
+
+## Entry 28 - CSV Export Feature
+
+**Task:** Review PLAN.md, mark completed tasks, and start the next task by implementing CSV export.
+
+**Summary:** Marked the "Calculate & Draw" buttons, "Save Annotated Image," and "Propose enhancements" items as completed in PLAN.md. Added a "Save CSV" button to `MainWindow` with a new `save_csv` method that exports parameters and metrics using pandas. Extended `MetricsPanel` with a `values` method, updated GUI tests, and added a new test for CSV export. All tests pass.

--- a/PLAN.md
+++ b/PLAN.md
@@ -223,6 +223,7 @@ Based on the “Development Plan for a Python-Based Droplet Shape Analysis Tool�
      -Discard all internal contours (e.g., bright interior region) before volume and fitting routines.
 
 20 **Missing Feature 1: “Calculate” & “Draw” Buttons**
+   <!-- Completed by Codex -->
    -Calculate
      -Compute surface tension for pendant drops or contact angle for sessile drops.
      -For pendant: find γ such that the curvature at the apex (red line) produces the observed max-diameter radius (blue line).
@@ -238,11 +239,13 @@ Based on the “Development Plan for a Python-Based Droplet Shape Analysis Tool�
      -Exports all user parameters and computed results (γ, θ, volume, dimensions) in comma-separated format.
 
 22 *Missing Feature 3: Save Annotated Image**
+   <!-- Completed by Codex -->
    -Add a “Save Image” button
      -Open a file-save dialog for naming.
      -Save the current view—including calibration box, ROI, apex & contact markers, and model overlay—as a single image file.
 
 23 **Propose enhancements**
+   <!-- Completed by Codex -->
    -Evaluate adding real-time metric updates when parameters change.
    -Investigate integrating true ML-based segmentation models.
    -Consider 3D droplet reconstruction for pendant drops.

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -158,3 +158,20 @@ class MetricsPanel(QWidget):
             self.height_label.setText(f"{height:.2f}")
         if diameter is not None:
             self.diameter_label.setText(f"{diameter:.2f}")
+
+    def values(self) -> dict[str, float]:
+        """Return the currently displayed metric values."""
+        def _to_float(label: QLabel) -> float:
+            try:
+                return float(label.text())
+            except ValueError:
+                return 0.0
+
+        return {
+            "ift": _to_float(self.ift_label),
+            "wo": _to_float(self.wo_label),
+            "volume": _to_float(self.volume_label),
+            "contact_angle": _to_float(self.angle_label),
+            "height": _to_float(self.height_label),
+            "diameter": _to_float(self.diameter_label),
+        }

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (
     QComboBox,
     QPushButton,
 )
+import pandas as pd
 
 from .controls import ZoomControl, ParameterPanel, MetricsPanel
 
@@ -99,6 +100,10 @@ class MainWindow(QMainWindow):
         self.draw_button = QPushButton("Draw Model")
         self.draw_button.clicked.connect(self.draw_model)
         control_layout.addWidget(self.draw_button)
+
+        self.save_csv_button = QPushButton("Save CSV")
+        self.save_csv_button.clicked.connect(self.save_csv)
+        control_layout.addWidget(self.save_csv_button)
 
         control_layout.addStretch()
         splitter.addWidget(control_widget)
@@ -380,6 +385,22 @@ class MainWindow(QMainWindow):
         self.graphics_view.render(painter)
         painter.end()
         image.save(str(path))
+
+    def save_csv(self, path: Path | None = None) -> None:
+        """Export parameters and metrics to a CSV file."""
+        if path is None:
+            p, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save CSV",
+                str(Path.home() / "results.csv"),
+                "CSV Files (*.csv)",
+            )
+            if not p:
+                return
+            path = Path(p)
+
+        data = {**self.parameter_panel.values(), **self.metrics_panel.values()}
+        pd.DataFrame([data]).to_csv(path, index=False)
 
     # --- Calibration drawing handling -------------------------------------------------
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -164,6 +164,9 @@ def test_metrics_panel_update():
     assert panel.ift_label.text().startswith("1.2")
     assert panel.volume_label.text().startswith("3.4")
 
+    metrics = panel.values()
+    assert metrics["ift"] == pytest.approx(1.2)
+
     window.close()
     app.quit()
 
@@ -385,6 +388,37 @@ def test_calculate_and_draw(tmp_path):
 
     window.draw_model()
     assert window.model_item is not None
+
+    window.close()
+    app.quit()
+
+
+def test_save_csv(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+    import pandas as pd
+
+    img = np.zeros((10, 10), dtype=np.uint8)
+    img[2:8, 2:8] = 255
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+    window.process_image()
+    window.calculate_parameters()
+
+    out_path = tmp_path / "out.csv"
+    window.save_csv(out_path)
+
+    assert out_path.exists()
+    df = pd.read_csv(out_path)
+    assert "air_density" in df.columns
+    assert "ift" in df.columns
 
     window.close()
     app.quit()


### PR DESCRIPTION
## Summary
- mark more tasks complete in PLAN.md
- add `values()` to `MetricsPanel`
- provide `Save CSV` button and method in `MainWindow`
- test metrics retrieval and CSV export
- log work in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686486f462e8832eb47360dec46f9036