### PR TITLE
Add manual contact point selection

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -752,3 +752,9 @@ initialization. All tests still pass (53 passed).
 **Task:** Resolve ValueError when line visibly intersects contour.
 
 **Summary:** Updated `contour_line_intersections` to check the wrap-around segment and removed redundant error check. Added regression test `test_intersections_wraparound_edge` ensuring intersection points on the closing edge are found. All tests pass (63 passed, 29 skipped).
+
+## Entry 126 - Manual contact points
+
+**Task:** Add manual contact point selection for sessile pipeline.
+
+**Summary:** Implemented `contour_line_intersection_near` helper and extended sessile geometry analysis to accept manually marked contact points. Updated GUI with a "Mark Contact Points" button enabling two-click selection and passing coordinates to the analysis. Added a unit test `test_intersection_near_selects_correct_point`. All tests pass (64 passed, 29 skipped).

--- a/tests/test_contact_geom.py
+++ b/tests/test_contact_geom.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pytest
 
-from menipy.physics.contact_geom import geom_metrics, contour_line_intersections, line_params
+from menipy.physics.contact_geom import (
+    geom_metrics,
+    contour_line_intersections,
+    contour_line_intersection_near,
+    line_params,
+)
 cv2 = __import__('cv2')
 
 
@@ -43,3 +48,22 @@ def test_intersections_wraparound_edge():
     left, right = contour_line_intersections(contour, a, b, c)
     pts = {tuple(np.round(pt, 6)) for pt in (left, right)}
     assert pts == {(0.0, 0.5), (1.0, 0.5)}
+
+
+def test_intersection_near_selects_correct_point():
+    contour = np.array(
+        [
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [2.0, 1.0],
+            [0.0, 1.0],
+        ],
+        float,
+    )
+    p1 = (-1.0, 0.5)
+    p2 = (3.0, 0.5)
+    a, b, c = line_params(p1, p2)
+    left, _ = contour_line_intersection_near(contour, a, b, c, (0.1, 0.5))
+    right, _ = contour_line_intersection_near(contour, a, b, c, (1.9, 0.5))
+    assert np.allclose(left, [0.0, 0.5])
+    assert np.allclose(right, [2.0, 0.5])


### PR DESCRIPTION
## Summary
- allow users to mark contact points in the contact angle tab
- compute intersections near user marks with `contour_line_intersection_near`
- adjust sessile analysis to use these manual points
- document the new feature in CODEXLOG
- test manual intersection helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e9a581e6c832e86fe35723d37ddb7