### PR TITLE
Fix substrate action initialization

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -397,3 +397,9 @@ tests added for these features.
 **Task:** Prevent AttributeError when checking active tab during setup.
 
 **Summary:** Moved the `currentChanged` signal connection in `MainWindow._setup_ui` until after the `contact_tab` is created. This avoids early invocation of `_update_tool_visibility` before the attribute exists, fixing the startup crash.
+
+## Entry 65 - Fix substrate action init
+
+**Task:** Prevent AttributeError for missing draw_substrate_action.
+
+**Summary:** Moved the initial `_update_tool_visibility()` call to after `draw_substrate_action` is created so the action exists before visibility is set.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -150,7 +150,6 @@ class MainWindow(QMainWindow):
 
         # Connect after tabs exist so currentChanged doesn't fire early
         self.tabs.currentChanged.connect(self._update_tool_visibility)
-        self._update_tool_visibility()
 
         # Drop analysis button connections
         self.calibration_tab.needle_region_button.clicked.connect(
@@ -192,6 +191,7 @@ class MainWindow(QMainWindow):
             lambda checked: self.set_substrate_mode(checked)
         )
         tools_menu.addAction(self.draw_substrate_action)
+        self._update_tool_visibility()
 
         self.mask_item = None
         self.contour_items = []


### PR DESCRIPTION
## Summary
- connect tab changed signal as before
- move initial `_update_tool_visibility()` call until after `draw_substrate_action` is created
- update CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686737c851e0832e94334109ed3fa2bf