### PR TITLE
Fix apex selection for pendant drops

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -816,3 +816,8 @@ initialization. All tests still pass (53 passed).
 **Task:** Ensure apex selection centers multiple candidates.
 
 **Summary:** Updated `_apex_point` in `processing.metrics` to average the horizontal positions when multiple contour points share the extreme distance to the substrate line. Added test `test_apex_point_middle` verifying that sessile and pendant metrics return the centered apex.
+## Entry 137 - Pendant apex median
+
+**Task:** Select the central apex when multiple pendant candidates exist.
+
+**Summary:** Modified `_apex_point` to return the candidate whose projection on the substrate line lies in the middle of all extreme points. `find_apex_index` now mirrors this by choosing the median-x point when several share the extremal height.

--- a/src/menipy/analysis/commons.py
+++ b/src/menipy/analysis/commons.py
@@ -54,15 +54,24 @@ def _max_horizontal_diameter(contour: np.ndarray) -> tuple[int, float, int, int]
 
 
 def find_apex_index(contour: np.ndarray, mode: str) -> int:
-    """Return the index of the apex point."""
+    """Return the index of the apex point.
+
+    When multiple points share the extremal y-coordinate, the candidate whose
+    ``x`` value is in the middle of the group is selected.  This mirrors the
+    behaviour of :func:`_apex_point` and keeps the apex centred.
+    """
     if mode == "pendant":
         y_ext = contour[:, 1].max()
-        candidates = np.where(contour[:, 1] == y_ext)[0]
+        idxs = np.where(contour[:, 1] == y_ext)[0]
     else:
         y_ext = contour[:, 1].min()
-        candidates = np.where(contour[:, 1] == y_ext)[0]
-    mid = len(candidates) // 2
-    return int(candidates[mid])
+        idxs = np.where(contour[:, 1] == y_ext)[0]
+    if len(idxs) == 1:
+        return int(idxs[0])
+    xs = contour[idxs, 0]
+    order = np.argsort(xs)
+    mid = len(order) // 2
+    return int(idxs[order[mid]])
 
 
 def compute_drop_metrics(

--- a/src/menipy/processing/metrics.py
+++ b/src/menipy/processing/metrics.py
@@ -15,9 +15,11 @@ def _apex_point(
 ) -> np.ndarray:
     """Return the apex relative to ``line_pt``/``line_dir``.
 
-    When several contour points share the extreme distance to the substrate
-    line, their mean coordinate is used.  This ensures a centred apex for
-    symmetric silhouettes.
+    The apex is taken as the contour point with the largest (sessile) or
+    smallest (pendant) signed distance to the substrate line.  If several
+    points share that extreme distance, the candidate whose projection onto
+    the substrate line is in the middle of the group is returned.  This
+    avoids biasing the apex toward either side when a flat region occurs.
     """
 
     dist = _signed_distance(contour, line_pt, line_dir)
@@ -32,7 +34,11 @@ def _apex_point(
     if len(idxs) == 1:
         return pts[0]
 
-    return pts.mean(axis=0)
+    # choose the candidate centred along the substrate direction
+    t = (pts - line_pt) @ line_dir
+    order = np.argsort(t)
+    mid = len(order) // 2
+    return pts[order[mid]]
 
 
 def metrics_sessile(


### PR DESCRIPTION
## Summary
- choose the middle candidate for pendant apex in `_apex_point`
- make `find_apex_index` return the median-x point
- log changes

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_687e3b79e7b4832e8b8ed494d273b3e1