### PR TITLE
Fix contour filtering by droplet side

### DIFF
--- a/src/menipy/analysis/sessile_alt.py
+++ b/src/menipy/analysis/sessile_alt.py
@@ -13,14 +13,29 @@ def compute_metrics(
     contour: np.ndarray,
     px_per_mm: float,
     substrate_line: tuple[tuple[float, float], tuple[float, float]] | None = None,
+    *,
+    keep_above: bool | None = None,
 ) -> dict:
-    """Return sessile-drop metrics for ``contour``."""
+    """Return sessile-drop metrics for ``contour``.
+
+    Parameters
+    ----------
+    contour:
+        Droplet contour points ``(x, y)``.
+    px_per_mm:
+        Calibration factor in pixels per millimetre.
+    substrate_line:
+        Two points defining the substrate line.
+    keep_above:
+        If ``True`` keep contour points above the line, if ``False`` keep the
+        points below it. ``None`` selects the side with the larger area.
+    """
     if substrate_line is None:
         return compute_drop_metrics(contour, px_per_mm, "contact-angle")
 
     apex_idx = find_apex_index(contour, "contact-angle")
     poly = np.array([substrate_line[0], substrate_line[1]], float)
-    geo = geom_metrics_alt(poly, contour, px_per_mm)
+    geo = geom_metrics_alt(poly, contour, px_per_mm, keep_above=keep_above)
     droplet_poly = geo.pop("droplet_poly")
     metrics = compute_drop_metrics(
         droplet_poly.astype(float),


### PR DESCRIPTION
## Summary
- allow choosing the droplet side in `sessile_alt.compute_metrics`
- filter sessile alt contours to the selected side during analysis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68792ada56a4832e82916998286ff66e