### PR TITLE
Add contour side plotting

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -696,3 +696,9 @@ initialization. All tests still pass (53 passed).
 **Task:** Add print statements to display intermediate values when computing left and right surface areas.
 
 **Summary:** Updated `compute_drop_metrics` in `analysis/commons.py` to print the profile points and resulting surface areas for each side. All tests pass (53 passed).
+## Entry 116 - Side contour plotting
+
+**Task:** Use matplotlib to generate an image of the droplet contour split by the apex.
+
+**Summary:** Added `save_contour_sides_image` in `analysis/plotting.py` to plot left and right contours using matplotlib. Introduced a test that saves a PNG when matplotlib is available. Matplotlib was re-added to `requirements.txt` and `setup.py`. All tests pass (53 passed, 29 skipped).
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ numpy
 scipy
 pandas
 
+# Plotting
+matplotlib
+
 # GUI framework
 PySide6
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "pandas>=1.5.3",
         "scikit-image>=0.19.3",
         "opencv-python>=4.7.0.72",
+        "matplotlib>=3.5.0",
         "PySide6>=6.5.1",
     ],
     entry_points={"console_scripts": ["menipy=menipy.gui:main"]},

--- a/src/menipy/analysis/__init__.py
+++ b/src/menipy/analysis/__init__.py
@@ -1,6 +1,7 @@
 """Drop analysis module."""
 
 from .commons import compute_drop_metrics, find_apex_index, extract_external_contour
+from .plotting import save_contour_sides_image
 from .pendant import compute_metrics as compute_pendant_metrics
 from .sessile import compute_metrics as compute_sessile_metrics
 from ..detection.needle import detect_vertical_edges
@@ -12,4 +13,5 @@ __all__ = [
     "find_apex_index",
     "extract_external_contour",
     "detect_vertical_edges",
+    "save_contour_sides_image",
 ]

--- a/src/menipy/analysis/plotting.py
+++ b/src/menipy/analysis/plotting.py
@@ -1,0 +1,82 @@
+"""Utility plotting functions for droplet contours."""
+
+from __future__ import annotations
+
+import numpy as np
+import cv2
+
+
+def _side_contours(contour: np.ndarray, apex_idx: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return left and right contour points split at the apex.
+
+    Parameters
+    ----------
+    contour:
+        External contour points ``(x, y)``.
+    apex_idx:
+        Index of the apex point within ``contour``.
+    """
+    if contour.ndim != 2 or contour.shape[1] != 2:
+        raise ValueError("contour must be of shape (N, 2)")
+    if not (0 <= apex_idx < len(contour)):
+        raise ValueError("apex_idx out of range")
+
+    x_min = int(np.floor(contour[:, 0].min()))
+    y_min = int(np.floor(contour[:, 1].min()))
+    x_max = int(np.ceil(contour[:, 0].max()))
+    y_max = int(np.ceil(contour[:, 1].max()))
+
+    mask = np.zeros((y_max - y_min + 1, x_max - x_min + 1), dtype=np.uint8)
+    shifted = np.round(contour - [x_min, y_min]).astype(np.int32)
+    cv2.drawContours(mask, [shifted], -1, 255, -1)
+
+    axis_x = int(round(contour[apex_idx, 0])) - x_min
+    left_edges = np.argmax(mask > 0, axis=1)
+    right_edges = mask.shape[1] - 1 - np.argmax(mask[:, ::-1] > 0, axis=1)
+    rows = np.where(mask.sum(axis=1) > 0)[0]
+
+    y_coords = rows + y_min
+    left = np.column_stack([left_edges[rows] + x_min, y_coords])
+    right = np.column_stack([right_edges[rows] + x_min, y_coords])
+    return left.astype(float), right.astype(float)
+
+
+def save_contour_sides_image(
+    contour: np.ndarray, apex_idx: int, out_path: str, format: str | None = None
+) -> None:
+    """Save a plot of contour sides split at the apex.
+
+    ``out_path`` determines the image format (png/jpg, etc.).
+    """
+    import importlib
+
+    if importlib.util.find_spec("matplotlib") is None:
+        raise RuntimeError("matplotlib is required for plotting")
+
+    import matplotlib
+
+    matplotlib.use("Agg")  # ensure headless backend
+    import matplotlib.pyplot as plt
+
+    left, right = _side_contours(contour, apex_idx)
+
+    fig, ax = plt.subplots()
+    ax.plot(contour[:, 0], contour[:, 1], "k-", linewidth=1, label="contour")
+    ax.plot(left[:, 0], left[:, 1], "r-", linewidth=2, label="left")
+    ax.plot(right[:, 0], right[:, 1], "b-", linewidth=2, label="right")
+    ax.plot(
+        contour[apex_idx, 0],
+        contour[apex_idx, 1],
+        "go",
+        markersize=4,
+        label="apex",
+    )
+    ax.set_aspect("equal")
+    ax.invert_yaxis()
+    ax.legend()
+
+    fig.savefig(out_path, format=format)
+    plt.close(fig)
+
+
+__all__ = ["save_contour_sides_image"]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,22 @@
+import importlib
+import numpy as np
+import cv2
+import pytest
+
+from menipy.analysis import find_apex_index, save_contour_sides_image
+
+
+def test_save_contour_sides_image(tmp_path):
+    if importlib.util.find_spec("matplotlib") is None:
+        pytest.skip("matplotlib not available")
+
+    img = np.zeros((40, 40), dtype=np.uint8)
+    cv2.circle(img, (20, 20), 10, 255, -1)
+    contour = cv2.findContours(img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[0][0].squeeze(1).astype(float)
+
+    apex_idx = find_apex_index(contour, "pendant")
+    out_path = tmp_path / "sides.png"
+    save_contour_sides_image(contour, apex_idx, str(out_path))
+
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `save_contour_sides_image` utility for plotting left and right contour lines
- reintroduce matplotlib to requirements and setup
- export new API from `analysis` and test saving a png when matplotlib is present
- log activity in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbc62a5ac832eaae027ab046c72d1