### PR TITLE
Fix calibration imports in GUI modules

### DIFF
--- a/src/menipy/gui/calibration_dialog.py
+++ b/src/menipy/gui/calibration_dialog.py
@@ -17,7 +17,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from ..utils import calibrate_from_points
+# Calibration helpers were moved to the dedicated package
+from ..calibration import calibrate_from_points
 
 
 @dataclass

--- a/src/menipy/gui/main_window.py
+++ b/src/menipy/gui/main_window.py
@@ -48,7 +48,8 @@ from ..processing import (
     detect_substrate_line,
 )
 from ..processing.segmentation import find_contours
-from ..utils import (
+# Import calibration utilities from the dedicated package
+from ..calibration import (
     get_calibration,
     pixels_to_mm,
     auto_calibrate,


### PR DESCRIPTION
## Summary
- update MainWindow and CalibrationDialog to import helpers from `menipy.calibration`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a958b266c832ebbf941a1c7d21ee5