### PR TITLE
Add debug prints for drop metrics

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -322,3 +322,10 @@ tests added for these features.
 **Task:** Add surface tension calculation methods and integrate them into drop analysis.
 
 **Summary:** Introduced `surface_tension.py` with Jennings–Pallas form factor, Young–Laplace surface tension, Bond number and contour based volume. `compute_drop_metrics` now outputs `gamma_mN_m`, `beta`, `Bo` and uses the new volume estimator. A minimal Sphinx config generates `docs/pendant_drop_methods.md` from these docstrings. Added unit tests for the new functions.
+
+## Entry 53 - Printing drop metrics for testing
+
+**Task:** Print each derived drop metric to the terminal for testing.
+
+**Summary:** Added print statements in `compute_drop_metrics` so height, diameter, apex, radius, beta, surface tension, Bond number, volume, contact angle and IFT values are displayed whenever metrics are computed. Existing tests continue to pass.
+

--- a/src/analysis/drop.py
+++ b/src/analysis/drop.py
@@ -154,6 +154,17 @@ def compute_drop_metrics(contour: np.ndarray, px_per_mm: float, mode: str) -> di
     )
     volume_uL = volume_from_contour(contour_mm)
 
+    print(f"height_mm={height_mm}")
+    print(f"diameter_mm={diameter_mm}")
+    print(f"apex={apex}")
+    print(f"radius_apex_mm={radius_apex_mm}")
+    print(f"beta={beta}")
+    print(f"gamma_mN_m={gamma * 1e3}")
+    print(f"Bo={bo}")
+    print(f"volume_uL={volume_uL}")
+    print(f"contact_angle_deg={angle}")
+    print(f"ift_mN_m={ift}")
+
     xs_contact = horizontal_intersections(contour, y_min)
     contact_line: tuple[tuple[int, int], tuple[int, int]] | None = None
     if xs_contact.size >= 2:


### PR DESCRIPTION
## Summary
- print all derived metrics during drop analysis for easier testing
- log the new behavior in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eec2c594832e9244e7d41e3e5ccb