### PR TITLE
Fix overlay import path

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -654,3 +654,8 @@ fixed.
 **Task:** Resolve IndentationError when executing `python -m src`.
 
 **Summary:** Added missing `if mode == "pendant":` line in `ui/main_window.py` to correctly open the analysis branch. Tests run successfully (53 passed).
+## Entry 109 - Fix overlay import path
+
+**Task:** Resolve `ModuleNotFoundError` for `src.menipy.pipelines.overlay` when executing `python -m src`.
+
+**Summary:** Updated pendant and sessile drawing pipelines to import `draw_drop_overlay` from `menipy.gui` rather than a non-existent local module. All tests pass (53 passed).

--- a/src/menipy/pipelines/pendant/drawing.py
+++ b/src/menipy/pipelines/pendant/drawing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 from PySide6.QtGui import QPixmap
 
-from ..overlay import draw_drop_overlay
+from ..gui import draw_drop_overlay
 from .geometry import PendantMetrics
 
 

--- a/src/menipy/pipelines/sessile/drawing.py
+++ b/src/menipy/pipelines/sessile/drawing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 from PySide6.QtGui import QPixmap
 
-from ..overlay import draw_drop_overlay
+from ..gui import draw_drop_overlay
 from .geometry import SessileMetrics
 
 


### PR DESCRIPTION
## Summary
- import overlay drawing from `menipy.gui` in drawing pipelines
- log the fix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0bd593e4832e9957aea912ec50b1