### PR TITLE
Show P1/P2 contact angles

### DIFF
--- a/src/menipy/gui/base_window.py
+++ b/src/menipy/gui/base_window.py
@@ -789,6 +789,8 @@ class BaseMainWindow(QMainWindow):
             height_line=metrics.get("h_mm"),
             apex_to_diam=metrics.get("apex_to_diam_mm") if mode == "pendant" else None,
             contact_to_diam=metrics.get("contact_to_diam_mm") if mode == "pendant" else None,
+            angle_p1=metrics.get("theta_slope_p1"),
+            angle_p2=metrics.get("theta_slope_p2"),
         )
 
         if self.drop_contour_item is not None:

--- a/src/menipy/gui/controls.py
+++ b/src/menipy/gui/controls.py
@@ -509,6 +509,10 @@ class AnalysisTab(QWidget):
         if show_contact_angle:
             self.angle_label = QLabel("0.0000")
             layout.addRow("Contact angle (º)", self.angle_label)
+            self.angle_p1_label = QLabel("0.0000")
+            layout.addRow("Angle P1 (º)", self.angle_p1_label)
+            self.angle_p2_label = QLabel("0.0000")
+            layout.addRow("Angle P2 (º)", self.angle_p2_label)
             self.width_label = QLabel("0.0000")
             layout.addRow("Base width (mm)", self.width_label)
             self.rb_label = QLabel("0.0000")
@@ -517,6 +521,8 @@ class AnalysisTab(QWidget):
             layout.addRow("Apex height (mm)", self.h_label)
         else:
             self.angle_label = None
+            self.angle_p1_label = None
+            self.angle_p2_label = None
             self.width_label = None
             self.rb_label = None
             self.h_label = None
@@ -584,6 +590,8 @@ class AnalysisTab(QWidget):
         height_line: float | None = None,
         apex_to_diam: float | None = None,
         contact_to_diam: float | None = None,
+        angle_p1: float | None = None,
+        angle_p2: float | None = None,
     ) -> None:
         if height is not None:
             self.height_label.setText(f"{height:.4f}")
@@ -635,6 +643,10 @@ class AnalysisTab(QWidget):
             self.apex_diam_label.setText(f"{apex_to_diam:.4f}")
         if contact_to_diam is not None and self.contact_diam_label is not None:
             self.contact_diam_label.setText(f"{contact_to_diam:.4f}")
+        if angle_p1 is not None and self.angle_p1_label is not None:
+            self.angle_p1_label.setText(f"{angle_p1:.4f}")
+        if angle_p2 is not None and self.angle_p2_label is not None:
+            self.angle_p2_label.setText(f"{angle_p2:.4f}")
 
     def metrics(self) -> dict[str, str]:
         data = {
@@ -667,6 +679,10 @@ class AnalysisTab(QWidget):
             data["apex_to_diam"] = self.apex_diam_label.text()
         if self.contact_diam_label is not None:
             data["contact_to_diam"] = self.contact_diam_label.text()
+        if self.angle_p1_label is not None:
+            data["angle_p1"] = self.angle_p1_label.text()
+        if self.angle_p2_label is not None:
+            data["angle_p2"] = self.angle_p2_label.text()
         return data
 
     def clear_metrics(self) -> None:
@@ -697,4 +713,6 @@ class AnalysisTab(QWidget):
             height_line=0.0,
             apex_to_diam=0.0,
             contact_to_diam=0.0,
+            angle_p1=0.0,
+            angle_p2=0.0,
         )

--- a/src/menipy/ui/main_window.py
+++ b/src/menipy/ui/main_window.py
@@ -265,6 +265,8 @@ class MainWindow(BaseMainWindow):
             height_line=metrics.get("h_mm"),
             apex_to_diam=metrics.get("apex_to_diam_mm"),
             contact_to_diam=metrics.get("contact_to_diam_mm"),
+            angle_p1=metrics.get("theta_slope_p1"),
+            angle_p2=metrics.get("theta_slope_p2"),
         )
         if self.drop_contour_item is not None:
             self.graphics_scene.removeItem(self.drop_contour_item)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -805,3 +805,35 @@ def test_clear_analysis_resets_metrics(tmp_path):
     assert window.contact_tab.diameter_label.text() == "0.0000"
     window.close()
     app.quit()
+
+
+def test_contact_angle_alt_metrics(tmp_path):
+    if QtWidgets is None:
+        pytest.skip("PySide6 not available")
+
+    import numpy as np
+    import cv2
+    from PySide6.QtCore import QLineF
+    from menipy.gui import SubstrateLineItem
+
+    img = np.zeros((40, 40), dtype=np.uint8)
+    cv2.circle(img, (20, 30), 8, 255, -1)
+    path = tmp_path / "drop.png"
+    cv2.imwrite(str(path), img)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MainWindow()
+    window.load_image(path)
+    window.drop_rect = (10, 20, 30, 39)
+    window.px_per_mm_drop = 10.0
+    window.substrate_line_item = SubstrateLineItem(QLineF(10, 38, 30, 38))
+    window.graphics_scene.addItem(window.substrate_line_item)
+    window._run_analysis("contact-angle-alt")
+
+    txt1 = window.contact_tab_alt.angle_p1_label.text()
+    txt2 = window.contact_tab_alt.angle_p2_label.text()
+    assert float(txt1) > 0
+    assert float(txt2) > 0
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- extend AnalysisTab to display contact angles at P1 and P2
- surface these metrics from alt sessile workflow
- test GUI update for alt contact angle metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe143819c832e9a273b847e275996