### PR TITLE
Implement robust contact region utilities

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -484,3 +484,9 @@ tests added for these features.
 **Task:** Confirm the alternative contact-angle tab uses the apex projection fix and keeps the dashed substrate line after analysis.
 
 **Summary:** Added a GUI test checking that `_run_analysis("contact-angle-alt")` leaves the same `SubstrateLineItem` with a dashed pen. Updated `README.md` to mention the *Contact Angle (Alt)* tab and clarified in `doc/contact_angle_alt.md` that `geom_metrics_alt` provides the projected symmetry axis. All tests continue to pass.
+## Entry 81 - Robust contact region
+
+**Task:** Implement robust contact-region extraction and mode-specific metrics.
+
+**Summary:** Added `region.close_droplet` with half-plane filtering, intersection clustering and mask closing. Implemented `metrics_sessile` and `metrics_pendant` to compute diameter, apex, height and volume via the new helper. Created `tests/test_contact_region.py` with regression cases. All tests pass.
+

--- a/src/processing/metrics.py
+++ b/src/processing/metrics.py
@@ -1,0 +1,69 @@
+"""Droplet metric helpers."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from ..models.properties import droplet_volume
+from .region import close_droplet, _signed_distance
+
+
+def _apex_point(contour: np.ndarray, line_pt: np.ndarray, line_dir: np.ndarray, mode: str) -> np.ndarray:
+    dist = _signed_distance(contour, line_pt, line_dir)
+    idx = int(np.argmax(dist)) if mode == "sessile" else int(np.argmin(dist))
+    return contour[idx]
+
+
+def metrics_sessile(
+    contour: np.ndarray,
+    line: Tuple[Tuple[float, float], Tuple[float, float]],
+    px_per_mm: float,
+) -> dict:
+    """Return sessile droplet metrics relative to a substrate line."""
+    p1, p2 = line
+    mask, c1, c2 = close_droplet(contour, p1, np.subtract(p2, p1), "sessile")
+    apex = _apex_point(contour, np.array(p1, float), np.subtract(p2, p1), "sessile")
+    nvec = np.array([-(p2[1] - p1[1]), p2[0] - p1[0]], float)
+    nvec /= np.hypot(nvec[0], nvec[1])
+    h_px = abs((apex - p1) @ nvec)
+    w_px = np.linalg.norm(c2 - c1)
+    volume = droplet_volume(mask, 1.0 / px_per_mm)
+    return {
+        "diameter_mm": float(w_px / px_per_mm),
+        "rb_mm": float(w_px / (2.0 * px_per_mm)),
+        "apex": (int(round(apex[0])), int(round(apex[1]))),
+        "height_mm": float(h_px / px_per_mm),
+        "volume_mm3": float(volume) if volume is not None else None,
+        "mask": mask,
+        "p1": (float(c1[0]), float(c1[1])),
+        "p2": (float(c2[0]), float(c2[1])),
+    }
+
+
+def metrics_pendant(
+    contour: np.ndarray,
+    line: Tuple[Tuple[float, float], Tuple[float, float]],
+    px_per_mm: float,
+) -> dict:
+    """Return pendant droplet metrics relative to a needle line."""
+    p1, p2 = line
+    mask, c1, c2 = close_droplet(contour, p1, np.subtract(p2, p1), "pendant")
+    apex = _apex_point(contour, np.array(p1, float), np.subtract(p2, p1), "pendant")
+    nvec = np.array([-(p2[1] - p1[1]), p2[0] - p1[0]], float)
+    nvec /= np.hypot(nvec[0], nvec[1])
+    h_px = abs((apex - p1) @ nvec)
+    w_px = np.linalg.norm(c2 - c1)
+    volume = droplet_volume(mask, 1.0 / px_per_mm)
+    return {
+        "diameter_mm": float(w_px / px_per_mm),
+        "rb_mm": float(w_px / (2.0 * px_per_mm)),
+        "apex": (int(round(apex[0])), int(round(apex[1]))),
+        "height_mm": float(h_px / px_per_mm),
+        "volume_mm3": float(volume) if volume is not None else None,
+        "mask": mask,
+        "p1": (float(c1[0]), float(c1[1])),
+        "p2": (float(c2[0]), float(c2[1])),
+    }
+

--- a/src/processing/region.py
+++ b/src/processing/region.py
@@ -1,0 +1,111 @@
+"""Droplet region utilities."""
+
+from __future__ import annotations
+
+from typing import Literal, Tuple
+
+import cv2
+import numpy as np
+
+
+_EPS = 2.0
+
+
+def _signed_distance(points: np.ndarray, line_pt: np.ndarray, line_dir: np.ndarray) -> np.ndarray:
+    """Return signed distances of ``points`` to the line defined by ``line_pt`` and ``line_dir``."""
+    nvec = np.array([-line_dir[1], line_dir[0]], float)
+    norm = np.hypot(nvec[0], nvec[1])
+    if norm == 0:
+        raise ValueError("line_dir cannot be zero")
+    nvec /= norm
+    return (points - line_pt) @ nvec
+
+
+def _cluster_points(points: np.ndarray, eps: float = 3.0) -> list[np.ndarray]:
+    """Cluster ``points`` using a simple distance-based BFS."""
+    remaining = list(range(len(points)))
+    clusters = []
+    while remaining:
+        seed = remaining.pop()
+        cluster = [seed]
+        changed = True
+        while changed:
+            changed = False
+            for idx in list(remaining):
+                if np.linalg.norm(points[idx] - points[seed]) <= eps:
+                    remaining.remove(idx)
+                    cluster.append(idx)
+                    changed = True
+        clusters.append(points[cluster])
+    return clusters
+
+
+def close_droplet(
+    contour: np.ndarray,
+    line_pt: Tuple[float, float],
+    line_dir: Tuple[float, float],
+    mode: Literal["sessile", "pendant"],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return a closed droplet mask and contact points ``p1``, ``p2``."""
+    if contour.ndim != 2 or contour.shape[1] != 2:
+        raise ValueError("contour must have shape (N,2)")
+    if mode not in {"sessile", "pendant"}:
+        raise ValueError("mode must be 'sessile' or 'pendant'")
+
+    contour = contour.astype(float)
+    line_pt = np.asarray(line_pt, float)
+    line_dir = np.asarray(line_dir, float)
+
+    dist = _signed_distance(contour, line_pt, line_dir)
+    keep = dist > _EPS if mode == "sessile" else dist < -_EPS
+    kept = contour[keep]
+    if kept.size == 0:
+        kept = contour
+
+    # --- locate intersections -------------------------------------------------
+    inter: list[np.ndarray] = []
+    dist_next = np.roll(dist, -1)
+    for p, q, dp, dq in zip(contour, np.roll(contour, -1, axis=0), dist, dist_next):
+        if dp == dq:
+            continue
+        if dp * dq <= 0:
+            t = dp / (dp - dq)
+            inter.append(p + t * (q - p))
+    if len(inter) < 2:
+        raise ValueError("line does not intersect contour")
+    inter_pts = np.array(inter)
+
+    if len(inter_pts) > 2:
+        clusters = _cluster_points(inter_pts, eps=3.0)
+        centroids = np.array([c.mean(axis=0) for c in clusters])
+    else:
+        centroids = inter_pts
+
+    tvals = centroids @ line_dir
+    if len(centroids) > 2:
+        diff = tvals[:, None] - tvals[None, :]
+        i, j = divmod(np.abs(diff).argmax(), diff.shape[0])
+        p1, p2 = centroids[min(i, j)], centroids[max(i, j)]
+    else:
+        order = np.argsort(tvals)
+        p1, p2 = centroids[order[0]], centroids[order[1]]
+
+    # --- mask closing ---------------------------------------------------------
+    x_min = int(np.floor(min(kept[:, 0].min(), p1[0], p2[0])))
+    x_max = int(np.ceil(max(kept[:, 0].max(), p1[0], p2[0])))
+    y_min = int(np.floor(min(kept[:, 1].min(), p1[1], p2[1])))
+    y_max = int(np.ceil(max(kept[:, 1].max(), p1[1], p2[1])))
+    mask = np.zeros((y_max - y_min + 1, x_max - x_min + 1), dtype=np.uint8)
+    shifted = np.round(kept - [x_min, y_min]).astype(np.int32)
+    if shifted.size > 0:
+        cv2.fillPoly(mask, [shifted], 255)
+    cv2.line(
+        mask,
+        tuple(np.round(p1 - [x_min, y_min]).astype(int)),
+        tuple(np.round(p2 - [x_min, y_min]).astype(int)),
+        255,
+        1,
+    )
+
+    return mask, p1, p2
+

--- a/tests/test_contact_region.py
+++ b/tests/test_contact_region.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from src.processing.region import close_droplet
+from src.processing.metrics import metrics_sessile, metrics_pendant
+
+
+def _circle_contour(r=20.0, n=200):
+    theta = np.linspace(0, 2 * np.pi, n)
+    return np.stack([r * np.cos(theta), r * np.sin(theta) + r], axis=1)
+
+
+def test_close_droplet_clusters():
+    pts = [
+        [-20, 0],
+        [-15, 0.3],
+        [-10, -0.3],
+        [-5, 0.3],
+        [0, -0.3],
+        [5, 0.3],
+        [10, -0.3],
+        [15, 0.3],
+        [20, 0],
+        [20, 40],
+        [-20, 40],
+    ]
+    contour = np.array(pts, float)
+    mask, p1, p2 = close_droplet(contour, (-25, 0), (50, 0), "sessile")
+    assert mask.any()
+    assert p1[0] < 0 < p2[0]
+
+
+def test_metrics_sessile_basic():
+    contour = _circle_contour()
+    line = ((-40.0, 20.0), (40.0, 20.0))
+    m = metrics_sessile(contour, line, px_per_mm=10.0)
+    assert pytest.approx(m["diameter_mm"], rel=1e-2) == 4.0
+    assert pytest.approx(m["height_mm"], rel=1e-2) == 2.0
+
+
+def test_metrics_pendant_basic():
+    contour = _circle_contour()
+    line = ((-40.0, 20.0), (40.0, 20.0))
+    m = metrics_pendant(contour, line, px_per_mm=10.0)
+    assert pytest.approx(m["diameter_mm"], rel=1e-2) == 4.0
+    assert pytest.approx(m["height_mm"], rel=1e-2) == 2.0
+


### PR DESCRIPTION
## Summary
- add helper to close droplet regions and cluster substrate intersections
- provide `metrics_sessile` and `metrics_pendant`
- test contact-region extraction and metrics
- log the new work in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cbc72d00832eb693468a3d36e81e