### PR TITLE
Fix Clean button resizing window

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -372,3 +372,9 @@ tests added for these features.
 **Task:** Resolve AttributeError due to referencing buttons before creation in `MainWindow` setup.
 
 **Summary:** Moved the initialization of `detect_button`, `clean_button`, and filter controls above their layout insertion to ensure attributes exist before use. All tests pass.
+
+## Entry 61 - Stop Clean button resizing window
+
+**Task:** Prevent the Clean Detection action from altering the main window dimensions.
+
+**Summary:** Removed the `adjustSize()` call from `MainWindow.clean_detection` so pressing "Clean" no longer resizes the GUI. All tests continue to pass.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -312,7 +312,6 @@ class MainWindow(QMainWindow):
             self.graphics_scene.removeItem(self.contact_line_item)
             self.contact_line_item = None
         self.last_mask = None
-        self.adjustSize()
         self.set_zoom(self.zoom_control.slider.value() / 100.0)
 
     def _display_image(self, img: np.ndarray) -> None:


### PR DESCRIPTION
## Summary
- prevent `clean_detection` from resizing the main window
- log the change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686726ebb738832e84e14ebe524c14a4