### PR TITLE
Add side selection button to contact tab

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -490,3 +490,9 @@ tests added for these features.
 
 **Summary:** Added `region.close_droplet` with half-plane filtering, intersection clustering and mask closing. Implemented `metrics_sessile` and `metrics_pendant` to compute diameter, apex, height and volume via the new helper. Created `tests/test_contact_region.py` with regression cases. All tests pass.
 
+## Entry 82 - Contact tab side selection
+
+**Task:** Let users choose the droplet side in the regular Contact Angle workflow.
+
+**Summary:** Added a "Select Drop Side" button to `contact_tab` in `MainWindow` and wired it to `_select_side_button_clicked`. Updated the tab widget test to expect the extra tab and created a GUI test for the new button. All tests pass.
+

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -159,6 +159,8 @@ class MainWindow(QMainWindow):
             "Detect Substrate Line"
         )
         self.contact_tab.layout().insertRow(1, self.contact_tab.detect_substrate_button)
+        self.contact_tab.side_button = QPushButton("Select Drop Side")
+        self.contact_tab.layout().insertRow(2, self.contact_tab.side_button)
         self.tabs.addTab(self.contact_tab, "Contact angle")
 
         self.contact_tab_alt = ContactAngleTabAlt()
@@ -186,6 +188,10 @@ class MainWindow(QMainWindow):
         if hasattr(self.contact_tab, "detect_substrate_button"):
             self.contact_tab.detect_substrate_button.clicked.connect(
                 self._detect_substrate_line
+            )
+        if hasattr(self.contact_tab, "side_button"):
+            self.contact_tab.side_button.clicked.connect(
+                self._select_side_button_clicked
             )
         self.contact_tab.analyze_button.clicked.connect(
             lambda: self._run_analysis("contact-angle")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -40,11 +40,12 @@ def test_tab_widget_setup():
         pytest.skip("PySide6 not available")
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
     window = MainWindow()
-    assert window.tabs.count() == 4
+    assert window.tabs.count() == 5
     assert window.tabs.tabText(0) == "Detection Test"
     assert window.tabs.tabText(1) == "Calibration"
     assert window.tabs.tabText(2) == "Pendant drop"
     assert window.tabs.tabText(3) == "Contact angle"
+    assert window.tabs.tabText(4) == "Contact Angle (Alt)"
     window.close()
     app.quit()
 
@@ -628,6 +629,35 @@ def test_contact_tab_detect_button(tmp_path):
     elif ang < -90.0:
         ang += 180.0
     assert abs(ang) <= 5.0
+    window.close()
+    app.quit()
+
+
+def test_contact_tab_side_button(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+    import numpy as np
+    import cv2
+    from unittest.mock import patch
+    from PySide6.QtCore import QLineF
+    from src.gui import SubstrateLineItem
+
+    img = np.zeros((20, 20), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+    assert window.contact_tab.side_button is not None
+    with patch("PySide6.QtWidgets.QMessageBox.information") as info:
+        window.contact_tab.side_button.click()
+        assert info.called
+    window.substrate_line_item = SubstrateLineItem(QLineF(1, 10, 18, 10))
+    window.graphics_scene.addItem(window.substrate_line_item)
+    with patch("PySide6.QtWidgets.QMessageBox.information") as info:
+        window.contact_tab.side_button.click()
+        assert not info.called
     window.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- add Select Drop Side button to the Contact Angle tab
- connect the button to the side selection handler
- update tab widget test to expect five tabs
- add a GUI test for the new button
- log the change in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d8642c74832eac30342e48fd599c