### PR TITLE
Remove unused matplotlib dependency

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -170,3 +170,10 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Review PLAN.md, mark completed tasks, and start the next task by implementing CSV export.
 
 **Summary:** Marked the "Calculate & Draw" buttons, "Save Annotated Image," and "Propose enhancements" items as completed in PLAN.md. Added a "Save CSV" button to `MainWindow` with a new `save_csv` method that exports parameters and metrics using pandas. Extended `MetricsPanel` with a `values` method, updated GUI tests, and added a new test for CSV export. All tests pass.
+
+
+## Entry 29 - Remove matplotlib dependency
+
+**Task:** Remove matplotlib from requirements and setup since it is unused.
+
+**Summary:** Deleted matplotlib from `requirements.txt` and the `install_requires` list in `setup.py`. All tests pass.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ scipy
 pandas
 # GUI framework
 PySide6
-# Plotting (optional overlays)
-matplotlib
 # Packaging and testing
 setuptools
 wheel

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         "scikit-image>=0.19.3",
         "opencv-python>=4.7.0.72",
         "PySide6>=6.5.1",
-        "matplotlib>=3.7.1",
     ],
     entry_points={"console_scripts": ["menipy=main:main"]},
 )


### PR DESCRIPTION
## Summary
- remove `matplotlib` from `requirements.txt`
- drop `matplotlib` from `install_requires` in `setup.py`
- log removal in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648a7862f4832ea8fe710664d22e71