### PR TITLE
Add surface tension and drop parameters

### DIFF
--- a/src/analysis/drop.py
+++ b/src/analysis/drop.py
@@ -181,6 +181,7 @@ def compute_drop_metrics(contour: np.ndarray, px_per_mm: float, mode: str) -> di
         "ift_mN_m": float(ift) if ift is not None else None,
         "gamma_mN_m": float(gamma * 1e3),
         "beta": float(beta),
+        "s1": float(s1),
         "Bo": float(bo),
         "wo": 0.0,
         "diameter_px": float(diam_px),

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -239,8 +239,14 @@ class DropAnalysisPanel(QWidget):
         layout.addRow("Volume (\u00b5L)", self.volume_label)
         self.angle_label = QLabel("0.0")
         layout.addRow("Contact angle (\u00b0)", self.angle_label)
-        self.ift_label = QLabel("0.0")
-        layout.addRow("IFT (mN/m)", self.ift_label)
+        self.gamma_label = QLabel("0.0")
+        layout.addRow("Surface tension (mN/m)", self.gamma_label)
+        self.beta_label = QLabel("0.0")
+        layout.addRow("Beta", self.beta_label)
+        self.s1_label = QLabel("0.0")
+        layout.addRow("s1", self.s1_label)
+        self.bo_label = QLabel("0.0")
+        layout.addRow("Bond number", self.bo_label)
         self.wo_label = QLabel("0.0")
         layout.addRow("Wo number", self.wo_label)
 
@@ -252,7 +258,10 @@ class DropAnalysisPanel(QWidget):
         diameter: float | None = None,
         volume: float | None = None,
         angle: float | None = None,
-        ift: float | None = None,
+        gamma: float | None = None,
+        beta: float | None = None,
+        s1: float | None = None,
+        bo: float | None = None,
         wo: float | None = None,
         radius: float | None = None,
     ) -> None:
@@ -269,8 +278,14 @@ class DropAnalysisPanel(QWidget):
             self.volume_label.setText(f"{volume:.2f}")
         if angle is not None:
             self.angle_label.setText(f"{angle:.2f}")
-        if ift is not None:
-            self.ift_label.setText(f"{ift:.2f}")
+        if gamma is not None:
+            self.gamma_label.setText(f"{gamma:.2f}")
+        if beta is not None:
+            self.beta_label.setText(f"{beta:.2f}")
+        if s1 is not None:
+            self.s1_label.setText(f"{s1:.2f}")
+        if bo is not None:
+            self.bo_label.setText(f"{bo:.2f}")
         if wo is not None:
             self.wo_label.setText(f"{wo:.2f}")
 
@@ -282,7 +297,10 @@ class DropAnalysisPanel(QWidget):
             "radius": self.radius_apex_label.text(),
             "volume": self.volume_label.text(),
             "angle": self.angle_label.text(),
-            "ift": self.ift_label.text(),
+            "gamma": self.gamma_label.text(),
+            "beta": self.beta_label.text(),
+            "s1": self.s1_label.text(),
+            "bo": self.bo_label.text(),
             "wo": self.wo_label.text(),
         }
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -496,7 +496,10 @@ class MainWindow(QMainWindow):
             diameter=metrics["diameter_mm"],
             volume=metrics["volume_uL"] if metrics["volume_uL"] is not None else 0.0,
             angle=metrics["contact_angle_deg"],
-            ift=metrics["ift_mN_m"] if metrics["ift_mN_m"] is not None else 0.0,
+            gamma=metrics["gamma_mN_m"],
+            beta=metrics["beta"],
+            s1=metrics["s1"],
+            bo=metrics["Bo"],
             wo=metrics["wo"],
             radius=metrics["radius_apex_mm"],
         )

--- a/tests/test_drop_metrics.py
+++ b/tests/test_drop_metrics.py
@@ -17,3 +17,4 @@ def test_max_diameter_and_radius_apex():
     assert metrics["diameter_line"][0][1] == metrics["diameter_line"][1][1]
     assert metrics["contact_line"] is not None
     assert metrics["radius_apex_mm"] > 0
+    assert metrics["s1"] > 0


### PR DESCRIPTION
## Summary
- compute and display surface tension from `surface_tension()`
- expose beta, Bond number and s1 on the Drop Analysis panel
- return `s1` from `compute_drop_metrics`
- adjust tests for new metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fecb90e4832e92938b6926ba6e43