### PR TITLE
Fix overlay import path again

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -659,3 +659,8 @@ fixed.
 **Task:** Resolve `ModuleNotFoundError` for `src.menipy.pipelines.overlay` when executing `python -m src`.
 
 **Summary:** Updated pendant and sessile drawing pipelines to import `draw_drop_overlay` from `menipy.gui` rather than a non-existent local module. All tests pass (53 passed).
+## Entry 110 - Correct relative import depth
+
+**Task:** Address `ModuleNotFoundError` when running the GUI due to incorrect relative imports in drawing pipelines.
+
+**Summary:** Updated `pendant/drawing.py` and `sessile/drawing.py` to import `draw_drop_overlay` from `menipy.gui` using `...gui` so the package resolves correctly. All tests pass (53 passed).

--- a/src/menipy/pipelines/pendant/drawing.py
+++ b/src/menipy/pipelines/pendant/drawing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 from PySide6.QtGui import QPixmap
 
-from ..gui import draw_drop_overlay
+from ...gui import draw_drop_overlay
 from .geometry import PendantMetrics
 
 

--- a/src/menipy/pipelines/sessile/drawing.py
+++ b/src/menipy/pipelines/sessile/drawing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 from PySide6.QtGui import QPixmap
 
-from ..gui import draw_drop_overlay
+from ...gui import draw_drop_overlay
 from .geometry import SessileMetrics
 
 


### PR DESCRIPTION
## Summary
- correct relative import depth for GUI overlay helper
- log the fix in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b130756b0832e9f4f41e38e1cae4d