### PR TITLE
Fix contour-line intersection detection

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -746,3 +746,9 @@ initialization. All tests still pass (53 passed).
 **Task:** Improve sessile contact detection to remove opposite-side noise and ensure contact points lie within the drawn substrate segment.
 
 **Summary:** Updated `contact_points_from_spline` in `analysis/sessile.py` to filter points on the apex side of the substrate, clamp spline intersections to the segment length and handle edge ordering. Added unit test `test_contact_points_clamped_to_segment` verifying that short substrate lines yield contact points on the endpoints. All tests pass (62 passed, 29 skipped).
+
+## Entry 125 - Fix intersection detection
+
+**Task:** Resolve ValueError when line visibly intersects contour.
+
+**Summary:** Updated `contour_line_intersections` to check the wrap-around segment and removed redundant error check. Added regression test `test_intersections_wraparound_edge` ensuring intersection points on the closing edge are found. All tests pass (63 passed, 29 skipped).

--- a/src/menipy/physics/contact_geom.py
+++ b/src/menipy/physics/contact_geom.py
@@ -25,7 +25,11 @@ def contour_line_intersections(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return the two contour-line intersection points (left, right)."""
     d = a * contour_px[:, 0] + b * contour_px[:, 1] + c
-    idx = np.where(np.diff(np.sign(d)))[0]
+    sign_d = np.sign(d)
+    idx = np.where(np.diff(sign_d))[0].tolist()
+    if sign_d[-1] != sign_d[0]:
+        idx.append(len(sign_d) - 1)
+
     pts: list[np.ndarray] = []
     for i in idx:
         p, q = contour_px[i], contour_px[(i + 1) % len(contour_px)]
@@ -35,8 +39,7 @@ def contour_line_intersections(
             continue
         t = dp / (dp - dq)
         pts.append(p + t * (q - p))
-    if not pts:
-        raise ValueError("Line does not intersect contour")
+
     if not pts:
         raise ValueError("Line does not intersect contour")
 

--- a/tests/test_contact_geom.py
+++ b/tests/test_contact_geom.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from menipy.physics.contact_geom import geom_metrics
+from menipy.physics.contact_geom import geom_metrics, contour_line_intersections, line_params
 cv2 = __import__('cv2')
 
 
@@ -25,3 +25,21 @@ def test_circle_geom_metrics():
     poly = metrics["droplet_poly"]
     area_px = cv2.contourArea(poly.astype(np.float32))
     assert area_px == pytest.approx(0.5 * np.pi * r_px ** 2, rel=1e-2)
+
+
+def test_intersections_wraparound_edge():
+    contour = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+        ],
+        float,
+    )
+    p1 = (-0.5, 0.5)
+    p2 = (1.5, 0.5)
+    a, b, c = line_params(p1, p2)
+    left, right = contour_line_intersections(contour, a, b, c)
+    pts = {tuple(np.round(pt, 6)) for pt in (left, right)}
+    assert pts == {(0.0, 0.5), (1.0, 0.5)}


### PR DESCRIPTION
## Summary
- handle wrap-around edge when finding line intersections
- add regression test for wrap-around intersections
- document the change in CODEXLOG

## Testing
- `pytest -q`
- `pytest tests/test_contact_geom.py::test_intersections_wraparound_edge -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1ec1ae80832eb2a1bea3f0006139