### PR TITLE
Fix substrate line offset in sessile analysis

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -673,3 +673,9 @@ fixed.
 `draw_drop_overlay` from `menipy.gui.overlay` rather than the package root.
 This prevents `gui/__init__` from re-importing the pipelines during
 initialization. All tests still pass (53 passed).
+## Entry 112 - Fix substrate line offset
+
+**Task:** Resolve ValueError when analyzing sessile drops due to mismatched substrate line coordinates.
+
+**Summary:** Adjusted `analyze_drop_image` in `ui/main_window.py` and `gui/base_window.py` to subtract the ROI origin from the substrate line before calling `analyze_sessile`. This ensures the line intersects the local contour. All tests pass (53 passed).
+

--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -689,10 +689,14 @@ class BaseMainWindow(QMainWindow):
             overlay = draw_pendant_overlays(self.image, pm)
         else:
             helpers = SessileHelpers(px_per_mm=self.px_per_mm_drop)
-            substrate = (
-                self.substrate_line_item.line().p1().toTuple(),
-                self.substrate_line_item.line().p2().toTuple(),
-            ) if self.substrate_line_item is not None else ((0, 0), (1, 0))
+            if self.substrate_line_item is not None:
+                line = self.substrate_line_item.line()
+                substrate = (
+                    (line.x1() - x1, line.y1() - y1),
+                    (line.x2() - x1, line.y2() - y1),
+                )
+            else:
+                substrate = ((0, 0), (1, 0))
             sm = analyze_sessile(roi, helpers, substrate)
             sm.contour += np.array([x1, y1])
             sm.apex = (sm.apex[0] + x1, sm.apex[1] + y1)

--- a/src/menipy/ui/main_window.py
+++ b/src/menipy/ui/main_window.py
@@ -188,10 +188,14 @@ class MainWindow(BaseMainWindow):
             overlay = draw_pendant_overlays(self.image, pm)
         else:
             helpers = SessileHelpers(px_per_mm=self.px_per_mm_drop)
-            substrate = (
-                self.substrate_line_item.line().p1().toTuple(),
-                self.substrate_line_item.line().p2().toTuple(),
-            ) if self.substrate_line_item is not None else ((0, 0), (1, 0))
+            if self.substrate_line_item is not None:
+                line = self.substrate_line_item.line()
+                substrate = (
+                    (line.x1() - x1, line.y1() - y1),
+                    (line.x2() - x1, line.y2() - y1),
+                )
+            else:
+                substrate = ((0, 0), (1, 0))
             sm = analyze_sessile(roi, helpers, substrate)
             sm.contour += np.array([x1, y1])
             sm.apex = (sm.apex[0] + x1, sm.apex[1] + y1)


### PR DESCRIPTION
## Summary
- correct substrate line coordinates relative to ROI
- log the fix in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1e4b62b4832e95aeff239fc067e3