### PR TITLE
Fix AnalysisTab metrics argument mismatch

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -348,3 +348,9 @@ tests added for these features.
 
 **Summary:** Added QFrame to the PySide6.QtWidgets import list in `src/gui/controls.py`. All tests pass.
 
+
+## Entry 57 - Fix metrics argument mismatch
+
+**Task:** Resolve TypeError from `AnalysisTab.set_metrics()` when running drop analysis.
+
+**Summary:** Removed the unsupported `beta` keyword from the `set_metrics` call in `gui/main_window.py`. Tests confirm the GUI now updates metrics without errors.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -508,7 +508,6 @@ class MainWindow(QMainWindow):
             volume=metrics["volume_uL"] if metrics["volume_uL"] is not None else 0.0,
             angle=metrics["contact_angle_deg"],
             gamma=metrics["gamma_mN_m"],
-            beta=metrics["beta"],
             s1=metrics["s1"],
             bo=metrics["Bo"],
             wo=metrics["wo"],


### PR DESCRIPTION
## Summary
- remove unsupported `beta` argument in drop analysis GUI
- log the fix in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686714ade134832e83330f382d807037