### PR TITLE
Add detection test tab with filters

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -360,3 +360,9 @@ tests added for these features.
 **Task:** Start main window maximized and set default widget sizes.
 
 **Summary:** Modified `src/main.py` to call `showMaximized()` and updated `MainWindow` setup to enforce a 200px minimum image view and 250px tab width. Added splitter size initialization and a test covering these defaults.
+## Entry 59 - Detection test interface
+
+**Task:** Move zoom control above image area, rename Classic tab, add detection and filter controls with associated buttons.
+
+**Summary:** Updated `MainWindow` layout to place `ZoomControl` atop the image view. The first tab is now "Detection Test" and includes a segmentation algorithm selector, Detect/Clean buttons, and filter selection with strength slider. Implemented `apply_filter`, `clean_filter`, and `clean_detection` helpers and simplified detection to show segmentation masks. Adjusted tests for the new tab name and ROI processing. All tests pass.
+

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -41,7 +41,7 @@ def test_tab_widget_setup():
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
     window = MainWindow()
     assert window.tabs.count() == 4
-    assert window.tabs.tabText(0) == "Classic"
+    assert window.tabs.tabText(0) == "Detection Test"
     assert window.tabs.tabText(1) == "Calibration"
     assert window.tabs.tabText(2) == "Pendant drop"
     assert window.tabs.tabText(3) == "Contact angle"
@@ -368,7 +368,6 @@ def test_process_image_with_roi(tmp_path):
     pixmap = window.mask_item.pixmap()
     assert pixmap.width() == 10
     assert pixmap.height() == 10
-    assert window.metrics_panel.mode_label.text() in {"sessile", "pendant", "unknown"}
 
     window.close()
     app.quit()


### PR DESCRIPTION
## Summary
- move ZoomControl above image view
- rename Classic tab to Detection Test with Detect/Clean and filter controls
- implement image filtering and cleaning helpers
- simplify process_image to show segmentation masks based on algorithm selector
- update tests for new tab name and segmentation output
- log changes in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672297e608832e90dd5dd05dd5f5b2