### PR TITLE
Fix missing QFrame import in AnalysisTab

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -341,3 +341,10 @@ tests added for these features.
 
 **Summary:** Introduced `CalibrationTab` for calibration settings and `AnalysisTab` for displaying pendant or contact-angle results. `MainWindow` now builds these tabs, selects the method when an Analyze button is pressed and reuses existing drop analysis logic. Tests expect four tabs and read metrics from the pendant tab. All tests pass.
 
+
+## Entry 56 - Fix QFrame import
+
+**Task:** Resolve NameError when creating AnalysisTab due to missing QFrame import.
+
+**Summary:** Added QFrame to the PySide6.QtWidgets import list in `src/gui/controls.py`. All tests pass.
+

--- a/src/gui/controls.py
+++ b/src/gui/controls.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QPushButton,
     QComboBox,
+    QFrame,
 )
 
 


### PR DESCRIPTION
## Summary
- import `QFrame` in `controls.py` for AnalysisTab
- log the fix in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686712f7c9cc832ea85b5f9eba88c94c