### PR TITLE
Fix drop ROI persistence and needle length

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -287,3 +287,9 @@ structure and GUI behaviour. All tests pass.
 **Task:** Ensure the needle and drop regions drawn in the Drop Analysis tab remain visible and are stored for later use.
 
 **Summary:** Updated `MainWindow` so disabling drawing mode no longer removes ROI rectangles. Added coordinate labels in `DropAnalysisPanel` with `set_regions`/`regions` methods. Rectangles are cleared when a new image loads. Introduced a new test verifying region persistence and reset. All tests pass.
+
+## Entry 48 - Drop overlay fixes and needle width
+
+**Task:** Preserve drop ROI after analysis and define needle length as horizontal distance between edges.
+
+**Summary:** Updated `detect_vertical_edges` to compute width between vertical contours and modified tests accordingly. Drop and needle ROI rectangles now retain visibility by assigning a higher Z value. Added GUI test check for drop ROI persistence. All tests pass.

--- a/src/analysis/needle.py
+++ b/src/analysis/needle.py
@@ -54,8 +54,10 @@ def detect_vertical_edges(img_roi: np.ndarray) -> tuple[tuple[int, int], tuple[i
     if len(xs) < 2:
         raise ValueError("Needle edges not detected")
 
-    axis_x = int(round(sum([min(xs), max(xs)]) / 2))
+    left_x = min(xs)
+    right_x = max(xs)
+    axis_x = int(round((left_x + right_x) / 2))
     top_pt = (axis_x, int(y_top))
     bottom_pt = (axis_x, int(y_bottom))
-    length_px = float(np.hypot(bottom_pt[0] - top_pt[0], bottom_pt[1] - top_pt[1]))
+    length_px = float(right_x - left_x)
     return top_pt, bottom_pt, length_px

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -699,6 +699,7 @@ class MainWindow(QMainWindow):
         pen.setWidth(2)
         rect = QRectF(pos, pos)
         self.needle_rect_item = self.graphics_scene.addRect(rect, pen)
+        self.needle_rect_item.setZValue(1)
         event.accept()
 
     def _needle_move(self, event):
@@ -749,6 +750,7 @@ class MainWindow(QMainWindow):
         pen.setWidth(2)
         rect = QRectF(pos, pos)
         self.drop_rect_item = self.graphics_scene.addRect(rect, pen)
+        self.drop_rect_item.setZValue(1)
         event.accept()
 
     def _drop_move(self, event):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -18,7 +18,7 @@ def test_detect_vertical_edges_simple():
     assert abs(bottom[1] - 35) <= 1
     assert abs(top[0] - 20) <= 1
     assert top[0] == bottom[0]
-    assert abs(length - 30) <= 2
+    assert abs(length - 10) <= 4
 
 
 def test_detect_vertical_edges_failure():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -493,6 +493,7 @@ def test_drop_analysis_workflow(tmp_path):
     metrics = window.analysis_panel.metrics()
     assert float(metrics["height"]) > 0
     assert window.drop_contour_item is not None
+    assert window.drop_rect_item is not None
     window.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- keep ROI rectangles visible by elevating their z-value
- measure needle width between vertical edges
- update analysis tests for new definition
- ensure drop ROI still visible after analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a29e1cb8832e96e7895dd13b4b0a