### PR TITLE
Fix default handler initialization

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -403,3 +403,8 @@ tests added for these features.
 **Task:** Prevent AttributeError for missing draw_substrate_action.
 
 **Summary:** Moved the initial `_update_tool_visibility()` call to after `draw_substrate_action` is created so the action exists before visibility is set.
+## Entry 66 - Initialize default event handlers
+
+**Task:** Resolve AttributeError when calling set_substrate_mode during window initialization.
+
+**Summary:** Saved the graphics view's default mouse event handlers before calling `_update_tool_visibility` in `_setup_ui`. This ensures `set_substrate_mode(False)` has access to the handlers. All tests pass.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -90,6 +90,10 @@ class MainWindow(QMainWindow):
         self.graphics_view = ImageView()
         self.graphics_view.setMinimumSize(200, 200)
         self.graphics_scene = self.graphics_view.scene()
+        # Save default mouse handlers before they may be overridden
+        self._default_press = self.graphics_view.mousePressEvent
+        self._default_move = self.graphics_view.mouseMoveEvent
+        self._default_release = self.graphics_view.mouseReleaseEvent
         image_layout.addWidget(self.graphics_view)
         splitter.addWidget(image_container)
 
@@ -205,9 +209,6 @@ class MainWindow(QMainWindow):
         self.roi_rect_item = None
         self.roi_rect = None
         self._roi_start = None
-        self._default_press = self.graphics_view.mousePressEvent
-        self._default_move = self.graphics_view.mouseMoveEvent
-        self._default_release = self.graphics_view.mouseReleaseEvent
 
         self.last_mask = None
         self.mask_offset = (0, 0)


### PR DESCRIPTION
## Summary
- save default mouse handlers before calling `_update_tool_visibility`
- update CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686739417ce8832eb6433d5955fb4b5a