### PR TITLE
Add debug prints for surface area metrics

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -690,3 +690,9 @@ initialization. All tests still pass (53 passed).
 **Task:** Report surface and projected areas for each side of the drop and expose missing distances in the GUI.
 
 **Summary:** `compute_drop_metrics` now splits the droplet mask about the apex to calculate left and right projected areas and surfaces of revolution. It returns these along with their mean. The `AnalysisTab` UI gained labels for the new metrics and now displays the apex-to-diameter and needle-to-diameter distances. `MainWindow` passes the additional values when updating the panel. Tests updated to verify the new keys. All tests pass (53 passed).
+
+## Entry 115 - Debug surface area steps
+
+**Task:** Add print statements to display intermediate values when computing left and right surface areas.
+
+**Summary:** Updated `compute_drop_metrics` in `analysis/commons.py` to print the profile points and resulting surface areas for each side. All tests pass (53 passed).

--- a/src/menipy/analysis/commons.py
+++ b/src/menipy/analysis/commons.py
@@ -162,8 +162,15 @@ def compute_drop_metrics(
     z = rows.astype(float)
     prof_left = np.column_stack([r_left, z])
     prof_right = np.column_stack([r_right, z])
+
+    print("Left profile points:", prof_left)
     asurf_left = surface_area_mm2(prof_left, px_per_mm)
+    print("Computed left surface area:", asurf_left)
+
+    print("Right profile points:", prof_right)
     asurf_right = surface_area_mm2(prof_right, px_per_mm)
+    print("Computed right surface area:", asurf_right)
+
     asurf_mean = 0.5 * (asurf_left + asurf_right)
     aproj_left = r_left.sum() * (px_to_mm ** 2)
     aproj_right = r_right.sum() * (px_to_mm ** 2)


### PR DESCRIPTION
## Summary
- print the profile arrays and resulting surface areas when computing left and right surfaces
- log the new debug capability in CODEXLOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3637a10c832ea61bd0987bb8f537