### PR TITLE
Fix ROI crash after clearing analysis

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -620,3 +620,9 @@ fixed.
 **Task:** Provide a clear way to return the viewer to the unmodified image.
 
 **Summary:** Added a `Clear Analysis` button below the image view that calls a new `clear_analysis` method. This routine restores the original image, removes detection and analysis overlays, and resets related state. Tests were updated with a new case ensuring the button works. All tests pass.
+
+## Entry 103 - Fix drawing after clear
+
+**Task:** Resolve crash when drawing needle ROI after using Clear Analysis.
+
+**Summary:** Updated `_display_image` to reset ROI and overlay references so cleared items do not leave dangling Qt objects. Tests pass.

--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -421,6 +421,13 @@ class BaseMainWindow(QMainWindow):
             )
         pixmap = QPixmap.fromImage(rgb)
         self.graphics_scene.clear()
+        self.needle_rect_item = None
+        self.drop_rect_item = None
+        self.needle_rect = None
+        self.drop_rect = None
+        self.needle_axis_item = None
+        self.needle_edge_items = []
+        self.calibration_tab.set_regions(needle=None, drop=None)
         self.graphics_view.set_pixmap(pixmap)
         self.pixmap_item = self.graphics_view.pixmap_item
 


### PR DESCRIPTION
## Summary
- avoid dangling ROI items when redisplaying the image
- log the fix in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad69b28dc832e87f82d9d2b07a572