### PR TITLE
Fix Save CSV signal argument handling

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -188,3 +188,9 @@ This file summarizes tasks requested of CODEX and a brief description of how COD
 **Task:** Remove matplotlib from requirements and setup since it is unused.
 
 **Summary:** Deleted matplotlib from `requirements.txt` and the `install_requires` list in `setup.py`. All tests pass.
+
+## Entry 32 - Fix file dialog signal arguments
+
+**Task:** Resolve a crash when using `Save CSV` due to PySide6 passing a boolean to slots expecting a path.
+
+**Summary:** Updated `MainWindow` connections for menu actions and the CSV button to use lambdas, preventing unintended boolean arguments from `triggered`/`clicked` signals. Added lambdas for `Open Image` and `Save Annotated Image` actions as well. All tests pass.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -102,7 +102,7 @@ class MainWindow(QMainWindow):
         control_layout.addWidget(self.draw_button)
 
         self.save_csv_button = QPushButton("Save CSV")
-        self.save_csv_button.clicked.connect(self.save_csv)
+        self.save_csv_button.clicked.connect(lambda: self.save_csv())
         control_layout.addWidget(self.save_csv_button)
 
         control_layout.addStretch()
@@ -112,12 +112,12 @@ class MainWindow(QMainWindow):
 
         # Menu actions
         open_action = QAction("Open Image", self)
-        open_action.triggered.connect(self.open_image)
+        open_action.triggered.connect(lambda: self.open_image())
         file_menu = self.menuBar().addMenu("File")
         file_menu.addAction(open_action)
 
         save_action = QAction("Save Annotated Image", self)
-        save_action.triggered.connect(self.save_annotated_image)
+        save_action.triggered.connect(lambda: self.save_annotated_image())
         file_menu.addAction(save_action)
 
         tools_menu = self.menuBar().addMenu("Tools")


### PR DESCRIPTION
## Summary
- connect CSV save button and file menu actions using lambdas so that boolean
  arguments from Qt signals don't reach the slots
- log the update in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648e028fc0832e97a89da4b90277c5