### PR TITLE
Fix python -m src import issue

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -576,3 +576,9 @@ verified that existing tests still pass.
 **Task:** Clean up remaining unused modules.
 
 **Summary:** Deleted obsolete `io` and `preprocessing` packages, the unused `properties2.py` module, and placeholder UI subpackages. Tests continue to pass, confirming these modules were not required.
+
+## Entry 97 - Relative import for src
+
+**Task:** Fix ModuleNotFoundError when executing `python -m src`.
+
+**Summary:** Modified `src/__main__.py` to use a relative import of `menipy.gui` so running the package with `python -m src` resolves the internal package correctly. Tests still pass.

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,6 +1,9 @@
 """Entry point for running the Menipy GUI."""
 
-from menipy.gui import main
+# When executed as ``python -m src`` the package root is ``src``. Use a
+# relative import so the contained ``menipy`` package is discoverable
+# without installing the project.
+from .menipy.gui import main
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use a relative import in `src/__main__.py` so `python -m src` works
- log the change in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a92cb7ba8832e9f8099e34dbee8a5