### PR TITLE
Update sessile metrics to use spline contact points

### DIFF
--- a/src/menipy/analysis/sessile.py
+++ b/src/menipy/analysis/sessile.py
@@ -27,6 +27,16 @@ def compute_metrics(
         substrate_line=substrate_line,
     )
     metrics.update(geo)
+
+    try:
+        cp1, cp2 = contact_points_from_spline(contour, substrate_line, delta=0.5)
+        metrics["contact_line"] = (
+            (int(round(cp1[0])), int(round(cp1[1]))),
+            (int(round(cp2[0])), int(round(cp2[1]))),
+        )
+    except Exception:
+        pass
+
     return metrics
 
 __all__ = ["compute_metrics"]

--- a/tests/test_sessile_metrics.py
+++ b/tests/test_sessile_metrics.py
@@ -1,0 +1,19 @@
+import numpy as np
+from menipy.analysis.sessile import compute_metrics as compute_sessile_metrics, contact_points_from_spline
+
+
+def _circle_contour(radius=20.0, center_y=10.0, n=200):
+    theta = np.linspace(0, 2 * np.pi, n)
+    return np.stack([radius * np.cos(theta), radius * np.sin(theta) + center_y], axis=1)
+
+
+def test_compute_metrics_uses_spline_points():
+    contour = _circle_contour()
+    line = ((-40.0, 0.0), (40.0, 0.0))
+    metrics = compute_sessile_metrics(contour, 10.0, substrate_line=line)
+    cp1, cp2 = contact_points_from_spline(contour, line, delta=0.5)
+    cp1 = (int(round(cp1[0])), int(round(cp1[1])))
+    cp2 = (int(round(cp2[0])), int(round(cp2[1])))
+    cl = metrics["contact_line"]
+    assert cl[0] == cp1
+    assert cl[1] == cp2


### PR DESCRIPTION
## Summary
- compute P1 and P2 for sessile drops using `contact_points_from_spline`
- add regression test ensuring contact points come from the spline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c6ec71468832eb1ec54a03526c396