### PR TITLE
Update pendant tab surface area display

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -713,3 +713,8 @@ initialization. All tests still pass (53 passed).
 **Task:** Display left, right and mean surface areas with higher precision and fix GUI default values.
 
 **Summary:** Updated `AnalysisTab` labels to default to "0.0000" and changed `set_metrics` to format values with four decimal places. Tests adjusted for the new precision. All tests pass (55 passed, 29 skipped).
+## Entry 119 - Adjust pendant surface metrics
+
+**Task:** Reorder metrics on pendant drop tab and rename mean surface area.
+
+**Summary:** Updated `AnalysisTab` layout so pendant mode now shows "Mean Droplet Surface Area (mm²)" directly below the volume metric and hides the generic surface area row. Contact angle mode retains the original layout. All tests pass (56 passed, 29 skipped).

--- a/src/menipy/gui/controls.py
+++ b/src/menipy/gui/controls.py
@@ -523,8 +523,12 @@ class AnalysisTab(QWidget):
 
         self.volume_label = QLabel("0.0000")
         layout.addRow("Volume (uL)", self.volume_label)
+        self.asurf_mean_label = QLabel("0.0000")
+        if not show_contact_angle:
+            layout.addRow("Mean Droplet Surface Area (mm²)", self.asurf_mean_label)
         self.asurf_label = QLabel("0.0000")
-        layout.addRow("Surface Area (mm²)", self.asurf_label)
+        if show_contact_angle:
+            layout.addRow("Surface Area (mm²)", self.asurf_label)
         self.gamma_label = QLabel("0.0000")
         layout.addRow("Surface Tension (mN/m)", self.gamma_label)
         self.wo_label = QLabel("0.0000")
@@ -545,8 +549,8 @@ class AnalysisTab(QWidget):
         layout.addRow("W_app (mN)", self.wapp_label)
         self.kappa0_label = QLabel("0.0000")
         layout.addRow("ko (1/m)", self.kappa0_label)
-        self.asurf_mean_label = QLabel("0.0000")
-        layout.addRow("Surface A mean (mm²)", self.asurf_mean_label)
+        if show_contact_angle:
+            layout.addRow("Surface A mean (mm²)", self.asurf_mean_label)
         self.asurf_left_label = QLabel("0.0000")
         layout.addRow("Surface A L (mm²)", self.asurf_left_label)
         self.asurf_right_label = QLabel("0.0000")


### PR DESCRIPTION
## Summary
- show `Mean Droplet Surface Area` right below volume for pendant drops
- hide generic `Surface Area` row on the pendant tab
- document the change in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5d4d42fc832ea93036a0387e8641