### PR TITLE
feat(pendant): minimal stage implementations + tests

### DIFF
--- a/src/menipy/pipelines/pendant/outputs.py
+++ b/src/menipy/pipelines/pendant/outputs.py
@@ -1,13 +1,21 @@
 """
-STUB: Pendant Pipeline - Outputs Stage
-
-This file is a placeholder stub for the result formatting and export.
-
-TODO: Implement outputs stage for pendant pipeline
-      - Define stage-specific logic
-      - Add proper error handling
-      - Write unit tests
-      - Update documentation
-
-See pendant_plan_pipeline.md for implementation details.
+Minimal outputs stage for the pendant pipeline.
+Collects fit parameters into `ctx.results` and ensures predictable keys.
 """
+from __future__ import annotations
+
+from typing import Optional
+from menipy.models.context import Context
+
+
+def run(ctx: Context) -> Optional[Context]:
+    if getattr(ctx, "fit", None):
+        names = ctx.fit.get("param_names", [])
+        params = ctx.fit.get("params", [])
+        fit_map = {n: p for n, p in zip(names, params)}
+        ctx.results = ctx.results or {}
+        ctx.results.update(fit_map)
+    ctx.results = ctx.results or {}
+    ctx.results.setdefault("surface_tension_mN_m", None)
+    ctx.results.setdefault("volume_uL", None)
+    return ctx

--- a/src/menipy/pipelines/pendant/physics.py
+++ b/src/menipy/pipelines/pendant/physics.py
@@ -1,13 +1,16 @@
 """
-STUB: Pendant Pipeline - Physics Stage
-
-This file is a placeholder stub for the physical parameter setup and calculations.
-
-TODO: Implement physics stage for pendant pipeline
-      - Define stage-specific logic
-      - Add proper error handling
-      - Write unit tests
-      - Update documentation
-
-See pendant_plan_pipeline.md for implementation details.
+Minimal physics stage for the pendant pipeline.
+Populates default densities and gravity if missing.
 """
+from __future__ import annotations
+
+from typing import Optional
+from menipy.models.context import Context
+
+
+def run(ctx: Context) -> Optional[Context]:
+    ctx.physics = ctx.physics or {}
+    ctx.physics.setdefault("rho1", 1000.0)
+    ctx.physics.setdefault("rho2", 1.2)
+    ctx.physics.setdefault("g", 9.80665)
+    return ctx

--- a/src/menipy/pipelines/pendant/preprocessing.py
+++ b/src/menipy/pipelines/pendant/preprocessing.py
@@ -1,13 +1,33 @@
 """
-STUB: Pendant Pipeline - Preprocessing Stage
-
-This file is a placeholder stub for the image preprocessing operations.
-
-TODO: Implement preprocessing stage for pendant pipeline
-      - Define stage-specific logic
-      - Add proper error handling
-      - Write unit tests
-      - Update documentation
-
-See pendant_plan_pipeline.md for implementation details.
+Minimal preprocessing stage for the pendant pipeline.
+Converts image to grayscale and applies a small Gaussian blur, setting
+`ctx.preprocessed` and basic metadata so downstream stages have a stable baseline.
 """
+from __future__ import annotations
+
+from typing import Optional
+import numpy as np
+import cv2
+
+from menipy.models.context import Context
+
+
+def run(ctx: Context) -> Optional[Context]:
+    img = getattr(ctx, "image", None)
+    if img is None:
+        return ctx
+
+    try:
+        if hasattr(img, "ndim") and img.ndim == 3 and img.shape[2] == 3:
+            gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = img.copy()
+    except Exception:
+        return ctx
+
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    ctx.preprocessed = blurred
+    ctx.preprocessed_settings = {"blur_ksize": (5, 5)}
+    ctx.preprocessed_history = ["gaussian_blur"]
+    ctx.preprocessed_roi = (0, 0, int(blurred.shape[1]), int(blurred.shape[0]))
+    return ctx

--- a/src/menipy/pipelines/pendant/scaling.py
+++ b/src/menipy/pipelines/pendant/scaling.py
@@ -1,13 +1,14 @@
 """
-STUB: Pendant Pipeline - Scaling Stage
-
-This file is a placeholder stub for the pixel-to-metric calibration.
-
-TODO: Implement scaling stage for pendant pipeline
-      - Define stage-specific logic
-      - Add proper error handling
-      - Write unit tests
-      - Update documentation
-
-See pendant_plan_pipeline.md for implementation details.
+Minimal scaling stage for the pendant pipeline.
+Sets a conservative default `px_per_mm` if none is present.
 """
+from __future__ import annotations
+
+from menipy.models.context import Context
+from typing import Optional
+
+
+def run(ctx: Context) -> Optional[Context]:
+    ctx.scale = ctx.scale or {}
+    ctx.scale.setdefault("px_per_mm", 1.0)
+    return ctx

--- a/src/menipy/pipelines/pendant/validation.py
+++ b/src/menipy/pipelines/pendant/validation.py
@@ -1,13 +1,18 @@
 """
-STUB: Pendant Pipeline - Validation Stage
-
-This file is a placeholder stub for the quality assurance and validation checks.
-
-TODO: Implement validation stage for pendant pipeline
-      - Define stage-specific logic
-      - Add proper error handling
-      - Write unit tests
-      - Update documentation
-
-See pendant_plan_pipeline.md for implementation details.
+Minimal validation stage for the pendant pipeline.
+Basic QA: true if solver succeeded or geometry exists.
 """
+from __future__ import annotations
+
+from typing import Optional
+from menipy.models.context import Context
+
+
+def run(ctx: Context) -> Optional[Context]:
+    ok = False
+    if getattr(ctx, "fit", None) and ctx.fit.get("solver", {}).get("success", False):
+        ok = True
+    elif getattr(ctx, "geometry", None) is not None:
+        ok = True
+    ctx.qa = {"ok": ok}
+    return ctx

--- a/tests/test_pendant_minimal_pipeline.py
+++ b/tests/test_pendant_minimal_pipeline.py
@@ -1,0 +1,54 @@
+import numpy as np
+from menipy.models.context import Context
+from menipy.pipelines.pendant.preprocessing import run as preprocessing_run
+from menipy.pipelines.pendant.scaling import run as scaling_run
+from menipy.pipelines.pendant.physics import run as physics_run
+from menipy.pipelines.pendant.validation import run as validation_run
+from menipy.pipelines.pendant.outputs import run as outputs_run
+
+
+def make_dummy_image(w=160, h=120):
+    img = np.zeros((h, w, 3), dtype=np.uint8)
+    try:
+        import cv2 as _cv
+
+        _cv.circle(img, (w // 2, h // 2), min(w, h) // 5, (255, 255, 255), -1)
+    except Exception:
+        img[h // 2 - 8 : h // 2 + 8, w // 2 - 8 : w // 2 + 8] = 255
+    return img
+
+
+def test_preprocessing_sets_fields():
+    ctx = Context()
+    ctx.image = make_dummy_image()
+    ctx = preprocessing_run(ctx)
+    assert hasattr(ctx, "preprocessed") and ctx.preprocessed is not None
+    assert ctx.preprocessed_settings["blur_ksize"] == (5, 5)
+
+
+def test_scaling_defaults():
+    ctx = Context()
+    ctx = scaling_run(ctx)
+    assert ctx.scale["px_per_mm"] == 1.0
+
+
+def test_physics_defaults():
+    ctx = Context()
+    ctx = physics_run(ctx)
+    assert ctx.physics["rho1"] == 1000.0
+    assert ctx.physics["g"] == 9.80665
+
+
+def test_validation_and_outputs():
+    ctx = Context()
+    ctx = validation_run(ctx)
+    assert ctx.qa["ok"] is False
+
+    ctx.geometry = object()
+    ctx = validation_run(ctx)
+    assert ctx.qa["ok"] is True
+
+    ctx.fit = {"param_names": ["R0_mm"], "params": [99.0]}
+    ctx = outputs_run(ctx)
+    assert ctx.results["R0_mm"] == 99.0
+    assert "surface_tension_mN_m" in ctx.results


### PR DESCRIPTION
Add minimal, conservative implementations for pendant pipeline stages (preprocessing, scaling, physics, validation, outputs) with unit tests under 	ests/test_pendant_minimal_pipeline.py. These are intentionally small, safe functions to replace stubs and allow progressive iteration. PTAL.