### PR TITLE
Fix alt GUI imports

### DIFF
--- a/src_alt/menipy/ui/main_window.py
+++ b/src_alt/menipy/ui/main_window.py
@@ -13,13 +13,13 @@ from PySide6.QtWidgets import (
 )
 from pathlib import Path
 
-from menipy import plugins
+from .. import plugins
 from src.gui.main_window import MainWindow as LegacyMainWindow
 from src.gui.items import SubstrateLineItem
 from src.gui.overlay import draw_drop_overlay
-from menipy.detection.needle import detect_vertical_edges
-from menipy.detection.substrate import detect_substrate_line
-from menipy.analysis.commons import (
+from ..detection.needle import detect_vertical_edges
+from ..detection.substrate import detect_substrate_line
+from ..analysis.commons import (
     extract_external_contour,
     compute_drop_metrics,
 )


### PR DESCRIPTION
## Summary
- fix relative imports in alt GUI main window so it loads when invoking via `python -m src_alt.menipy.gui`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6c5d242c832e8b9c3e408956e150