### PR TITLE
Fix apex detection and axis overlay

### DIFF
--- a/doc/contact_angle_alt.md
+++ b/doc/contact_angle_alt.md
@@ -8,8 +8,8 @@ user defined substrate polyline and support tilted setups.
   in drawing order.
 * **project_pts_onto_poly** – projects arbitrary points onto a polyline and
   yields distances and foot points.
-* **symmetry_axis** – computes a symmetry axis perpendicular to the substrate
-  through the apex when available.
+* **symmetry_axis** – returns the apex point and a unit vector normal to the
+  substrate line.
 
 * **polyline_contour_intersections** – returns ordered intersections between the
   user drawn substrate and the droplet contour.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -647,20 +647,32 @@ class MainWindow(QMainWindow):
             metrics["diameter_line"][1],
         )
         if mode == "contact-angle-alt" and self.substrate_line_item is not None:
-            p1 = np.array([metrics["xL_px"], -(metrics["a"] * metrics["xL_px"] + metrics["c"]) / metrics["b"]])
-            p2 = np.array([metrics["xR_px"], -(metrics["a"] * metrics["xR_px"] + metrics["c"]) / metrics["b"]])
-            poly = np.array([
-                self.substrate_line_item.line().p1().toTuple(),
-                self.substrate_line_item.line().p2().toTuple(),
-            ], dtype=float)
-            apex_pt = np.array(metrics["apex"], dtype=float)
-            s1, s2 = symmetry_axis(apex_pt, poly, p1, p2)
-            axis_line = (tuple(np.round(s1).astype(int)), tuple(np.round(s2).astype(int)))
+            p1 = np.array([
+                metrics["xL_px"],
+                -(metrics["a"] * metrics["xL_px"] + metrics["c"]) / metrics["b"],
+            ])
+            p2 = np.array([
+                metrics["xR_px"],
+                -(metrics["a"] * metrics["xR_px"] + metrics["c"]) / metrics["b"],
+            ])
+            line_dir = p2 - p1
+        elif self.substrate_line_item is not None:
+            line_dir = np.array(
+                self.substrate_line_item.line().p2().toTuple(), float
+            ) - np.array(self.substrate_line_item.line().p1().toTuple(), float)
+            p1 = np.array(diameter_line[0], float)
+            p2 = np.array(diameter_line[1], float)
         else:
-            axis_line = (
-                metrics["apex"],
-                (metrics["apex"][0], y_min if mode == "pendant" else y_max),
-            )
+            line_dir = np.array([1.0, 0.0])
+            p1 = np.array(diameter_line[0], float)
+            p2 = np.array(diameter_line[1], float)
+
+        apex_pt = np.array(metrics["apex"], dtype=float)
+        _, axis_vec = symmetry_axis(apex_pt, line_dir)
+        axis_len = 1.2 * np.linalg.norm(p2 - p1)
+        s1 = apex_pt - 0.5 * axis_len * axis_vec
+        s2 = apex_pt + 0.5 * axis_len * axis_vec
+        axis_line = (tuple(np.round(s1).astype(int)), tuple(np.round(s2).astype(int)))
         if self.drop_contour_item is not None:
             self.graphics_scene.removeItem(self.drop_contour_item)
         if self.diameter_item is not None:

--- a/tests/test_contact_angle_alt.py
+++ b/tests/test_contact_angle_alt.py
@@ -32,11 +32,11 @@ def test_projection_and_axis_tilt():
     rot = np.array([[np.cos(np.pi / 6), -np.sin(np.pi / 6)], [np.sin(np.pi / 6), np.cos(np.pi / 6)]])
     poly_tilt = poly @ rot.T
     apex = np.array([0, 5]) @ rot.T
-    p1 = poly_tilt[0]
-    p2 = poly_tilt[1]
-    s1, s2 = symmetry_axis(apex, poly_tilt, p1, p2)
-    assert s1.shape == (2,)
-    assert s2.shape == (2,)
+    line_dir = poly_tilt[1] - poly_tilt[0]
+    pt, vec = symmetry_axis(apex, line_dir)
+    assert pt.shape == (2,)
+    assert vec.shape == (2,)
+    assert np.isclose(np.linalg.norm(vec), 1.0, rtol=1e-6)
 
 
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -6,6 +6,7 @@ from src.detectors.geometry_alt import (
     find_substrate_intersections,
     apex_point,
     split_contour_by_line,
+    symmetry_axis,
 )
 
 
@@ -24,5 +25,19 @@ def test_halfplane_and_apex():
     seg = split_contour_by_line(contour, line_pt, line_dir)
     assert any(np.allclose(pt, p1) for pt in seg)
     assert any(np.allclose(pt, p2) for pt in seg)
-    apex, _ = apex_point(seg, line_pt, line_dir)
+    apex, _ = apex_point(seg, line_pt, line_dir, "sessile")
     assert apex[1] == pytest.approx(20.0, rel=1e-2)
+
+    # symmetry axis should be vertical
+    pt, vec = symmetry_axis(apex, line_dir)
+    angle = np.degrees(np.arccos(np.clip(np.dot(vec, [0, 1]), -1.0, 1.0)))
+    assert angle <= 1.0
+
+
+def test_apex_point_pendant():
+    contour = _circle_contour()
+    line_pt = np.array([-20.0, 20.0])
+    line_dir = np.array([40.0, 0.0])
+    seg = split_contour_by_line(contour, line_pt, line_dir, keep_above=False)
+    apex, _ = apex_point(seg, line_pt, line_dir, "pendant")
+    assert apex[1] == pytest.approx(0.0, abs=1e-2)


### PR DESCRIPTION
## Summary
- refine apex detection relative to substrate line orientation
- compute symmetry axis from the line normal
- update GUI overlay to draw a finite symmetry axis
- adjust documentation
- extend geometry tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b9702c04832eb25145356d46845e