### PR TITLE
Add missing drop analysis features

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -299,3 +299,14 @@ structure and GUI behaviour. All tests pass.
 **Task:** Update README and documentation.
 
 **Summary:** Added `doc/drop_analysis.md` detailing the workflow and algorithms for the new Drop Analysis tab. README now references the new document and describes the tab features.
+
+## Entry 50 - Drop analysis missing features
+
+**Task:** Implement new metrics and overlays for drop analysis.
+
+**Summary:** Added `_max_horizontal_diameter` in `analysis/drop.py` to locate the
+widest slice and contact line. `compute_drop_metrics` now returns the maximum
+horizontal diameter coordinates, apex radius, and optional contact line.
+`draw_drop_overlay` draws this line and the contact line. GUI panels show the
+"Radius–Apex" metric and render the new overlays. Documentation updated and unit
+tests added for these features.

--- a/doc/drop_analysis.md
+++ b/doc/drop_analysis.md
@@ -18,9 +18,11 @@ regions of interest drawn by the user on the main image canvas.
    pixels and combined with the known needle length in mm to obtain the
    pixel-to-mm scale.
 5. Press **Drop Region** and draw a green rectangle enclosing the droplet.
-6. Press **Analyze Image** to extract the external contour and overlay the
-   symmetry axis, apex, and max diameter line. Results are displayed in the
-   panel.
+6. Press **Analyze Image** to extract the external contour. The overlay shows
+   the symmetry axis, apex point, a blue line marking the maximum horizontal
+   diameter at its measured height, and an orange line where the droplet touches
+   the needle. Results are displayed in the panel, including the distance from
+   this diameter to the apex.
 
 ## 3. Algorithms
 
@@ -30,7 +32,10 @@ regions of interest drawn by the user on the main image canvas.
 - **Drop Contour and Metrics** – implemented in `analysis/drop.py`. The outer
   contour is obtained using morphological filtering and `cv2.findContours`.
   Metrics such as height, diameter, volume, contact angle and surface tension
-  are computed assuming axial symmetry.
+  are computed assuming axial symmetry. The routine locates the widest
+  horizontal slice of the contour to determine the true diameter and records the
+  distance from that slice to the apex. When the droplet meets the upper ROI
+  boundary, the contact line is highlighted.
 
 For additional examples, see `examples/pendant_demo.png`.
 

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -163,6 +163,8 @@ class MetricsPanel(QWidget):
             self.ift_label.setText(f"{ift:.2f}")
         if wo is not None:
             self.wo_label.setText(f"{wo:.2f}")
+        if radius is not None:
+            self.radius_apex_label.setText(f"{radius:.2f}")
         if volume is not None:
             self.volume_label.setText(f"{volume:.2f}")
         if contact_angle is not None:
@@ -231,6 +233,8 @@ class DropAnalysisPanel(QWidget):
         layout.addRow("Height (mm)", self.height_label)
         self.diameter_label = QLabel("0.0")
         layout.addRow("Diameter (mm)", self.diameter_label)
+        self.radius_apex_label = QLabel("0.0")
+        layout.addRow("Radius–Apex (mm)", self.radius_apex_label)
         self.volume_label = QLabel("0.0")
         layout.addRow("Volume (\u00b5L)", self.volume_label)
         self.angle_label = QLabel("0.0")
@@ -250,6 +254,7 @@ class DropAnalysisPanel(QWidget):
         angle: float | None = None,
         ift: float | None = None,
         wo: float | None = None,
+        radius: float | None = None,
     ) -> None:
         """Update displayed metric values."""
         if scale is not None:
@@ -258,6 +263,8 @@ class DropAnalysisPanel(QWidget):
             self.height_label.setText(f"{height:.2f}")
         if diameter is not None:
             self.diameter_label.setText(f"{diameter:.2f}")
+        if radius is not None:
+            self.radius_apex_label.setText(f"{radius:.2f}")
         if volume is not None:
             self.volume_label.setText(f"{volume:.2f}")
         if angle is not None:
@@ -272,6 +279,7 @@ class DropAnalysisPanel(QWidget):
             "scale": self.scale_label.text(),
             "height": self.height_label.text(),
             "diameter": self.diameter_label.text(),
+            "radius": self.radius_apex_label.text(),
             "volume": self.volume_label.text(),
             "angle": self.angle_label.text(),
             "ift": self.ift_label.text(),

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -494,7 +494,9 @@ class MainWindow(QMainWindow):
             return
         contour += np.array([x1, y1])
         mode = self.analysis_panel.method_combo.currentText()
-        metrics = compute_drop_metrics(contour.astype(float), self.px_per_mm_drop, mode)
+        metrics = compute_drop_metrics(
+            contour.astype(float), self.px_per_mm_drop, mode
+        )
         self.analysis_panel.set_metrics(
             height=metrics["height_mm"],
             diameter=metrics["diameter_mm"],
@@ -502,12 +504,14 @@ class MainWindow(QMainWindow):
             angle=metrics["contact_angle_deg"],
             ift=metrics["ift_mN_m"] if metrics["ift_mN_m"] is not None else 0.0,
             wo=metrics["wo"],
+            radius=metrics["radius_apex_mm"],
         )
-        x_min = int(contour[:, 0].min())
-        x_max = int(contour[:, 0].max())
         y_min = int(contour[:, 1].min())
         y_max = int(contour[:, 1].max())
-        diameter_line = ((x_min, metrics["apex"][1]), (x_max, metrics["apex"][1]))
+        diameter_line = (
+            metrics["diameter_line"][0],
+            metrics["diameter_line"][1],
+        )
         axis_line = (
             metrics["apex"],
             (metrics["apex"][0], y_min if mode == "pendant" else y_max),
@@ -526,6 +530,7 @@ class MainWindow(QMainWindow):
             contour,
             diameter_line=diameter_line,
             axis_line=axis_line,
+            contact_line=metrics.get("contact_line"),
             apex=metrics["apex"],
         )
         self.drop_contour_item = self.graphics_scene.addPixmap(overlay)

--- a/src/gui/overlay.py
+++ b/src/gui/overlay.py
@@ -18,6 +18,7 @@ def draw_drop_overlay(
     *,
     diameter_line: tuple[tuple[int, int], tuple[int, int]] | None = None,
     axis_line: tuple[tuple[int, int], tuple[int, int]] | None = None,
+    contact_line: tuple[tuple[int, int], tuple[int, int]] | None = None,
     apex: tuple[int, int] | None = None,
 ) -> QPixmap:
     """Return a ``QPixmap`` of ``image`` with droplet overlays drawn.
@@ -42,6 +43,8 @@ def draw_drop_overlay(
         cv2.line(canvas, diameter_line[0], diameter_line[1], (255, 0, 0), 2)
     if axis_line is not None:
         cv2.line(canvas, axis_line[0], axis_line[1], (0, 0, 255), 2)
+    if contact_line is not None:
+        cv2.line(canvas, contact_line[0], contact_line[1], (0, 165, 255), 2)
     if apex is not None:
         cv2.circle(canvas, apex, 3, (255, 255, 0), -1)
     return QPixmap.fromImage(_to_qimage(canvas))

--- a/tests/test_drop_metrics.py
+++ b/tests/test_drop_metrics.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from src.analysis.drop import compute_drop_metrics
+
+
+def test_max_diameter_and_radius_apex():
+    cv2 = __import__('cv2')
+    radius = 10
+    img = np.zeros((50, 50), dtype=np.uint8)
+    cv2.circle(img, (25, 30), radius, 255, -1)
+    roi = img[20:45, 10:40]
+    contour = cv2.findContours(roi, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[0][0].squeeze(1).astype(float)
+    contour += np.array([10, 20])
+    metrics = compute_drop_metrics(contour, px_per_mm=5.0, mode="pendant")
+    assert pytest.approx(metrics["diameter_px"], abs=1) == 2 * radius
+    assert metrics["diameter_line"][0][1] == metrics["diameter_line"][1][1]
+    assert metrics["contact_line"] is not None
+    assert metrics["radius_apex_mm"] > 0

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -464,6 +464,7 @@ def test_draw_drop_overlay_pixmap():
         contour,
         diameter_line=((5, 10), (15, 10)),
         axis_line=((10, 5), (10, 15)),
+        contact_line=((5, 5), (15, 5)),
         apex=(10, 10),
     )
     assert pix.width() == 20 and pix.height() == 20


### PR DESCRIPTION
## Summary
- detect max horizontal diameter and contact line in `compute_drop_metrics`
- show the diameter line and contact line on the overlay
- expose Radius–Apex metric in the GUI panel
- update documentation for drop analysis
- add tests for new metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866af97fa90832eb5179c480fc141df