### PR TITLE
Improve default GUI sizing

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -354,3 +354,9 @@ tests added for these features.
 **Task:** Resolve TypeError from `AnalysisTab.set_metrics()` when running drop analysis.
 
 **Summary:** Removed the unsupported `beta` keyword from the `set_metrics` call in `gui/main_window.py`. Tests confirm the GUI now updates metrics without errors.
+
+## Entry 58 - GUI defaults
+
+**Task:** Start main window maximized and set default widget sizes.
+
+**Summary:** Modified `src/main.py` to call `showMaximized()` and updated `MainWindow` setup to enforce a 200px minimum image view and 250px tab width. Added splitter size initialization and a test covering these defaults.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -80,11 +80,13 @@ class MainWindow(QMainWindow):
 
         # Image display area
         self.graphics_view = ImageView()
+        self.graphics_view.setMinimumSize(200, 200)
         self.graphics_scene = self.graphics_view.scene()
         splitter.addWidget(self.graphics_view)
 
         # Control panel wrapped in tabs
         self.tabs = QTabWidget()
+        self.tabs.setMinimumWidth(250)
         splitter.addWidget(self.tabs)
 
         classic_widget = QWidget()
@@ -137,6 +139,7 @@ class MainWindow(QMainWindow):
         )
 
         self.setCentralWidget(splitter)
+        splitter.setSizes([max(self.width() - 250, 200), 250])
 
         # Menu actions
         open_action = QAction("Open Image", self)

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ def main() -> None:
     """Launch the Menipy GUI application."""
     app = QApplication([])
     window = MainWindow()
-    window.show()
+    window.showMaximized()
     app.exec()
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -49,6 +49,18 @@ def test_tab_widget_setup():
     app.quit()
 
 
+def test_widget_default_sizes():
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    assert window.graphics_view.minimumWidth() == 200
+    assert window.graphics_view.minimumHeight() == 200
+    assert window.tabs.minimumWidth() == 250
+    window.close()
+    app.quit()
+
+
 def test_load_image_retains_size(tmp_path):
     if QtWidgets is None:
         pytest.skip("PySide6 not available")


### PR DESCRIPTION
## Summary
- start the Qt main window maximized
- enforce minimum sizes for the graphics view and tab area
- initialize splitter sizes
- test the new size defaults
- log the change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68671d7d8cac832ea328e2dd9c91aff6