### PR TITLE
Fix pendant overlay visuals

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -638,3 +638,8 @@ fixed.
 **Task:** Ensure analysis metrics and result overlays fully reset when clearing.
 
 **Summary:** Added `clear_metrics` helpers to GUI panels and updated `clear_analysis` to reset scale and metrics displays. New tests verify metric labels return to defaults after clearing. All tests pass.
+## Entry 106 - Separate pendant overlays and remove stray axis line
+
+**Task:** Adjust overlay drawing so pendant and sessile analyses have distinct visuals and remove unintended red axis line on pendant drops.**
+
+**Summary:** Updated `BaseMainWindow` and `ui.main_window` to only compute and draw the axis line for contact-angle analyses. Pendant overlays now receive center and contact lines only in pendant mode. This eliminates the diagonal red line and keeps sessile visuals unchanged. All tests pass (53 passed).

--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -724,31 +724,29 @@ class BaseMainWindow(QMainWindow):
             apex_to_diam=metrics.get("apex_to_diam_mm") if mode == "pendant" else None,
             contact_to_diam=metrics.get("contact_to_diam_mm") if mode == "pendant" else None,
         )
-        y_min = int(contour[:, 1].min())
-        y_max = int(contour[:, 1].max())
         diameter_line = (
             metrics["diameter_line"][0],
             metrics["diameter_line"][1],
         )
-        if self.substrate_line_item is not None:
-            line_dir = np.array(
-                self.substrate_line_item.line().p2().toTuple(), float
-            ) - np.array(self.substrate_line_item.line().p1().toTuple(), float)
-            p1 = np.array(diameter_line[0], float)
-            p2 = np.array(diameter_line[1], float)
-        else:
-            line_dir = np.array([1.0, 0.0])
+        axis_line = None
+        if mode == "contact-angle":
+            if self.substrate_line_item is not None:
+                line_dir = np.array(
+                    self.substrate_line_item.line().p2().toTuple(), float
+                ) - np.array(self.substrate_line_item.line().p1().toTuple(), float)
+            else:
+                line_dir = np.array([1.0, 0.0])
             p1 = np.array(diameter_line[0], float)
             p2 = np.array(diameter_line[1], float)
 
-        apex_pt = np.array(metrics["apex"], dtype=float)
-        t = np.dot(apex_pt - p1, line_dir) / np.dot(line_dir, line_dir)
-        t = np.clip(t, 0.0, 1.0)
-        foot_pt = p1 + t * line_dir
-        axis_line = (
-            tuple(np.round(foot_pt).astype(int)),
-            tuple(np.round(apex_pt).astype(int)),
-        )
+            apex_pt = np.array(metrics["apex"], dtype=float)
+            t = np.dot(apex_pt - p1, line_dir) / np.dot(line_dir, line_dir)
+            t = np.clip(t, 0.0, 1.0)
+            foot_pt = p1 + t * line_dir
+            axis_line = (
+                tuple(np.round(foot_pt).astype(int)),
+                tuple(np.round(apex_pt).astype(int)),
+            )
         if self.drop_contour_item is not None:
             self.graphics_scene.removeItem(self.drop_contour_item)
         if self.diameter_item is not None:

--- a/src/menipy/ui/main_window.py
+++ b/src/menipy/ui/main_window.py
@@ -218,25 +218,25 @@ class MainWindow(BaseMainWindow):
             metrics["diameter_line"][0],
             metrics["diameter_line"][1],
         )
-        if self.substrate_line_item is not None:
-            line_dir = np.array(
-                self.substrate_line_item.line().p2().toTuple(), float
-            ) - np.array(self.substrate_line_item.line().p1().toTuple(), float)
-            p1 = np.array(diameter_line[0], float)
-            p2 = np.array(diameter_line[1], float)
-        else:
-            line_dir = np.array([1.0, 0.0])
+        axis_line = None
+        if mode == "contact-angle":
+            if self.substrate_line_item is not None:
+                line_dir = np.array(
+                    self.substrate_line_item.line().p2().toTuple(), float
+                ) - np.array(self.substrate_line_item.line().p1().toTuple(), float)
+            else:
+                line_dir = np.array([1.0, 0.0])
             p1 = np.array(diameter_line[0], float)
             p2 = np.array(diameter_line[1], float)
 
-        apex_pt = np.array(metrics["apex"], dtype=float)
-        t = np.dot(apex_pt - p1, line_dir) / np.dot(line_dir, line_dir)
-        t = np.clip(t, 0.0, 1.0)
-        foot_pt = p1 + t * line_dir
-        axis_line = (
-            tuple(np.round(foot_pt).astype(int)),
-            tuple(np.round(apex_pt).astype(int)),
-        )
+            apex_pt = np.array(metrics["apex"], dtype=float)
+            t = np.dot(apex_pt - p1, line_dir) / np.dot(line_dir, line_dir)
+            t = np.clip(t, 0.0, 1.0)
+            foot_pt = p1 + t * line_dir
+            axis_line = (
+                tuple(np.round(foot_pt).astype(int)),
+                tuple(np.round(apex_pt).astype(int)),
+            )
         if self.drop_contour_item is not None:
             self.graphics_scene.removeItem(self.drop_contour_item)
         if self.diameter_item is not None:
@@ -246,16 +246,18 @@ class MainWindow(BaseMainWindow):
         if self.apex_dot_item is not None:
             self.graphics_scene.removeItem(self.apex_dot_item)
 
-        contact_line = metrics.get("contact_line")
-        center_pt = metrics.get("diameter_center")
-        center_apex_line = (center_pt, metrics["apex"]) if center_pt is not None else None
+        contact_line = metrics.get("contact_line") if mode == "pendant" else None
+        center_pt = metrics.get("diameter_center") if mode == "pendant" else None
+        center_apex_line = None
         center_contact_line = None
-        if center_pt is not None and contact_line is not None:
-            cl_center = (
-                (contact_line[0][0] + contact_line[1][0]) // 2,
-                (contact_line[0][1] + contact_line[1][1]) // 2,
-            )
-            center_contact_line = (center_pt, cl_center)
+        if mode == "pendant" and center_pt is not None:
+            center_apex_line = (center_pt, metrics["apex"])
+            if contact_line is not None:
+                cl_center = (
+                    (contact_line[0][0] + contact_line[1][0]) // 2,
+                    (contact_line[0][1] + contact_line[1][1]) // 2,
+                )
+                center_contact_line = (center_pt, cl_center)
 
         overlay = draw_drop_overlay(
             self.image,


### PR DESCRIPTION
## Summary
- conditionally compute axis line only for contact-angle analysis
- limit center lines to pendant overlays
- log update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aeef60184832ea47af00707b581cd