### PR TITLE
Add UI runner for refactored package

### DIFF
--- a/src_alt/menipy/__init__.py
+++ b/src_alt/menipy/__init__.py
@@ -2,5 +2,9 @@
 
 from .sharpen_plugin import sharpen_filter
 
-__all__ = ["sharpen_filter"]
+try:
+    from .gui import main as gui_main
+except Exception:  # pragma: no cover - optional dependency
+    gui_main = None
 
+__all__ = ["sharpen_filter", "gui_main"]

--- a/src_alt/menipy/gui.py
+++ b/src_alt/menipy/gui.py
@@ -1,0 +1,19 @@
+"""Launch the Menipy GUI application."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QApplication
+
+from .ui import MainWindow
+
+
+def main() -> None:
+    """Run the graphical interface."""
+    app = QApplication.instance() or QApplication([])
+    window = MainWindow()
+    window.showMaximized()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/src_alt/tests/test_imports.py
+++ b/src_alt/tests/test_imports.py
@@ -29,6 +29,7 @@ MODULES = [
     "menipy.metrics.metrics",
     "menipy.ui.main_window",
     "menipy.cli",
+    "menipy.gui",
     "menipy.utils",
     "menipy.plugins",
 ]


### PR DESCRIPTION
## Summary
- add a GUI entry point in `src_alt` so the PySide6 UI can be started
- expose `gui_main` optional import in `menipy` package
- ensure import tests cover the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a67e2775c832eba4a1d414983c8dc