### PR TITLE
Switch GUI to modular main window

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -588,3 +588,17 @@ verified that existing tests still pass.
 **Task:** Check for remaining import errors after exposing `main()` entry point.
 
 **Summary:** Ran the test suite (53 passed) and executed `python -m src`. The command failed due to missing system library `libEGL.so.1`, indicating a runtime environment issue rather than a Python import error. No additional import errors were found.
+
+## Entry 99 - Refactored UI default
+
+**Task:** Replace legacy GUI exports with the refactored version.
+
+**Summary:** Renamed `gui/main_window.py` to `_legacy_main_window.py` and updated `ui.main_window` to import from the new private module. `menipy.gui.__init__` now exposes `ui.MainWindow`, ensuring the plugin menu is always available. All tests pass.
+
+## Entry 100 - Modularize main window
+
+**Task:** Remove legacy implementation and import the refactored window.
+
+**Summary:** Replaced `_legacy_main_window.py` with `base_window.py` containing a
+`BaseMainWindow` class. The refactored UI now subclasses this base class and all
+imports use the new module. The old file was deleted.

--- a/src/menipy/gui/__init__.py
+++ b/src/menipy/gui/__init__.py
@@ -1,6 +1,7 @@
 """GUI package initialization."""
 
-from .main_window import MainWindow
+# Export the refactored UI as the default MainWindow
+from ..ui import MainWindow
 from .image_view import ImageView
 from .calibration_dialog import CalibrationDialog
 from .controls import (

--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -74,7 +74,7 @@ from ..detectors.geometry_alt import side_of_polyline
 
 
 
-class MainWindow(QMainWindow):
+class BaseMainWindow(QMainWindow):
     """Main application window with image view and control panel."""
 
     def __init__(self, parent=None):
@@ -1084,7 +1084,7 @@ class MainWindow(QMainWindow):
 def main():
     """Launch the Menipy GUI application."""
     app = QApplication([])
-    window = MainWindow()
+    window = BaseMainWindow()
     window.show()
     app.exec()
 

--- a/src/menipy/ui/main_window.py
+++ b/src/menipy/ui/main_window.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
 from pathlib import Path
 
 from .. import plugins
-from menipy.gui.main_window import MainWindow as LegacyMainWindow
+from menipy.gui.base_window import BaseMainWindow
 from menipy.gui.items import SubstrateLineItem
 from menipy.gui.overlay import draw_drop_overlay
 from ..detection.needle import detect_vertical_edges
@@ -44,7 +44,7 @@ class PluginDialog(QDialog):
         layout.addWidget(close_btn)
 
 
-class MainWindow(LegacyMainWindow):
+class MainWindow(BaseMainWindow):
     """Main window using refactored detection and analysis modules."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- rename legacy main window file to `base_window.py` and provide `BaseMainWindow`
- update the refactored UI to subclass `BaseMainWindow`
- drop `_legacy_main_window.py` and document the change in `CODEXLOG.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a9ecffdcc832eae85bb02c2bc0a77