### PR TITLE
Refine sessile contour detection

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -729,3 +729,8 @@ initialization. All tests still pass (53 passed).
 **Task:** Explain duplicate contour smoothing in sessile mode.
 
 **Summary:** No code changes required. The existing `smooth_contour_segment` helper parallels logic from the contact-angle tab but is scoped to sessile analysis for clarity. The reviewer note was addressed in documentation.
+## Entry 122 - Refine sessile contour
+
+**Task:** Improve sessile mode contour detection so the selected side stops at the substrate and excludes points below it.
+
+**Summary:** Added `remove_island_points`, `find_spline_roots`, and `select_left_and_right_roots` helpers in `analysis/sessile.py`. Updated `smooth_contour_segment` to filter by side, drop points near the substrate, remove small clusters, and keep only spline segments above the line. Added unit test `test_sessile_segment` verifying side filtering and no points below the substrate. All tests pass (61 passed, 29 skipped).

--- a/tests/test_sessile_segment.py
+++ b/tests/test_sessile_segment.py
@@ -1,0 +1,28 @@
+import numpy as np
+from menipy.analysis.sessile import smooth_contour_segment
+
+
+def _circle(radius=20.0, center=(0.0, -10.0), n=300):
+    theta = np.linspace(0, 2 * np.pi, n)
+    return np.stack(
+        [radius * np.cos(theta) + center[0], radius * np.sin(theta) + center[1]],
+        axis=1,
+    )
+
+
+def test_segment_above_substrate():
+    contour = _circle()
+    line = ((-40.0, 0.0), (40.0, 0.0))
+    seg, p1, p2 = smooth_contour_segment(contour, line, "left", delta=0.1, min_cluster=5)
+    assert np.all(seg[:, 1] < 0.0 + 1e-6)
+    assert p1[1] <= 0.0 + 1e-6
+    assert p2[1] <= 0.0 + 1e-6
+
+
+def test_segment_side_filtering():
+    contour = _circle()
+    line = ((-40.0, 0.0), (40.0, 0.0))
+    left, _, _ = smooth_contour_segment(contour, line, "left", delta=0.1, min_cluster=5)
+    right, _, _ = smooth_contour_segment(contour, line, "right", delta=0.1, min_cluster=5)
+    assert left[:, 0].max() <= 0.0 + 1e-6
+    assert right[:, 0].min() >= 0.0 - 1e-6


### PR DESCRIPTION
## Summary
- ensure sessile segment detection ignores points near/below the substrate
- introduce helper utilities for spline root finding and noise removal
- update smooth_contour_segment to use the new helpers
- add tests verifying the contour only covers the chosen side above the substrate
- record changes in CODEXLOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c8178033c832ea9b0698760f2b634