### PR TITLE
Add Clear Analysis button

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -613,3 +613,10 @@ relative imports so the module works when the project is executed as a
 module without installation. Tests pass and running `python -m src`
 fails only due to missing GUI libraries, confirming the import issue is
 fixed.
+
+
+## Entry 102 - Add analysis reset button
+
+**Task:** Provide a clear way to return the viewer to the unmodified image.
+
+**Summary:** Added a `Clear Analysis` button below the image view that calls a new `clear_analysis` method. This routine restores the original image, removes detection and analysis overlays, and resets related state. Tests were updated with a new case ensuring the button works. All tests pass.

--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -100,6 +100,9 @@ class BaseMainWindow(QMainWindow):
         self._default_move = self.graphics_view.mouseMoveEvent
         self._default_release = self.graphics_view.mouseReleaseEvent
         image_layout.addWidget(self.graphics_view)
+        self.clear_analysis_button = QPushButton("Clear Analysis")
+        self.clear_analysis_button.clicked.connect(self.clear_analysis)
+        image_layout.addWidget(self.clear_analysis_button)
         splitter.addWidget(image_container)
 
         # Control panel wrapped in tabs
@@ -361,6 +364,42 @@ class BaseMainWindow(QMainWindow):
             self.contact_line_item = None
         self.last_mask = None
         self.set_zoom(self.zoom_control.slider.value() / 100.0)
+
+    def clear_analysis(self) -> None:
+        """Restore the image and remove all overlays."""
+        self.clean_filter()
+        self.clean_detection()
+        for item in (
+            self.needle_axis_item,
+            self.drop_contour_item,
+            self.drop_axis_item,
+            self.diameter_item,
+            self.apex_dot_item,
+            self.substrate_line_item,
+            self.model_item,
+            self.roi_rect_item,
+            self.needle_rect_item,
+            self.drop_rect_item,
+        ):
+            if item is not None:
+                self.graphics_scene.removeItem(item)
+        for item in self.needle_edge_items:
+            self.graphics_scene.removeItem(item)
+        self.needle_edge_items.clear()
+        self.needle_axis_item = None
+        self.drop_contour_item = None
+        self.drop_axis_item = None
+        self.diameter_item = None
+        self.apex_dot_item = None
+        self.substrate_line_item = None
+        self.model_item = None
+        self.roi_rect_item = None
+        self.roi_rect = None
+        self.needle_rect_item = None
+        self.needle_rect = None
+        self.drop_rect_item = None
+        self.drop_rect = None
+        self.px_per_mm_drop = 0.0
 
     def _display_image(self, img: np.ndarray) -> None:
         """Display ``img`` in the graphics view and clear overlays."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -662,3 +662,27 @@ def test_contact_tab_side_button(tmp_path):
     app.quit()
 
 
+def test_clear_analysis_button(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+    import numpy as np
+    import cv2
+
+    img = np.zeros((20, 20, 3), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+    window.filter_slider.setValue(2)
+    window.apply_filter()
+    window.process_image()
+    assert window.mask_item is not None
+    window.clear_analysis_button.click()
+    assert window.mask_item is None
+    assert np.array_equal(window.image, window.original_image)
+    window.close()
+    app.quit()
+
+


### PR DESCRIPTION
## Summary
- add Clear Analysis button below the image view
- implement `clear_analysis` to restore the original image and remove overlays
- test button behaviour
- log the change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad232eb80832ea597adf42cd1e2f5