### PR TITLE
Implement droplet polygon for contact angle workflow

### DIFF
--- a/tests/test_contact_geom.py
+++ b/tests/test_contact_geom.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from src.physics.contact_geom import geom_metrics
+cv2 = __import__('cv2')
 
 
 def test_circle_geom_metrics():
@@ -21,3 +22,6 @@ def test_circle_geom_metrics():
     metrics = geom_metrics(tuple(p1), tuple(p2), contour_rot, apex_idx, px_per_mm)
     assert metrics["rb_mm"] == pytest.approx(1.0, rel=1e-2)
     assert metrics["h_mm"] == pytest.approx(1.0, rel=2e-2)
+    poly = metrics["droplet_poly"]
+    area_px = cv2.contourArea(poly.astype(np.float32))
+    assert area_px == pytest.approx(0.5 * np.pi * r_px ** 2, rel=1e-2)


### PR DESCRIPTION
## Summary
- extend `geom_metrics` to compute droplet polygon trimmed by the substrate
- update GUI workflow so contact-angle calculations use this polygon
- test droplet polygon creation in `test_contact_geom`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674a74dd44832e8efab82b4c81ac82