### PR TITLE
Add spline-based sessile contact point detection

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -718,3 +718,9 @@ initialization. All tests still pass (53 passed).
 **Task:** Reorder metrics on pendant drop tab and rename mean surface area.
 
 **Summary:** Updated `AnalysisTab` layout so pendant mode now shows "Mean Droplet Surface Area (mm²)" directly below the volume metric and hides the generic surface area row. Contact angle mode retains the original layout. All tests pass (56 passed, 29 skipped).
+
+## Entry 120 - Spline contact points
+
+**Task:** Implement sessile drop contact-point computation using spline extrapolation.**
+
+**Summary:** Added `contact_points_from_spline` in `analysis/sessile.py` to filter contour points, fit smoothed cubic splines and compute intersections with a substrate line. Created `tests/test_spline_contact.py` covering basic and rotated cases. All tests pass (58 passed, 29 skipped).

--- a/src/menipy/analysis/sessile.py
+++ b/src/menipy/analysis/sessile.py
@@ -30,3 +30,53 @@ def compute_metrics(
     return metrics
 
 __all__ = ["compute_metrics"]
+
+
+def contact_points_from_spline(
+    contour: np.ndarray,
+    line: tuple[tuple[float, float], tuple[float, float]],
+    delta: float,
+    *,
+    smoothing: float = 1.0,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return sessile-drop contact points via spline extrapolation."""
+
+    from scipy.interpolate import UnivariateSpline
+
+    p1, p2 = np.asarray(line[0], float), np.asarray(line[1], float)
+    d = p2 - p1
+    angle = np.arctan2(d[1], d[0])
+
+    rot = np.array(
+        [
+            [np.cos(-angle), -np.sin(-angle)],
+            [np.sin(-angle), np.cos(-angle)],
+        ]
+    )
+    contour_t = (contour - p1) @ rot.T
+
+    mask = np.abs(contour_t[:, 1]) >= delta
+    filtered = contour_t[mask]
+    if len(filtered) < 4:
+        raise ValueError("Too few points after filtering")
+
+    apex_idx = int(np.argmax(filtered[:, 1]))
+    x_apex = filtered[apex_idx, 0]
+
+    left = filtered[filtered[:, 0] <= x_apex]
+    right = filtered[filtered[:, 0] >= x_apex]
+    left = left[np.argsort(left[:, 1])]
+    right = right[np.argsort(right[:, 1])]
+
+    spl_l = UnivariateSpline(left[:, 1], left[:, 0], s=smoothing)
+    spl_r = UnivariateSpline(right[:, 1], right[:, 0], s=smoothing)
+
+    x_l = float(spl_l(0.0))
+    x_r = float(spl_r(0.0))
+
+    contact_l = np.array([x_l, 0.0]) @ rot + p1
+    contact_r = np.array([x_r, 0.0]) @ rot + p1
+    return tuple(contact_l), tuple(contact_r)
+
+
+__all__.append("contact_points_from_spline")

--- a/tests/test_spline_contact.py
+++ b/tests/test_spline_contact.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+from menipy.analysis.sessile import contact_points_from_spline
+
+
+def _circle_contour(radius=20.0, center_y=10.0, n=200):
+    theta = np.linspace(0, 2 * np.pi, n)
+    return np.stack([radius * np.cos(theta), radius * np.sin(theta) + center_y], axis=1)
+
+
+def test_contact_points_basic():
+    contour = _circle_contour()
+    line = ((-40.0, 0.0), (40.0, 0.0))
+    p1, p2 = contact_points_from_spline(contour, line, delta=0.5)
+    assert np.allclose(p1[1], 0.0, atol=1e-2)
+    assert np.allclose(p2[1], 0.0, atol=1e-2)
+    assert p1[0] < 0 < p2[0]
+
+
+def test_contact_points_rotated():
+    contour = _circle_contour()
+    angle = np.deg2rad(15.0)
+    rot = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
+    contour_r = contour @ rot.T
+    line = ((-40.0, 0.0), (40.0, 0.0))
+    line_r = (tuple(rot @ np.array(line[0])), tuple(rot @ np.array(line[1])))
+    p1, p2 = contact_points_from_spline(contour_r, line_r, delta=0.5)
+    from menipy.physics.contact_geom import line_params
+    a, b, c = line_params(line_r[0], line_r[1])
+    assert abs(a * p1[0] + b * p1[1] + c) < 1e-2
+    assert abs(a * p2[0] + b * p2[1] + c) < 1e-2
+    assert p1[0] < p2[0]


### PR DESCRIPTION
## Summary
- implement `contact_points_from_spline` for sessile contour analysis
- test contact points for basic and rotated cases
- log update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c695f2224832ea17328cee2758b86