### PR TITLE
Improve droplet detection fallback

### DIFF
--- a/src/menipy/pipelines/sessile/geometry_alt.py
+++ b/src/menipy/pipelines/sessile/geometry_alt.py
@@ -309,9 +309,13 @@ def analyze(
 
     substrate_y = int(round((substrate[0][1] + substrate[1][1]) / 2))
     contours = clean_droplet_contour(mask, substrate_y)
-    if not contours:
-        raise ValueError("no droplet region detected")
-    clean_contour = max(contours, key=cv2.contourArea)
+    if contours:
+        clean_contour = max(contours, key=cv2.contourArea)
+    else:
+        try:
+            clean_contour = extract_outer_contour(mask)
+        except ValueError:
+            raise ValueError("no droplet region detected") from None
 
     p1_guess = contact_points[0] if contact_points else substrate[0]
     p2_guess = contact_points[1] if contact_points else substrate[1]


### PR DESCRIPTION
## Summary
- improve sessile pipeline to fall back on outer contour detection if cleaning fails

## Testing
- `pytest -q` *(fails: Qt platform plugin issues)*

------
https://chatgpt.com/codex/tasks/task_e_6870fff8f8e8832eabf0408410ec888c