### PR TITLE
Disable auto-analysis for substrate line

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -923,7 +923,6 @@ class MainWindow(QMainWindow):
         if self.substrate_line_item is not None:
             self.graphics_scene.removeItem(self.substrate_line_item)
         self.substrate_line_item = SubstrateLineItem(QLineF(pos, pos))
-        self.substrate_line_item.moved.connect(self.analyze_drop_image)
         self.graphics_scene.addItem(self.substrate_line_item)
         event.accept()
 
@@ -949,7 +948,6 @@ class MainWindow(QMainWindow):
             line.x2(),
             line.y2(),
         )
-        self.substrate_line_item.moved.emit()
         self._substrate_start = None
         self.draw_substrate_action.setChecked(False)
         self.set_substrate_mode(False)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -557,13 +557,15 @@ def test_substrate_line_updates_metrics(tmp_path):
     window.px_per_mm_drop = 10.0
     window.substrate_line_item = SubstrateLineItem(QLineF(10, 38, 30, 38))
     window.graphics_scene.addItem(window.substrate_line_item)
-    window.substrate_line_item.moved.connect(window.analyze_drop_image)
     window._run_analysis("contact-angle")
     before = window.contact_tab.width_label.text()
     line = window.substrate_line_item.line()
     line.translate(0, -2)
     window.substrate_line_item.setLine(line)
     QtWidgets.QApplication.processEvents()
+    after = window.contact_tab.width_label.text()
+    assert before == after
+    window._run_analysis("contact-angle")
     after = window.contact_tab.width_label.text()
     window.close()
     app.quit()
@@ -594,7 +596,6 @@ def test_contact_tab_draw_button(tmp_path):
         assert warn.called
     window.substrate_line_item = SubstrateLineItem(QLineF(1, 10, 18, 10))
     window.graphics_scene.addItem(window.substrate_line_item)
-    window.substrate_line_item.moved.connect(window.analyze_drop_image)
     with patch("PySide6.QtWidgets.QMessageBox.warning") as warn:
         window._run_analysis("contact-angle")
         assert not warn.called


### PR DESCRIPTION
## Summary
- remove auto-analysis trigger when drawing substrate line
- update tests for manual analysis workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867426dfeac832ebe7e4e9398b699e3