### PR TITLE
Implement contour cleanup for alt sessile

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -781,3 +781,9 @@ initialization. All tests still pass (53 passed).
 **Task:** Fix droplet detection failure when contact line touches the substrate.
 
 **Summary:** Updated `exclude_near_line` to keep contours that touch the line segment between contact points. Regression tests pass (64 passed, 34 skipped).
+
+## Entry 131 - Contour cleanup
+
+**Task:** Implement droplet contour preprocessing for the alt sessile method.
+
+**Summary:** Added `clean_droplet_contour` in `geometry_alt.py` to mask substrate pixels, remove noise and isolate the main droplet. Modified `analyze` to use this helper and created unit test `test_clean_droplet_contour_basic`. All tests pass.

--- a/tests/test_alt_workflow.py
+++ b/tests/test_alt_workflow.py
@@ -8,6 +8,7 @@ try:
         find_contact_points,
         compute_apex,
         compute_contact_angles,
+        clean_droplet_contour,
         analyze,
         HelperBundle,
     )
@@ -19,6 +20,7 @@ except Exception as exc:  # pragma: no cover - dependency issue
     compute_contact_angles = None
     analyze = None
     HelperBundle = None
+    clean_droplet_contour = None
     missing_dependency = exc
 else:
     missing_dependency = None
@@ -32,6 +34,19 @@ def test_filter_contours_by_size():
     res = filter_contours_by_size([c1, c2], 0.5, 2.0)
     assert len(res) == 1
     assert np.allclose(res[0], c1)
+
+
+def test_clean_droplet_contour_basic():
+    if clean_droplet_contour is None:
+        pytest.skip(f"PySide6 not available: {missing_dependency}")
+    img = np.zeros((80, 100), np.uint8)
+    cv2.circle(img, (50, 30), 20, 255, -1)
+    img[70:, :] = 255  # noise below substrate
+    contours = clean_droplet_contour(img, 60, min_area=50)
+    assert len(contours) == 1
+    cnt = contours[0]
+    assert cnt.shape[1] == 2
+    assert cnt[:, 1].max() < 60
 
 
 def test_project_onto_line():


### PR DESCRIPTION
## Summary
- add `clean_droplet_contour` helper in `geometry_alt.py`
- use contour cleanup in alt sessile `analyze`
- test contour cleanup routine
- log new task in `CODEXLOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687059d20064832ea2ad1c869e6e12c3