### PR TITLE
Add pendant overlay metrics and visuals

### DIFF
--- a/src/menipy/analysis/commons.py
+++ b/src/menipy/analysis/commons.py
@@ -155,6 +155,7 @@ def compute_drop_metrics(
     asurf = surface_area_mm2(contour_local, px_per_mm)
     wapp = apparent_weight_mN(volume_uL, delta_rho) if volume_uL is not None else None
 
+    diameter_center = (int(round((x_left + x_right) / 2)), int(round(y_diam)))
     contact_line: tuple[tuple[int, int], tuple[int, int]] | None = None
     if substrate_line is not None:
         from ..physics.contact_geom import line_params, contour_line_intersections
@@ -177,6 +178,14 @@ def compute_drop_metrics(
             x_c_right = int(round(xs_contact.max()))
             contact_line = ((x_c_left, int(round(y_min))), (x_c_right, int(round(y_min))))
 
+    apex_to_diam_mm = abs(apex[1] - y_diam) / px_per_mm
+    contact_to_diam_mm = None
+    apex_to_contact_mm = None
+    if contact_line is not None:
+        y_contact = (contact_line[0][1] + contact_line[1][1]) / 2
+        contact_to_diam_mm = abs(y_contact - y_diam) / px_per_mm
+        apex_to_contact_mm = abs(apex[1] - y_contact) / px_per_mm
+
     return {
         "height_mm": float(height_mm),
         "diameter_mm": float(diameter_mm),
@@ -196,7 +205,11 @@ def compute_drop_metrics(
         "W_app_mN": float(wapp) if wapp is not None else None,
         "diameter_px": float(diam_px),
         "diameter_line": ((x_left, y_diam), (x_right, y_diam)),
+        "diameter_center": diameter_center,
         "radius_apex_mm": float(radius_apex_mm),
+        "apex_to_diam_mm": float(apex_to_diam_mm),
+        "contact_to_diam_mm": float(contact_to_diam_mm) if contact_to_diam_mm is not None else None,
+        "apex_to_contact_mm": float(apex_to_contact_mm) if apex_to_contact_mm is not None else None,
         "contact_line": contact_line,
     }
 

--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -721,6 +721,8 @@ class BaseMainWindow(QMainWindow):
             width=metrics.get("w_mm"),
             rbase=metrics.get("rb_mm"),
             height_line=metrics.get("h_mm"),
+            apex_to_diam=metrics.get("apex_to_diam_mm") if mode == "pendant" else None,
+            contact_to_diam=metrics.get("contact_to_diam_mm") if mode == "pendant" else None,
         )
         y_min = int(contour[:, 1].min())
         y_max = int(contour[:, 1].max())
@@ -756,14 +758,30 @@ class BaseMainWindow(QMainWindow):
         if self.apex_dot_item is not None:
             self.graphics_scene.removeItem(self.apex_dot_item)
 
+        center_pt = metrics.get("diameter_center") if mode == "pendant" else None
+        contact_line = metrics.get("contact_line") if mode == "pendant" else None
+        center_apex_line = None
+        center_contact_line = None
+        if mode == "pendant" and center_pt is not None:
+            center_apex_line = (center_pt, metrics["apex"])
+            if contact_line is not None:
+                cl_center = (
+                    (contact_line[0][0] + contact_line[1][0]) // 2,
+                    (contact_line[0][1] + contact_line[1][1]) // 2,
+                )
+                center_contact_line = (center_pt, cl_center)
+
         overlay = draw_drop_overlay(
             self.image,
             contour,
             diameter_line=diameter_line,
             axis_line=axis_line,
-            contact_line=None,
+            contact_line=contact_line,
             apex=metrics["apex"],
-            contact_pts=metrics.get("contact_line"),
+            contact_pts=contact_line,
+            center_pt=center_pt,
+            center_apex_line=center_apex_line,
+            center_contact_line=center_contact_line,
         )
         self.drop_contour_item = self.graphics_scene.addPixmap(overlay)
 

--- a/src/menipy/gui/controls.py
+++ b/src/menipy/gui/controls.py
@@ -467,6 +467,14 @@ class AnalysisTab(QWidget):
         layout.addRow("Apex (x,y)", self.apex_label)
         self.radius_apex_label = QLabel("0.0")
         layout.addRow("Apex radius (mm)", self.radius_apex_label)
+        if not show_contact_angle:
+            self.apex_diam_label = QLabel("0.0")
+            layout.addRow("Apex→diam (mm)", self.apex_diam_label)
+            self.contact_diam_label = QLabel("0.0")
+            layout.addRow("Needle→diam (mm)", self.contact_diam_label)
+        else:
+            self.apex_diam_label = None
+            self.contact_diam_label = None
 
         sep2 = QFrame()
         sep2.setFrameShape(QFrame.HLine)
@@ -529,6 +537,8 @@ class AnalysisTab(QWidget):
         width: float | None = None,
         rbase: float | None = None,
         height_line: float | None = None,
+        apex_to_diam: float | None = None,
+        contact_to_diam: float | None = None,
     ) -> None:
         if height is not None:
             self.height_label.setText(f"{height:.2f}")
@@ -566,6 +576,10 @@ class AnalysisTab(QWidget):
             self.rb_label.setText(f"{rbase:.2f}")
         if height_line is not None and self.h_label is not None:
             self.h_label.setText(f"{height_line:.2f}")
+        if apex_to_diam is not None and self.apex_diam_label is not None:
+            self.apex_diam_label.setText(f"{apex_to_diam:.2f}")
+        if contact_to_diam is not None and self.contact_diam_label is not None:
+            self.contact_diam_label.setText(f"{contact_to_diam:.2f}")
 
     def metrics(self) -> dict[str, str]:
         data = {
@@ -589,6 +603,10 @@ class AnalysisTab(QWidget):
             data["width"] = self.width_label.text()
             data["rbase"] = self.rb_label.text()
             data["height_line"] = self.h_label.text()
+        if self.apex_diam_label is not None:
+            data["apex_to_diam"] = self.apex_diam_label.text()
+        if self.contact_diam_label is not None:
+            data["contact_to_diam"] = self.contact_diam_label.text()
         return data
 
     def clear_metrics(self) -> None:
@@ -612,6 +630,8 @@ class AnalysisTab(QWidget):
             width=0.0,
             rbase=0.0,
             height_line=0.0,
+            apex_to_diam=0.0,
+            contact_to_diam=0.0,
         )
 
 

--- a/src/menipy/gui/overlay.py
+++ b/src/menipy/gui/overlay.py
@@ -12,6 +12,36 @@ def _to_qimage(arr: np.ndarray) -> QImage:
     return QImage(arr.data, arr.shape[1], arr.shape[0], arr.strides[0], fmt).copy()
 
 
+def _draw_dashed_line(
+    img: np.ndarray,
+    p1: tuple[int, int],
+    p2: tuple[int, int],
+    color: tuple[int, int, int],
+    *,
+    dash: int = 5,
+    thickness: int = 1,
+) -> None:
+    """Draw a dashed line on ``img``."""
+    p1 = np.array(p1, float)
+    p2 = np.array(p2, float)
+    length = np.linalg.norm(p2 - p1)
+    if length == 0:
+        return
+    direction = (p2 - p1) / length
+    n = int(length // dash)
+    for i in range(0, n, 2):
+        start = p1 + direction * (i * dash)
+        end = p1 + direction * (min((i + 1) * dash, length))
+        cv2.line(
+            img,
+            tuple(np.round(start).astype(int)),
+            tuple(np.round(end).astype(int)),
+            color,
+            thickness,
+            lineType=cv2.LINE_8,
+        )
+
+
 def draw_drop_overlay(
     image: np.ndarray,
     contour: np.ndarray | None = None,
@@ -21,6 +51,9 @@ def draw_drop_overlay(
     contact_line: tuple[tuple[int, int], tuple[int, int]] | np.ndarray | None = None,
     apex: tuple[int, int] | None = None,
     contact_pts: tuple[tuple[int, int], tuple[int, int]] | None = None,
+    center_pt: tuple[int, int] | None = None,
+    center_apex_line: tuple[tuple[int, int], tuple[int, int]] | None = None,
+    center_contact_line: tuple[tuple[int, int], tuple[int, int]] | None = None,
 ) -> QPixmap:
     """Return a ``QPixmap`` of ``image`` with droplet overlays drawn.
 
@@ -38,6 +71,12 @@ def draw_drop_overlay(
         Optional apex point ``(x, y)``.
     contact_pts:
         Optional pair of contact points ``(P1, P2)``.
+    center_pt:
+        Center of the maximum radius line.
+    center_apex_line:
+        Optional dashed line from ``center_pt`` to the apex.
+    center_contact_line:
+        Optional dashed line from ``center_pt`` to the contact line center.
     """
     canvas = image.copy()
     if contour is not None:
@@ -57,5 +96,11 @@ def draw_drop_overlay(
     if contact_pts is not None:
         for pt in contact_pts:
             cv2.circle(canvas, tuple(pt), 3, (255, 255, 0), -1)
+    if center_pt is not None:
+        cv2.circle(canvas, center_pt, 3, (255, 255, 255), -1)
+    if center_apex_line is not None:
+        _draw_dashed_line(canvas, center_apex_line[0], center_apex_line[1], (255, 255, 0))
+    if center_contact_line is not None:
+        _draw_dashed_line(canvas, center_contact_line[0], center_contact_line[1], (255, 255, 0))
     return QPixmap.fromImage(_to_qimage(canvas))
 

--- a/src/menipy/ui/main_window.py
+++ b/src/menipy/ui/main_window.py
@@ -247,6 +247,16 @@ class MainWindow(BaseMainWindow):
             self.graphics_scene.removeItem(self.apex_dot_item)
 
         contact_line = metrics.get("contact_line")
+        center_pt = metrics.get("diameter_center")
+        center_apex_line = (center_pt, metrics["apex"]) if center_pt is not None else None
+        center_contact_line = None
+        if center_pt is not None and contact_line is not None:
+            cl_center = (
+                (contact_line[0][0] + contact_line[1][0]) // 2,
+                (contact_line[0][1] + contact_line[1][1]) // 2,
+            )
+            center_contact_line = (center_pt, cl_center)
+
         overlay = draw_drop_overlay(
             self.image,
             contour,
@@ -255,6 +265,9 @@ class MainWindow(BaseMainWindow):
             contact_line=contact_line,
             apex=metrics["apex"],
             contact_pts=contact_line,
+            center_pt=center_pt,
+            center_apex_line=center_apex_line,
+            center_contact_line=center_contact_line,
         )
         self.drop_contour_item = self.graphics_scene.addPixmap(overlay)
 

--- a/tests/test_drop_metrics.py
+++ b/tests/test_drop_metrics.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from menipy.analysis.drop import compute_drop_metrics, find_apex_index
+from menipy.analysis import compute_drop_metrics, find_apex_index
 
 
 def test_max_diameter_and_radius_apex():
@@ -18,6 +18,10 @@ def test_max_diameter_and_radius_apex():
     assert metrics["contact_line"] is not None
     assert metrics["radius_apex_mm"] > 0
     assert metrics["s1"] > 0
+    assert metrics["diameter_center"] == (25, 30)
+    assert pytest.approx(metrics["apex_to_diam_mm"], abs=0.1) == 2.0
+    assert pytest.approx(metrics["contact_to_diam_mm"], abs=0.1) == 2.0
+    assert pytest.approx(metrics["apex_to_contact_mm"], abs=0.1) == 4.0
 
 
 def test_find_apex_index_median():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -476,6 +476,9 @@ def test_draw_drop_overlay_pixmap():
         contact_line=((5, 5), (15, 5)),
         apex=(10, 10),
         contact_pts=((5, 5), (15, 5)),
+        center_pt=(10, 10),
+        center_apex_line=((10, 10), (10, 10)),
+        center_contact_line=((10, 10), (10, 5)),
     )
     assert pix.width() == 20 and pix.height() == 20
 


### PR DESCRIPTION
## Summary
- compute center and distance metrics in `compute_drop_metrics`
- update GUI overlay drawing to show center point with dashed lines
- display new pendant metrics in `AnalysisTab`
- extend overlay utilities for dashed lines
- adjust tests for new overlay and metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae86915f0832e954d4c75c3e576ac