### PR TITLE
Add contact point overlay

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -502,3 +502,9 @@ tests added for these features.
 **Task:** Remove the temporary Contact Angle Alt tab now that the main contact angle tab works.
 
 **Summary:** Deleted `contact_angle_tab_alt.py` and references to the alternative tab in `MainWindow`, exports and GUI tests. Updated documentation and README accordingly. All tests pass.
+
+## Entry 84 - Highlight contact points
+
+**Task:** Add overlay markers for the substrate contact points P1 and P2.
+
+**Summary:** Extended `draw_drop_overlay` with a ``contact_pts`` parameter to draw yellow dots at the intersection points. Updated `MainWindow.analyze_drop_image` to pass the contact points from ``compute_drop_metrics`` and adjusted the GUI test. All tests pass.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -693,6 +693,7 @@ class MainWindow(QMainWindow):
             axis_line=axis_line,
             contact_line=None,
             apex=metrics["apex"],
+            contact_pts=metrics.get("contact_line"),
         )
         self.drop_contour_item = self.graphics_scene.addPixmap(overlay)
 

--- a/src/gui/overlay.py
+++ b/src/gui/overlay.py
@@ -20,6 +20,7 @@ def draw_drop_overlay(
     axis_line: tuple[tuple[int, int], tuple[int, int]] | None = None,
     contact_line: tuple[tuple[int, int], tuple[int, int]] | np.ndarray | None = None,
     apex: tuple[int, int] | None = None,
+    contact_pts: tuple[tuple[int, int], tuple[int, int]] | None = None,
 ) -> QPixmap:
     """Return a ``QPixmap`` of ``image`` with droplet overlays drawn.
 
@@ -35,6 +36,8 @@ def draw_drop_overlay(
         Optional symmetry/height axis line.
     apex:
         Optional apex point ``(x, y)``.
+    contact_pts:
+        Optional pair of contact points ``(P1, P2)``.
     """
     canvas = image.copy()
     if contour is not None:
@@ -51,5 +54,8 @@ def draw_drop_overlay(
             cv2.line(canvas, contact_line[0], contact_line[1], (0, 165, 255), 2)
     if apex is not None:
         cv2.circle(canvas, apex, 3, (255, 255, 0), -1)
+    if contact_pts is not None:
+        for pt in contact_pts:
+            cv2.circle(canvas, tuple(pt), 3, (255, 255, 0), -1)
     return QPixmap.fromImage(_to_qimage(canvas))
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -475,6 +475,7 @@ def test_draw_drop_overlay_pixmap():
         axis_line=((10, 5), (10, 15)),
         contact_line=((5, 5), (15, 5)),
         apex=(10, 10),
+        contact_pts=((5, 5), (15, 5)),
     )
     assert pix.width() == 20 and pix.height() == 20
 


### PR DESCRIPTION
## Summary
- draw contact points in `draw_drop_overlay`
- show contact points after drop analysis
- update overlay unit test
- log the change in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e25bfee8832e87c92ef48dbc9fae