### PR TITLE
fix: avoid alt sessile circular import

### DIFF
--- a/CODEXLOG.md
+++ b/CODEXLOG.md
@@ -838,3 +838,8 @@ initialization. All tests still pass (53 passed).
 **Task:** Add file locations for internal imports in import map.
 
 **Summary:** Regenerated `IMPORTED.md` to append source file paths for modules within `src`, leaving third-party packages unchanged.
+## Entry 141 - Break circular import in alt sessile pipeline
+
+**Task:** Fix circular import between analysis and pipeline modules.
+
+**Summary:** Deferred the import of `compute_sessile_metrics_alt` inside `pipelines/sessile/geometry_alt.analyze` so `line_params` can be imported without triggering a loop. Tests fail to run due to missing OpenCV dependencies.

--- a/src/menipy/pipelines/sessile/geometry_alt.py
+++ b/src/menipy/pipelines/sessile/geometry_alt.py
@@ -5,7 +5,6 @@ from typing import Literal
 import numpy as np
 import cv2
 
-from ...analysis import compute_sessile_metrics_alt
 #from ...physics.contact_geom import line_params
 from ...detectors.geometry_alt import split_contour_by_line
 import math
@@ -396,6 +395,7 @@ def analyze(
 
     cp1, cp2 = find_contact_points(clean_contour, substrate, p1_guess, p2_guess)
     apex_pt = compute_apex(clean_contour, substrate, cp1, cp2)
+    from ...analysis import compute_sessile_metrics_alt
 
     metrics = compute_sessile_metrics_alt(
         clean_contour.astype(float),


### PR DESCRIPTION
## Summary
- prevent circular import between analysis and alt sessile pipeline by lazily importing `compute_sessile_metrics_alt`
- update CODEXLOG with entry for circular import fix

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68adc835b34c832ea486e6af9f8f2e75