### PR TITLE
Fix circular import in drawing pipelines

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -664,3 +664,12 @@ fixed.
 **Task:** Address `ModuleNotFoundError` when running the GUI due to incorrect relative imports in drawing pipelines.
 
 **Summary:** Updated `pendant/drawing.py` and `sessile/drawing.py` to import `draw_drop_overlay` from `menipy.gui` using `...gui` so the package resolves correctly. All tests pass (53 passed).
+
+## Entry 111 - Break GUI import cycle
+
+**Task:** Resolve circular import error when running `python -m src`.
+
+**Summary:** Updated pendant and sessile drawing pipelines to import
+`draw_drop_overlay` from `menipy.gui.overlay` rather than the package root.
+This prevents `gui/__init__` from re-importing the pipelines during
+initialization. All tests still pass (53 passed).

--- a/src/menipy/pipelines/pendant/drawing.py
+++ b/src/menipy/pipelines/pendant/drawing.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import numpy as np
 from PySide6.QtGui import QPixmap
 
-from ...gui import draw_drop_overlay
+# Import the overlay helper directly to avoid triggering the ``gui`` package
+# initialization while this module is imported. Importing from ``...gui`` would
+# execute ``gui/__init__.py`` which pulls in the pipelines package again and
+# leads to a circular import when running ``python -m src``.
+from ...gui.overlay import draw_drop_overlay
 from .geometry import PendantMetrics
 
 

--- a/src/menipy/pipelines/sessile/drawing.py
+++ b/src/menipy/pipelines/sessile/drawing.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import numpy as np
 from PySide6.QtGui import QPixmap
 
-from ...gui import draw_drop_overlay
+# Import the overlay helper directly to avoid a circular import with the
+# ``gui`` package's ``__init__`` when this module is imported from within that
+# package.
+from ...gui.overlay import draw_drop_overlay
 from .geometry import SessileMetrics
 
 


### PR DESCRIPTION
## Summary
- adjust pendant and sessile drawing pipelines to import overlay helper from `gui.overlay`
- document fix in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1728b23c832ea81461488ae12ca8