### PR TITLE
fix(ci): resolve all CI failures — EGL/Qt headless, Black formatting, lint matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install system dependencies for Qt/EGL
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libegl1 \
+            libgles2 \
+            libopengl0 \
+            xvfb \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-xinerama0 \
+            libxcb-xfixes0
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,7 +44,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=src --cov-report=xml --cov-report=term-missing
+          xvfb-run -a pytest --cov=src --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install package and dev tools
         run: |

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,5 +1,6 @@
 # Runs the command-line interface:  python -m adsa
 """Entry point for running Menipy as a module."""
+
 from menipy.gui.app import main
 
 if __name__ == "__main__":

--- a/src/menipy/common/_module_loader.py
+++ b/src/menipy/common/_module_loader.py
@@ -2,6 +2,7 @@ import sys
 import importlib.util
 from pathlib import Path
 
+
 def load_module_from_path(path: Path, module_name: str):
     """Load a Python module from a file path."""
     spec = importlib.util.spec_from_file_location(module_name, str(path))

--- a/src/menipy/common/acquisition.py
+++ b/src/menipy/common/acquisition.py
@@ -1,5 +1,6 @@
 # src/menipy/common/acquisition.py
 """Common acquisition utilities for loading images from files or cameras."""
+
 from __future__ import annotations
 
 from typing import Sequence
@@ -42,7 +43,7 @@ def from_file(paths: Sequence[str]) -> Sequence[np.ndarray]:
 def from_camera(device: int = 0, n_frames: int = 1) -> Sequence[np.ndarray]:
     """
     Grab frames from a camera.
-    
+
     .. note::
         This is currently a placeholder returning black frames.
         Proper integration with `cv2.VideoCapture` is planned.

--- a/src/menipy/common/acquisition_stage.py
+++ b/src/menipy/common/acquisition_stage.py
@@ -5,6 +5,7 @@ Unified acquisition stage implementation for all pipelines.
 This module provides a consistent image loading strategy that is shared
 across all pipeline implementations to ensure consistent behavior.
 """
+
 from __future__ import annotations
 
 import logging
@@ -18,18 +19,18 @@ from menipy.models.context import Context
 
 def do_acquisition(ctx: Context, logger: logging.Logger) -> Context:
     """Unified acquisition stage for all pipelines.
-    
+
     Handles image loading from multiple sources with consistent behavior:
-    
+
         1. Return early if frames already exist
     2. Wrap numpy array in Frame if ctx.image is ndarray
     3. Load from ctx.image if it's a string path
     4. Load from ctx.image_path if provided
-    
+
     Args:
         ctx: Pipeline context object
         logger: Logger instance for the calling pipeline
-        
+
     Returns:
         Updated context with ctx.frames, ctx.frame, and ctx.image populated
     """
@@ -37,38 +38,42 @@ def do_acquisition(ctx: Context, logger: logging.Logger) -> Context:
     if getattr(ctx, "frames", None) and len(ctx.frames) > 0:
         logger.info(f"[do_acquisition] Frames already exist: {len(ctx.frames)}")
         return ctx
-    
+
     # Check if we have a direct image (numpy array)
     image = getattr(ctx, "image", None)
-    
+
     # If image is a string path, treat it as image_path
     if isinstance(image, (str, Path)):
         if not getattr(ctx, "image_path", None):
             ctx.image_path = str(image)
         image = None  # Clear so we load from path below
-    
+
     # Wrap numpy array in Frame
     if image is not None and isinstance(image, np.ndarray):
         from menipy.models.frame import Frame
-        
+
         frame = Frame(image=image)
         ctx.frames = [frame]
         ctx.frame = frame
-        logger.info(f"[do_acquisition] Wrapped ctx.image in frame, shape: {image.shape}")
+        logger.info(
+            f"[do_acquisition] Wrapped ctx.image in frame, shape: {image.shape}"
+        )
         return ctx
-    
+
     # Try to load from file path
     image_path = getattr(ctx, "image_path", None)
     if not image_path:
         logger.warning("[do_acquisition] No image or image_path available!")
         return ctx
-    
+
     # Try OpenCV first (most common), then fall back to acquisition module
     try:
         import cv2
+
         img = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
         if img is not None:
             from menipy.models.frame import Frame
+
             frame = Frame(image=img)
             ctx.frames = [frame]
             ctx.frame = frame
@@ -76,19 +81,24 @@ def do_acquisition(ctx: Context, logger: logging.Logger) -> Context:
             logger.info(f"[do_acquisition] Loaded image from {image_path} via cv2")
             return ctx
     except Exception as e:
-        logger.debug(f"[do_acquisition] cv2 load failed: {e}, trying acquisition module")
-    
+        logger.debug(
+            f"[do_acquisition] cv2 load failed: {e}, trying acquisition module"
+        )
+
     # Fallback to acquisition module
     try:
         from menipy.common import acquisition as acq
-        logger.info(f"[do_acquisition] Loading from file via acquisition module: {image_path}")
+
+        logger.info(
+            f"[do_acquisition] Loading from file via acquisition module: {image_path}"
+        )
         frames = acq.from_file([image_path])
         if frames:
             ctx.frames = frames
             ctx.frame = frames[0]
-            ctx.image = frames[0].image if hasattr(frames[0], 'image') else frames[0]
+            ctx.image = frames[0].image if hasattr(frames[0], "image") else frames[0]
             logger.info(f"[do_acquisition] Loaded {len(frames)} frames from disk")
     except Exception as e:
         logger.error(f"[do_acquisition] Failed to load from file: {e}")
-    
+
     return ctx

--- a/src/menipy/common/auto_calibrator.py
+++ b/src/menipy/common/auto_calibrator.py
@@ -5,6 +5,7 @@ This module provides automatic detection of substrate, needle, drop contour,
 and ROI regions for the calibration wizard. Detection strategies are
 pipeline-specific (sessile vs pendant).
 """
+
 from __future__ import annotations
 
 import logging
@@ -20,31 +21,31 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CalibrationResult:
     """Results from automatic calibration detection."""
-    
+
     # Substrate line as ((x1, y1), (x2, y2)) - horizontal baseline
     substrate_line: Optional[Tuple[Tuple[int, int], Tuple[int, int]]] = None
-    
+
     # Needle region as (x, y, width, height) if detected
     needle_rect: Optional[Tuple[int, int, int, int]] = None
-    
+
     # Drop contour as Nx2 array of (x, y) points
     drop_contour: Optional[np.ndarray] = None
-    
+
     # ROI as (x, y, width, height) encompassing the region of interest
     roi_rect: Optional[Tuple[int, int, int, int]] = None
-    
+
     # Contact points (left and right) where drop meets substrate/needle
     contact_points: Optional[Tuple[Tuple[int, int], Tuple[int, int]]] = None
-    
+
     # Apex point (bottom for pendant, top for sessile)
     apex_point: Optional[Tuple[int, int]] = None
-    
+
     # Confidence scores for each detection (0.0 - 1.0)
     confidence_scores: dict = field(default_factory=dict)
-    
+
     # Enhanced image used for detection (for preview)
     enhanced_image: Optional[np.ndarray] = None
-    
+
     # Binary mask from segmentation (for preview)
     binary_mask: Optional[np.ndarray] = None
 
@@ -52,11 +53,11 @@ class CalibrationResult:
 class AutoCalibrator:
     """
     Automatic region detection for calibration wizard.
-    
+
     Uses CLAHE for contrast enhancement and adaptive/Otsu thresholding
     for robust segmentation across different image conditions.
     """
-    
+
     def __init__(
         self,
         image: np.ndarray,
@@ -72,7 +73,7 @@ class AutoCalibrator:
     ) -> None:
         """
         Initialize the auto-calibrator.
-        
+
         Args:
             image: Input image (BGR or grayscale)
             pipeline_name: Pipeline type ("sessile", "pendant", etc.)
@@ -86,7 +87,7 @@ class AutoCalibrator:
         """
         self.original_image = image.copy()
         self.pipeline_name = pipeline_name.lower()
-        
+
         # Parameters
         self.clahe_clip_limit = clahe_clip_limit
         self.clahe_tile_size = clahe_tile_size
@@ -95,36 +96,35 @@ class AutoCalibrator:
         self.margin_fraction = margin_fraction
         self.min_area_fraction = min_area_fraction
         self.roi_padding = roi_padding
-        
+
         # Derived properties
         if len(image.shape) == 3:
             self.gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         else:
             self.gray = image.copy()
-        
+
         self.height, self.width = self.gray.shape[:2]
         self.image_area = self.height * self.width
-        
+
         # Apply CLAHE for contrast enhancement
         clahe = cv2.createCLAHE(
-            clipLimit=self.clahe_clip_limit,
-            tileGridSize=self.clahe_tile_size
+            clipLimit=self.clahe_clip_limit, tileGridSize=self.clahe_tile_size
         )
         self.enhanced_gray = clahe.apply(self.gray)
-        
+
         # Internal state
         self._substrate_y: Optional[int] = None
         self._needle_contour: Optional[np.ndarray] = None
         self._needle_rect: Optional[Tuple[int, int, int, int]] = None
         self._drop_contour: Optional[np.ndarray] = None
         self._binary_clean: Optional[np.ndarray] = None
-    
+
     def detect_all(self) -> CalibrationResult:
         """
         Run full detection pipeline and return results.
-        
+
         Routes to pipeline-specific detection strategy.
-        
+
         Returns:
             CalibrationResult with all detected regions and confidence scores.
         """
@@ -132,215 +132,231 @@ class AutoCalibrator:
             return self._detect_pendant()
         else:
             return self._detect_sessile()
-    
+
     def _detect_sessile(self) -> CalibrationResult:
         """Run sessile drop detection pipeline."""
         result = CalibrationResult()
         result.enhanced_image = self.enhanced_gray.copy()
-        
+
         # Step 1: Detect substrate baseline
         substrate_line, substrate_conf = self._detect_substrate()
         if substrate_line:
             result.substrate_line = substrate_line
             result.confidence_scores["substrate"] = substrate_conf
-            logger.info(f"Substrate detected at y={self._substrate_y} (conf={substrate_conf:.2f})")
-        
+            logger.info(
+                f"Substrate detected at y={self._substrate_y} (conf={substrate_conf:.2f})"
+            )
+
         # Step 2: Segment image using adaptive thresholding
         self._segment_image_adaptive()
-        result.binary_mask = self._binary_clean.copy() if self._binary_clean is not None else None
-        
+        result.binary_mask = (
+            self._binary_clean.copy() if self._binary_clean is not None else None
+        )
+
         # Step 3: Detect needle
         needle_rect, needle_conf = self._detect_needle_sessile()
         if needle_rect:
             result.needle_rect = needle_rect
             result.confidence_scores["needle"] = needle_conf
             logger.info(f"Needle detected: {needle_rect} (conf={needle_conf:.2f})")
-        
+
         # Step 4: Detect drop contour
         drop_contour, contact_pts, drop_conf = self._detect_drop_sessile()
         if drop_contour is not None and len(drop_contour) > 0:
             result.drop_contour = drop_contour
             result.contact_points = contact_pts
             result.confidence_scores["drop"] = drop_conf
-            logger.info(f"Drop detected with {len(drop_contour)} points (conf={drop_conf:.2f})")
-        
+            logger.info(
+                f"Drop detected with {len(drop_contour)} points (conf={drop_conf:.2f})"
+            )
+
         # Step 5: Compute ROI from detected regions
         roi_rect, roi_conf = self._compute_roi(result)
         if roi_rect:
             result.roi_rect = roi_rect
             result.confidence_scores["roi"] = roi_conf
             logger.info(f"ROI computed: {roi_rect} (conf={roi_conf:.2f})")
-        
+
         # Compute overall confidence
         if result.confidence_scores:
-            result.confidence_scores["overall"] = sum(result.confidence_scores.values()) / len(result.confidence_scores)
-        
+            result.confidence_scores["overall"] = sum(
+                result.confidence_scores.values()
+            ) / len(result.confidence_scores)
+
         return result
-    
+
     def _detect_pendant(self) -> CalibrationResult:
         """
         Run pendant drop detection pipeline.
-        
+
         Uses Otsu thresholding (better for high-contrast silhouettes).
         Detects needle by shaft lines and contact points where contour deviates.
         """
         result = CalibrationResult()
         result.enhanced_image = self.enhanced_gray.copy()
-        
+
         # Step 1: Segment using Otsu thresholding
         self._segment_image_otsu()
-        result.binary_mask = self._binary_clean.copy() if self._binary_clean is not None else None
-        
+        result.binary_mask = (
+            self._binary_clean.copy() if self._binary_clean is not None else None
+        )
+
         # Step 2: Find the main drop contour
         drop_cnt, drop_conf = self._find_pendant_drop_contour()
         if drop_cnt is None:
             logger.warning("Pendant: Could not find drop contour")
             return result
-        
+
         # Step 3: Detect needle and contact points
         needle_rect, contact_pts, needle_conf = self._detect_needle_pendant(drop_cnt)
         if needle_rect:
             result.needle_rect = needle_rect
             result.contact_points = contact_pts
             result.confidence_scores["needle"] = needle_conf
-            logger.info(f"Pendant needle detected: {needle_rect} (conf={needle_conf:.2f})")
-        
+            logger.info(
+                f"Pendant needle detected: {needle_rect} (conf={needle_conf:.2f})"
+            )
+
         # Step 4: Find apex (bottom of drop)
         apex_pt, apex_conf = self._detect_apex_pendant(drop_cnt)
         if apex_pt:
             result.apex_point = apex_pt
             result.confidence_scores["apex"] = apex_conf
             logger.info(f"Pendant apex detected at {apex_pt} (conf={apex_conf:.2f})")
-        
+
         # Step 5: Set drop contour
         drop_contour = drop_cnt.reshape(-1, 2).astype(np.float64)
         result.drop_contour = drop_contour
         result.confidence_scores["drop"] = drop_conf
-        
+
         # Step 6: Compute ROI
         roi_rect, roi_conf = self._compute_roi_pendant(result)
         if roi_rect:
             result.roi_rect = roi_rect
             result.confidence_scores["roi"] = roi_conf
             logger.info(f"Pendant ROI computed: {roi_rect} (conf={roi_conf:.2f})")
-        
+
         # Compute overall confidence
         if result.confidence_scores:
-            result.confidence_scores["overall"] = sum(result.confidence_scores.values()) / len(result.confidence_scores)
-        
+            result.confidence_scores["overall"] = sum(
+                result.confidence_scores.values()
+            ) / len(result.confidence_scores)
+
         return result
-    
+
     # ======================== Segmentation Methods ========================
-    
+
     def _segment_image_adaptive(self) -> None:
         """Segment using adaptive thresholding (for sessile)."""
         blur = cv2.GaussianBlur(self.enhanced_gray, (5, 5), 0)
-        
+
         binary = cv2.adaptiveThreshold(
-            blur, 255,
+            blur,
+            255,
             cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
             cv2.THRESH_BINARY_INV,
             self.adaptive_block_size,
-            self.adaptive_c
+            self.adaptive_c,
         )
-        
+
         # Mask below substrate line
         if self._substrate_y is not None:
-            binary[self._substrate_y - 2:, :] = 0
-        
+            binary[self._substrate_y - 2 :, :] = 0
+
         # Morphological cleanup
         kernel = np.ones((3, 3), np.uint8)
         binary_clean = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel, iterations=2)
-        binary_clean = cv2.morphologyEx(binary_clean, cv2.MORPH_CLOSE, kernel, iterations=2)
-        
+        binary_clean = cv2.morphologyEx(
+            binary_clean, cv2.MORPH_CLOSE, kernel, iterations=2
+        )
+
         self._binary_clean = binary_clean
-    
+
     def _segment_image_otsu(self) -> None:
         """Segment using Otsu thresholding (for pendant high-contrast)."""
         blur = cv2.GaussianBlur(self.gray, (5, 5), 0)
-        
-        _, binary = cv2.threshold(
-            blur, 0, 255,
-            cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU
-        )
-        
+
+        _, binary = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+
         # Morphological cleanup
         kernel = np.ones((5, 5), np.uint8)
         binary_clean = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel, iterations=2)
-        
+
         self._binary_clean = binary_clean
-    
+
     # ======================== Sessile Detection Methods ========================
-    
-    def _detect_substrate(self) -> Tuple[Optional[Tuple[Tuple[int, int], Tuple[int, int]]], float]:
+
+    def _detect_substrate(
+        self,
+    ) -> Tuple[Optional[Tuple[Tuple[int, int], Tuple[int, int]]], float]:
         """Detect substrate baseline using gradient analysis on image margins."""
         margin_px = max(10, min(50, int(self.width * self.margin_fraction)))
-        
+
         left_strip = self.enhanced_gray[:, 0:margin_px]
-        right_strip = self.enhanced_gray[:, self.width - margin_px:self.width]
-        
+        right_strip = self.enhanced_gray[:, self.width - margin_px : self.width]
+
         y_left = self._find_horizon_median(left_strip)
         y_right = self._find_horizon_median(right_strip)
-        
+
         if y_left is None and y_right is None:
             self._substrate_y = int(self.height * 0.8)
             return ((0, self._substrate_y), (self.width, self._substrate_y)), 0.3
-        
+
         if y_left is None:
             y_left = y_right
         if y_right is None:
             y_right = y_left
-        
+
         self._substrate_y = int((y_left + y_right) / 2)
-        
+
         diff = abs(y_left - y_right)
         max_diff = self.height * 0.1
         consistency = max(0.0, 1.0 - diff / max_diff)
         confidence = 0.5 + 0.5 * consistency
-        
+
         substrate_line = ((0, self._substrate_y), (self.width, self._substrate_y))
         return substrate_line, confidence
-    
+
     def _find_horizon_median(self, strip_gray: np.ndarray) -> Optional[int]:
         """Find horizon line in a vertical strip using gradient analysis."""
         detected_ys: List[int] = []
         h, w = strip_gray.shape
         min_limit, max_limit = int(h * 0.05), int(h * 0.95)
-        
+
         for col in range(w):
             col_data = strip_gray[:, col].astype(float)
             grad = np.diff(col_data)
             valid_grad = grad[min_limit:max_limit]
-            
+
             if len(valid_grad) == 0:
                 continue
-            
+
             best_idx = np.argmin(valid_grad)
             best_y = best_idx + min_limit
             detected_ys.append(best_y)
-        
+
         if not detected_ys:
             return None
-        
+
         return int(np.median(detected_ys))
-    
-    def _detect_needle_sessile(self) -> Tuple[Optional[Tuple[int, int, int, int]], float]:
+
+    def _detect_needle_sessile(
+        self,
+    ) -> Tuple[Optional[Tuple[int, int, int, int]], float]:
         """Detect needle region (contour touching top border) for sessile."""
         if self._binary_clean is None:
             return None, 0.0
-        
+
         contours, _ = cv2.findContours(
-            self._binary_clean,
-            cv2.RETR_EXTERNAL,
-            cv2.CHAIN_APPROX_SIMPLE
+            self._binary_clean, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        
+
         if not contours:
             return None, 0.0
-        
+
         for cnt in contours:
             x, y, w, h = cv2.boundingRect(cnt)
-            
+
             if y < 5:
                 self._needle_contour = cnt
                 self._needle_rect = (x, y, w, h)  # Store for drop detection filter
@@ -349,14 +365,18 @@ class AutoCalibrator:
                     confidence = min(1.0, 0.7 + 0.1 * min(aspect_ratio / 5, 3))
                 else:
                     confidence = 0.5
-                
+
                 return (x, y, w, h), confidence
-        
+
         return None, 0.0
-    
-    def _detect_drop_sessile(self) -> Tuple[Optional[np.ndarray], Optional[Tuple[Tuple[int, int], Tuple[int, int]]], float]:
+
+    def _detect_drop_sessile(
+        self,
+    ) -> Tuple[
+        Optional[np.ndarray], Optional[Tuple[Tuple[int, int], Tuple[int, int]]], float
+    ]:
         """Detect drop contour and contact points for sessile.
-        
+
         For sessile drops, the contour must:
             - Be well below the needle (50px gap minimum)
         - Touch the substrate line
@@ -364,57 +384,60 @@ class AutoCalibrator:
         """
         if self._binary_clean is None:
             return None, None, 0.0
-        
+
         contours, _ = cv2.findContours(
-            self._binary_clean,
-            cv2.RETR_EXTERNAL,
-            cv2.CHAIN_APPROX_SIMPLE
+            self._binary_clean, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        
+
         if not contours:
             return None, None, 0.0
-        
+
         center_x = self.width // 2
         min_area = self.image_area * self.min_area_fraction
         substrate_touch_tolerance = 15  # pixels
-        
+
         # Separate contours: those touching substrate vs floating
         substrate_contours = []
         floating_contours = []
-        
+
         for cnt in contours:
             x, y, w, h = cv2.boundingRect(cnt)
             area = cv2.contourArea(cnt)
             top_y = y
             bottom_y = y + h
-            
+
             # Skip very small contours
             if area < min_area:
                 continue
-            
+
             # Skip contours touching image edges (except bottom/substrate)
             if x < 5 or (x + w) > (self.width - 5):
                 continue
-            
+
             # ===== NEEDLE FILTER =====
             # Skip contours too close to needle (pendant drops)
             if self._needle_rect is not None:
                 n_x, n_y, n_w, n_h = self._needle_rect
                 needle_bottom = n_y + n_h
                 needle_center_x = n_x + n_w // 2
-                
+
                 # Sessile drop must start well BELOW needle bottom (50px gap)
                 min_gap_from_needle = 50
                 if top_y < needle_bottom + min_gap_from_needle:
-                    logger.debug(f"Skipping contour near needle (top_y={top_y}, needle_bottom={needle_bottom})")
+                    logger.debug(
+                        f"Skipping contour near needle (top_y={top_y}, needle_bottom={needle_bottom})"
+                    )
                     continue
-                
+
                 # Skip contours horizontally aligned with needle if close to it
                 cnt_center_x = x + w // 2
-                if abs(cnt_center_x - needle_center_x) < n_w and top_y < needle_bottom + 100:
+                if (
+                    abs(cnt_center_x - needle_center_x) < n_w
+                    and top_y < needle_bottom + 100
+                ):
                     logger.debug("Skipping contour aligned with needle")
                     continue
-            
+
             # ===== RECTANGULARITY FILTER =====
             # Skip rectangular contours (likely ROI boundaries, not droplets)
             rect_area = w * h
@@ -422,42 +445,52 @@ class AutoCalibrator:
                 rectangularity = area / rect_area
                 # Perfect rectangle = 1.0, circle/ellipse ≈ 0.78
                 if rectangularity > 0.85:
-                    logger.debug(f"Skipping rectangular contour (rect={rectangularity:.2f})")
+                    logger.debug(
+                        f"Skipping rectangular contour (rect={rectangularity:.2f})"
+                    )
                     continue
-            
+
             # ===== REFLECTION FILTER =====
             # Center must be ABOVE substrate (not a reflection below substrate)
             if self._substrate_y is not None:
                 cnt_cy = y + h // 2
                 if cnt_cy > self._substrate_y:
                     continue
-            
+
             # Calculate metrics for sorting
             cnt_center_x = x + w // 2
             distance_from_center = abs(cnt_center_x - center_x)
-            
+
             # ===== SUBSTRATE CONTACT CHECK =====
             if self._substrate_y is not None:
                 distance_to_substrate = abs(bottom_y - self._substrate_y)
                 touches_substrate = distance_to_substrate <= substrate_touch_tolerance
-                
+
                 if touches_substrate:
-                    substrate_contours.append((cnt, area, distance_from_center, distance_to_substrate))
+                    substrate_contours.append(
+                        (cnt, area, distance_from_center, distance_to_substrate)
+                    )
                 else:
-                    floating_contours.append((cnt, area, distance_from_center, distance_to_substrate))
+                    floating_contours.append(
+                        (cnt, area, distance_from_center, distance_to_substrate)
+                    )
             else:
                 floating_contours.append((cnt, area, distance_from_center, 0))
-        
+
         # Prefer substrate-touching contours
         if substrate_contours:
             # Sort by: closest to substrate, then largest area, then closest to center
             substrate_contours.sort(key=lambda x: (x[3], -x[1], x[2]))
             valid_contours = substrate_contours
-            logger.info(f"Found {len(substrate_contours)} substrate-touching contour(s)")
+            logger.info(
+                f"Found {len(substrate_contours)} substrate-touching contour(s)"
+            )
         elif floating_contours:
             floating_contours.sort(key=lambda x: (-x[1], x[2]))
             valid_contours = floating_contours
-            logger.warning("No substrate-touching contours found, using floating contours")
+            logger.warning(
+                "No substrate-touching contours found, using floating contours"
+            )
         else:
             # No valid contours found after filtering - try fallback
             if contours:
@@ -472,34 +505,43 @@ class AutoCalibrator:
                     return None, None, 0.0
             else:
                 return None, None, 0.0
-        
+
         # Select best contour from valid_contours
         best_cnt = valid_contours[0][0]
         self._drop_contour = best_cnt
-        
+
         hull = cv2.convexHull(best_cnt)
         points = hull[:, 0, :]
-        
+
         if self._substrate_y is not None:
             # Find contact points: leftmost and rightmost points near substrate
             substrate_tolerance = 20  # pixels tolerance for "near substrate"
-            
+
             # Get points that are near the substrate line
-            near_substrate = [pt for pt in points 
-                              if abs(pt[1] - self._substrate_y) <= substrate_tolerance]
-            
+            near_substrate = [
+                pt
+                for pt in points
+                if abs(pt[1] - self._substrate_y) <= substrate_tolerance
+            ]
+
             # Get dome points (above substrate, including boundary points)
             # We accept points up to substrate_tolerance below substrate (handling reflection)
             # but we CLAMP them to the substrate level to ensure a flat baseline.
-            dome_raw = [pt for pt in points if pt[1] <= (self._substrate_y + substrate_tolerance)]
+            dome_raw = [
+                pt
+                for pt in points
+                if pt[1] <= (self._substrate_y + substrate_tolerance)
+            ]
             dome_points = []
             for pt in dome_raw:
                 if pt[1] > self._substrate_y:
                     # Clamp to substrate line
-                    dome_points.append(np.array([pt[0], self._substrate_y], dtype=pt.dtype))
+                    dome_points.append(
+                        np.array([pt[0], self._substrate_y], dtype=pt.dtype)
+                    )
                 else:
                     dome_points.append(pt)
-            
+
             # Find contact points from near_substrate or from the whole contour
             if near_substrate:
                 # Contact points are leftmost and rightmost near substrate
@@ -515,135 +557,135 @@ class AutoCalibrator:
                 # No valid points
                 drop_contour = points.astype(np.float64)
                 return drop_contour, None, 0.4
-            
+
             # Contact points are at the substrate Y level
             cp_left = (int(x_left), self._substrate_y)
             cp_right = (int(x_right), self._substrate_y)
             contact_points = (cp_left, cp_right)
-            
+
             if dome_points:
                 dome_points = sorted(dome_points, key=lambda p: p[0])
-                
+
                 # Build a closed polygon:
-                    # 1. Start at left contact point (on substrate)
+                # 1. Start at left contact point (on substrate)
                 # 2. Trace dome contour from left to right
                 # 3. End at right contact point (on substrate)
                 # 4. Close back to left contact point (the baseline)
                 final_polygon = np.array(
-                    [[x_left, self._substrate_y]] +  # Left contact point
-                    [[p[0], p[1]] for p in dome_points] +  # Dome contour
-                    [[x_right, self._substrate_y]] +  # Right contact point
-                    [[x_left, self._substrate_y]],  # Close polygon back to start
-                    dtype=np.float64
+                    [[x_left, self._substrate_y]]  # Left contact point
+                    + [[p[0], p[1]] for p in dome_points]  # Dome contour
+                    + [[x_right, self._substrate_y]]  # Right contact point
+                    + [[x_left, self._substrate_y]],  # Close polygon back to start
+                    dtype=np.float64,
                 )
             else:
                 # No dome points - use convex hull but add contact points
                 all_pts = sorted(points, key=lambda p: p[0])
                 final_polygon = np.array(
-                    [[x_left, self._substrate_y]] +  # Left contact point
-                    [[p[0], p[1]] for p in all_pts] +  # All contour points
-                    [[x_right, self._substrate_y]] +  # Right contact point
-                    [[x_left, self._substrate_y]],  # Close polygon
-                    dtype=np.float64
+                    [[x_left, self._substrate_y]]  # Left contact point
+                    + [[p[0], p[1]] for p in all_pts]  # All contour points
+                    + [[x_right, self._substrate_y]]  # Right contact point
+                    + [[x_left, self._substrate_y]],  # Close polygon
+                    dtype=np.float64,
                 )
-            
+
             hull_area = cv2.contourArea(hull)
             cnt_area = cv2.contourArea(best_cnt)
             solidity = cnt_area / max(hull_area, 1)
             confidence = min(1.0, solidity + 0.2)
-            
+
             logger.info(f"Contact points detected: left={cp_left}, right={cp_right}")
             return final_polygon, contact_points, confidence
-        
+
         drop_contour = points.astype(np.float64)
         return drop_contour, None, 0.6
-    
+
     # ======================== Pendant Detection Methods ========================
-    
+
     def _find_pendant_drop_contour(self) -> Tuple[Optional[np.ndarray], float]:
         """Find the main drop contour for pendant (largest, centered)."""
         if self._binary_clean is None:
             return None, 0.0
-        
+
         contours, _ = cv2.findContours(
-            self._binary_clean,
-            cv2.RETR_EXTERNAL,
-            cv2.CHAIN_APPROX_SIMPLE
+            self._binary_clean, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        
+
         if not contours:
             return None, 0.0
-        
+
         img_center_x = self.width // 2
         min_area = self.image_area * 0.05  # At least 5% of image
-        
+
         valid_contours = []
         for cnt in contours:
             area = cv2.contourArea(cnt)
             if area < min_area:
                 continue
-            
+
             M = cv2.moments(cnt)
             if M["m00"] != 0:
                 cx = int(M["m10"] / M["m00"])
                 # Must be roughly centered (within 30% of center)
                 if abs(cx - img_center_x) < (self.width * 0.3):
                     valid_contours.append((cnt, area))
-        
+
         if not valid_contours:
             return None, 0.0
-        
+
         # Select largest valid contour
         drop_cnt = max(valid_contours, key=lambda x: x[1])[0]
         self._drop_contour = drop_cnt
-        
+
         # Confidence based on size and centering
         area = cv2.contourArea(drop_cnt)
         area_ratio = area / self.image_area
         confidence = min(1.0, 0.6 + area_ratio * 2)
-        
+
         return drop_cnt, confidence
-    
-    def _detect_needle_pendant(
-        self, drop_cnt: np.ndarray
-    ) -> Tuple[Optional[Tuple[int, int, int, int]], Optional[Tuple[Tuple[int, int], Tuple[int, int]]], float]:
+
+    def _detect_needle_pendant(self, drop_cnt: np.ndarray) -> Tuple[
+        Optional[Tuple[int, int, int, int]],
+        Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
+        float,
+    ]:
         """
         Detect needle region for pendant drop using shaft line analysis.
-        
+
         Finds the vertical shaft lines at the top of the contour, then
         walks down to find where the contour deviates (contact points).
         """
         x, y, w, h = cv2.boundingRect(drop_cnt)
         pts = drop_cnt.reshape(-1, 2)
-        
+
         # Define needle shaft reference (top 20 pixels)
         top_limit = y + 20
-        
+
         # Left shaft line: median X of points in top-left quadrant
-        left_shaft_pts = pts[(pts[:, 1] < top_limit) & (pts[:, 0] < (x + w/2))]
+        left_shaft_pts = pts[(pts[:, 1] < top_limit) & (pts[:, 0] < (x + w / 2))]
         if len(left_shaft_pts) == 0:
             return None, None, 0.0
         ref_x_left = np.median(left_shaft_pts[:, 0])
-        
+
         # Right shaft line: median X of points in top-right quadrant
-        right_shaft_pts = pts[(pts[:, 1] < top_limit) & (pts[:, 0] > (x + w/2))]
+        right_shaft_pts = pts[(pts[:, 1] < top_limit) & (pts[:, 0] > (x + w / 2))]
         if len(right_shaft_pts) == 0:
             return None, None, 0.0
         ref_x_right = np.median(right_shaft_pts[:, 0])
-        
+
         # Tolerance: how many pixels "out" counts as drop starting?
         tolerance = 3
-        
+
         # Create mask for precise scanning
         mask = np.zeros((self.height, self.width), dtype=np.uint8)
         cv2.drawContours(mask, [drop_cnt], -1, 255, 1)
-        
+
         # Find left contact point (where contour moves left of shaft)
         contact_y_left = y
         contact_x_left = int(ref_x_left)
-        
+
         for cy in range(y, y + h):
-            row = mask[cy, 0:int(x + w/2)]  # Left half
+            row = mask[cy, 0 : int(x + w / 2)]  # Left half
             indices = np.where(row > 0)[0]
             if len(indices) > 0:
                 current_x = indices[0]  # Leftmost pixel
@@ -651,101 +693,103 @@ class AutoCalibrator:
                     contact_y_left = cy
                     contact_x_left = current_x
                     break
-        
+
         # Find right contact point (where contour moves right of shaft)
         contact_y_right = y
         contact_x_right = int(ref_x_right)
-        
+
         for cy in range(y, y + h):
-            row = mask[cy, int(x + w/2):self.width]  # Right half
+            row = mask[cy, int(x + w / 2) : self.width]  # Right half
             indices = np.where(row > 0)[0]
             if len(indices) > 0:
-                current_x = indices[-1] + int(x + w/2)  # Rightmost pixel
+                current_x = indices[-1] + int(x + w / 2)  # Rightmost pixel
                 if current_x > (ref_x_right + tolerance):
                     contact_y_right = cy
                     contact_x_right = current_x
                     break
-        
+
         # Needle bottom is the higher of the two contact points
         needle_bottom = min(contact_y_left, contact_y_right)
-        
+
         # Build needle rectangle
         needle_x = int(ref_x_left)
         needle_y = y
         needle_w = int(ref_x_right - ref_x_left)
         needle_h = needle_bottom - y
-        
+
         if needle_w <= 0 or needle_h <= 0:
             return None, None, 0.0
-        
+
         needle_rect = (needle_x, needle_y, needle_w, needle_h)
         contact_points = (
             (contact_x_left, contact_y_left),
-            (contact_x_right, contact_y_right)
+            (contact_x_right, contact_y_right),
         )
-        
+
         # Confidence based on needle aspect ratio
         aspect = needle_h / max(needle_w, 1)
         confidence = min(1.0, 0.6 + 0.1 * min(aspect, 4))
-        
+
         return needle_rect, contact_points, confidence
-    
-    def _detect_apex_pendant(self, drop_cnt: np.ndarray) -> Tuple[Optional[Tuple[int, int]], float]:
+
+    def _detect_apex_pendant(
+        self, drop_cnt: np.ndarray
+    ) -> Tuple[Optional[Tuple[int, int]], float]:
         """Detect apex point (bottom of pendant drop)."""
         pts = drop_cnt.reshape(-1, 2)
-        
+
         # Apex is the point with maximum Y (bottom of drop)
         apex_idx = np.argmax(pts[:, 1])
         apex_pt = pts[apex_idx]
-        
+
         apex = (int(apex_pt[0]), int(apex_pt[1]))
-        
+
         # High confidence - apex is straightforward to find
         return apex, 0.95
-    
+
     def _compute_roi_pendant(
         self, result: CalibrationResult
     ) -> Tuple[Optional[Tuple[int, int, int, int]], float]:
         """Compute ROI for pendant drop (from needle to apex)."""
         if result.drop_contour is None:
             return None, 0.0
-        
+
         contour = np.asarray(result.drop_contour)
         x_min = int(np.min(contour[:, 0]))
         x_max = int(np.max(contour[:, 0]))
         y_min = int(np.min(contour[:, 1]))
         y_max = int(np.max(contour[:, 1]))
-        
+
         # Include apex with padding
         if result.apex_point:
             y_max = max(y_max, result.apex_point[1])
-        
+
         # Apply padding
         pad = self.roi_padding
         x_min = max(0, x_min - pad)
         y_min = max(0, y_min)  # Start from top of drop (needle)
         x_max = min(self.width, x_max + pad)
         y_max = min(self.height, y_max + pad)
-        
+
         roi_width = x_max - x_min
         roi_height = y_max - y_min
-        
+
         if roi_width <= 0 or roi_height <= 0:
             return None, 0.0
-        
+
         return (x_min, y_min, roi_width, roi_height), 0.9
-    
+
     # ======================== Common Methods ========================
-    
+
     def _compute_roi(
         self, result: CalibrationResult
     ) -> Tuple[Optional[Tuple[int, int, int, int]], float]:
         """Compute ROI rectangle encompassing detected regions (sessile)."""
         x_min, y_min = self.width, self.height
         x_max, y_max = 0, 0
-        
+
         has_data = False
-        
+
         if result.drop_contour is not None and len(result.drop_contour) > 0:
             contour = np.asarray(result.drop_contour)
             x_min = min(x_min, int(np.min(contour[:, 0])))
@@ -753,11 +797,11 @@ class AutoCalibrator:
             y_min = min(y_min, int(np.min(contour[:, 1])))
             y_max = max(y_max, int(np.max(contour[:, 1])))
             has_data = True
-        
+
         if result.substrate_line and self._substrate_y is not None:
             y_max = max(y_max, self._substrate_y)
             has_data = True
-        
+
         if result.needle_rect:
             nx, ny, nw, nh = result.needle_rect
             needle_include_y = ny + int(nh * 0.7)
@@ -765,22 +809,22 @@ class AutoCalibrator:
             x_min = min(x_min, nx)
             x_max = max(x_max, nx + nw)
             has_data = True
-        
+
         if not has_data:
             return None, 0.0
-        
+
         pad = self.roi_padding
         x_min = max(0, x_min - pad)
         y_min = max(0, y_min - pad)
         x_max = min(self.width, x_max + pad)
         y_max = min(self.height, y_max + pad)
-        
+
         roi_width = x_max - x_min
         roi_height = y_max - y_min
-        
+
         if roi_width <= 0 or roi_height <= 0:
             return None, 0.0
-        
+
         area_ratio = (roi_width * roi_height) / self.image_area
         if area_ratio < 0.1:
             confidence = 0.5
@@ -788,23 +832,21 @@ class AutoCalibrator:
             confidence = 0.6
         else:
             confidence = 0.9
-        
+
         return (x_min, y_min, roi_width, roi_height), confidence
 
 
 def run_auto_calibration(
-    image: np.ndarray,
-    pipeline_name: str = "sessile",
-    **kwargs
+    image: np.ndarray, pipeline_name: str = "sessile", **kwargs
 ) -> CalibrationResult:
     """
     Convenience function to run auto-calibration.
-    
+
     Args:
         image: Input image (BGR or grayscale)
         pipeline_name: Pipeline type ("sessile", "pendant", etc.)
         **kwargs: Additional parameters for AutoCalibrator
-        
+
     Returns:
         CalibrationResult with detected regions.
     """

--- a/src/menipy/common/contour_smoothing.py
+++ b/src/menipy/common/contour_smoothing.py
@@ -20,28 +20,28 @@ logger = logging.getLogger(__name__)
 
 def filter_monotonic_contour(points: np.ndarray) -> np.ndarray:
     """Filter contour to ensure it is monotonic in X.
-    
+
     If multiple Y values exist for the same X, keep the minimum Y (upper point).
-    
+
     Args:
         points: (N, 2) array of contour points.
-        
+
     Returns:
         Filtered (M, 2) array with unique X values.
     """
     if len(points) < 2:
         return points
-        
+
     sorted_pts = points[np.argsort(points[:, 0])]
     unique_x, indices = np.unique(sorted_pts[:, 0], return_inverse=True)
-    
+
     filtered_points = []
     for i in range(len(unique_x)):
-        mask = (indices == i)
+        mask = indices == i
         y_values = sorted_pts[mask, 1]
         min_y = np.min(y_values)
         filtered_points.append([unique_x[i], min_y])
-        
+
     return np.array(filtered_points)
 
 
@@ -51,15 +51,15 @@ def find_contact_intersections(
     substrate_y: float,
 ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
     """Find left and right contact points as curve-baseline intersections.
-    
+
     Searches for zero-crossings of (y - substrate_y) from both ends
     of the curve and linearly interpolates the crossing point.
-    
+
     Args:
         x: X coordinates (sorted).
         y: Y coordinates.
         substrate_y: Y value of the substrate line.
-        
+
     Returns:
         Tuple of (left_contact, right_contact), each as (x, y) array or None.
     """
@@ -89,21 +89,22 @@ def find_contact_intersections(
         sign = np.sign(d_arr)
         # Find sign changes
         idx = np.where(sign[:-1] * sign[1:] < 0)[0]
-        
+
         if len(idx) == 0:
             return None
 
         i = idx[0]  # First crossing
-        
+
         # Linear interpolation
-        denom = d_arr[i+1] - d_arr[i]
+        denom = d_arr[i + 1] - d_arr[i]
         if denom == 0:
             t = 0.5
         else:
             t = -d_arr[i] / denom
-            
-        x_c = x_arr[i] + t * (x_arr[i+1] - x_arr[i])
+
+        x_c = x_arr[i] + t * (x_arr[i + 1] - x_arr[i])
         return np.array([x_c, substrate_y])
+
     # locate_contact end
 
     left_cp = locate_contact(x, d, from_left=True)
@@ -122,7 +123,7 @@ def smooth_contour(
     extrapolate_contact_points: bool = True,
 ) -> Optional[Dict[str, Any]]:
     """Apply Savitzky-Golay smoothing to a droplet contour.
-    
+
     Args:
         contour_xy: (N, 2) array of contour points.
         substrate_y: Y coordinate of the substrate line.
@@ -130,7 +131,7 @@ def smooth_contour(
         polyorder: Polynomial order for the filter.
         filter_monotonic: If True, ensure one Y per X value.
         filter_below_substrate: If True, remove points below substrate.
-        
+
     Returns:
         Dictionary with smoothing results:
             - x_smooth, y_smooth: Smoothed coordinates
@@ -138,49 +139,51 @@ def smooth_contour(
         - left_contact, right_contact: Contact points (or None)
         - left_slope, right_slope: Tangent slopes at contacts
         - left_angle_deg, right_angle_deg: Contact angles in degrees
-        
+
         Returns None if smoothing fails (too few points, etc.)
     """
     dome_points = contour_xy.copy()
-    
+
     # Filter points below substrate
     if filter_below_substrate:
         mask = dome_points[:, 1] <= substrate_y
         dome_points = dome_points[mask]
-        
+
     if len(dome_points) < 5:
         logger.warning("Too few points for smoothing: %d", len(dome_points))
         return None
-        
+
     if filter_monotonic:
         dome_points = filter_monotonic_contour(dome_points)
-    
+
     # Ensure window is odd
     if window_length % 2 == 0:
         window_length += 1
-    
+
     # Sort by x for monotonic curve
     order = np.argsort(dome_points[:, 0])
     x = dome_points[order, 0].astype(float)
     y = dome_points[order, 1].astype(float)
-    
+
     # Handle cases where window is too large
     if len(x) < window_length:
         window_length = len(x) if len(x) % 2 == 1 else len(x) - 1
-    
+
     if window_length < polyorder + 2:
-        logger.warning("Not enough points for smoothing: %d points, need %d", 
-                      len(x), polyorder + 2)
+        logger.warning(
+            "Not enough points for smoothing: %d points, need %d", len(x), polyorder + 2
+        )
         return None
 
     try:
         y_smooth = savgol_filter(y, window_length=window_length, polyorder=polyorder)
-        y_deriv = savgol_filter(y, window_length=window_length, polyorder=polyorder, 
-                                deriv=1, delta=1.0)
+        y_deriv = savgol_filter(
+            y, window_length=window_length, polyorder=polyorder, deriv=1, delta=1.0
+        )
     except ValueError as e:
         logger.warning("Savgol filter failed: %s", e)
         return None
-    
+
     # Find apex (minimum Y, accounting for flat tops)
     min_y = np.min(y_smooth)
     min_idx = np.where(np.isclose(y_smooth, min_y))[0]
@@ -193,15 +196,14 @@ def smooth_contour(
         apex_x = float(x[apex_idx])
         apex_y = float(y_smooth[apex_idx])
     apex = (apex_x, apex_y)
-    
+
     # Find contact points
     left_contact, right_contact = find_contact_intersections(x, y_smooth, substrate_y)
-    
-    
+
     # Calculate slopes at contact points
     left_slope = 0.0
     right_slope = 0.0
-    
+
     if left_contact is not None:
         idx_l = np.argmin(np.abs(x - left_contact[0]))
         left_slope = float(y_deriv[idx_l])
@@ -234,124 +236,137 @@ def smooth_contour(
         else:
             right_contact = np.array([x[-1], y_smooth[-1]])
             right_slope = float(y_deriv[-1])
-            
+
     # --- Extrapolation Logic ---
     if extrapolate_contact_points:
         # Left Extrapolation
         if left_contact is not None:
             dist_y = substrate_y - left_contact[1]
-            is_floating = dist_y > 1.0 
+            is_floating = dist_y > 1.0
             is_flat = abs(left_slope) < 0.2
-            
+
             if is_floating or is_flat:
                 target_y_start = left_contact[1] - 5
                 target_y_end = left_contact[1] - 20
-                mask = (x <= apex[0]) & (y_smooth < target_y_start) & (y_smooth > target_y_end)
+                mask = (
+                    (x <= apex[0])
+                    & (y_smooth < target_y_start)
+                    & (y_smooth > target_y_end)
+                )
                 if np.sum(mask) > 3:
                     region_slopes = y_deriv[mask]
                     region_x = x[mask]
                     region_y = y_smooth[mask]
-                    anchor_idx = np.argmax(region_y) 
+                    anchor_idx = np.argmax(region_y)
                     anchor_x = region_x[anchor_idx]
                     anchor_y = region_y[anchor_idx]
                     anchor_slope = region_slopes[anchor_idx]
-                    
+
                     if abs(anchor_slope) > 0.05:
                         new_x = anchor_x + (substrate_y - anchor_y) / anchor_slope
-                        logger.debug(f"Extrapolating Left CP: Old=({left_contact[0]:.1f}, {left_contact[1]:.1f}) -> New=({new_x:.1f}, {substrate_y})")
+                        logger.debug(
+                            f"Extrapolating Left CP: Old=({left_contact[0]:.1f}, {left_contact[1]:.1f}) -> New=({new_x:.1f}, {substrate_y})"
+                        )
                         left_contact = np.array([new_x, float(substrate_y)])
                         left_slope = float(anchor_slope)
 
         # Right Extrapolation
         if right_contact is not None:
             dist_y = substrate_y - right_contact[1]
-            is_floating = dist_y > 1.0 
+            is_floating = dist_y > 1.0
             is_flat = abs(right_slope) < 0.2
             if is_floating or is_flat:
                 target_y_start = right_contact[1] - 5
                 target_y_end = right_contact[1] - 20
-                mask = (x >= apex[0]) & (y_smooth < target_y_start) & (y_smooth > target_y_end)
+                mask = (
+                    (x >= apex[0])
+                    & (y_smooth < target_y_start)
+                    & (y_smooth > target_y_end)
+                )
                 if np.sum(mask) > 3:
                     region_slopes = y_deriv[mask]
                     region_x = x[mask]
                     region_y = y_smooth[mask]
-                    anchor_idx = np.argmax(region_y) 
+                    anchor_idx = np.argmax(region_y)
                     anchor_x = region_x[anchor_idx]
                     anchor_y = region_y[anchor_idx]
                     anchor_slope = region_slopes[anchor_idx]
                     if abs(anchor_slope) > 0.05:
                         new_x = anchor_x + (substrate_y - anchor_y) / anchor_slope
-                        logger.debug(f"Extrapolating Right CP: Old=({right_contact[0]:.1f}, {right_contact[1]:.1f}) -> New=({new_x:.1f}, {substrate_y})")
+                        logger.debug(
+                            f"Extrapolating Right CP: Old=({right_contact[0]:.1f}, {right_contact[1]:.1f}) -> New=({new_x:.1f}, {substrate_y})"
+                        )
                         right_contact = np.array([new_x, float(substrate_y)])
                         right_slope = float(anchor_slope)
 
-    
     # Calculate contact angles from slopes
     # For left side: slope is typically negative (curve going up), angle = atan(|slope|)
     # For right side: slope is typically positive, angle = atan(|slope|)
     left_angle_deg = float(np.degrees(np.arctan(abs(left_slope))))
     right_angle_deg = float(np.degrees(np.arctan(abs(right_slope))))
-    
+
     return {
-        'x_smooth': x,
-        'y_smooth': y_smooth,
-        'apex': apex,
-        'left_contact': left_contact,
-        'right_contact': right_contact,
-        'left_slope': left_slope,
-        'right_slope': right_slope,
-        'left_angle_deg': left_angle_deg,
-        'right_angle_deg': right_angle_deg,
+        "x_smooth": x,
+        "y_smooth": y_smooth,
+        "apex": apex,
+        "left_contact": left_contact,
+        "right_contact": right_contact,
+        "left_slope": left_slope,
+        "right_slope": right_slope,
+        "left_angle_deg": left_angle_deg,
+        "right_angle_deg": right_angle_deg,
     }
 
 
 def run(ctx: Context, settings=None) -> Context:
     """Apply contour smoothing as a pipeline stage.
-    
+
     Reads contour from ctx.contour and substrate line from ctx.substrate_line,
     applies Savgol smoothing, and stores results in ctx.smoothing_results.
-    
+
     Args:
         ctx: Pipeline context.
         settings: ContourSmoothingSettings or None (uses defaults).
-        
+
     Returns:
         Updated context with smoothing_results dict.
     """
     # Import here to avoid circular imports
     from menipy.models.config import ContourSmoothingSettings
-    
+
     if settings is None:
         settings = ContourSmoothingSettings()
-    
+
     if not settings.enabled:
         return ctx
-    
+
     # Get contour
-    contour = getattr(ctx, 'contour', None)
+    contour = getattr(ctx, "contour", None)
     if contour is None or contour.xy is None:
         logger.warning("No contour available for smoothing")
         return ctx
-        
+
     contour_xy = np.asarray(contour.xy)
     if contour_xy.size == 0:
         logger.warning("Empty contour, skipping smoothing")
         return ctx
-    
+
     # Get substrate Y from substrate_line
-    substrate_line = getattr(ctx, 'substrate_line', None)
+    substrate_line = getattr(ctx, "substrate_line", None)
     if substrate_line is None:
         # Fallback to baseline_y from geometry
-        geometry = getattr(ctx, 'geometry', None)
-        if geometry and getattr(geometry, 'baseline_y', None):
+        geometry = getattr(ctx, "geometry", None)
+        if geometry and getattr(geometry, "baseline_y", None):
             substrate_y = geometry.baseline_y
         else:
             substrate_y = float(np.max(contour_xy[:, 1]))
-            logger.info("No substrate line found, using max Y as baseline: %.1f", substrate_y)
+            logger.info(
+                "No substrate line found, using max Y as baseline: %.1f", substrate_y
+            )
     else:
         p1, p2 = substrate_line
         substrate_y = float((p1[1] + p2[1]) / 2)
-    
+
     # Apply smoothing
     result = smooth_contour(
         contour_xy,
@@ -362,14 +377,18 @@ def run(ctx: Context, settings=None) -> Context:
         filter_below_substrate=settings.filter_below_substrate,
         extrapolate_contact_points=settings.extrapolate_contact_points,
     )
-    
+
     if result is not None:
         ctx.smoothing_results = result
-        logger.info("Contour smoothing applied: apex=(%.1f, %.1f), angles L=%.1f° R=%.1f°",
-                   result['apex'][0], result['apex'][1],
-                   result['left_angle_deg'], result['right_angle_deg'])
+        logger.info(
+            "Contour smoothing applied: apex=(%.1f, %.1f), angles L=%.1f° R=%.1f°",
+            result["apex"][0],
+            result["apex"][1],
+            result["left_angle_deg"],
+            result["right_angle_deg"],
+        )
     else:
         ctx.smoothing_results = None
         logger.warning("Contour smoothing failed")
-    
+
     return ctx

--- a/src/menipy/common/detection_helpers.py
+++ b/src/menipy/common/detection_helpers.py
@@ -5,6 +5,7 @@ This module provides pipeline-agnostic helper functions that use the
 detection plugins to automatically detect ROI, needle, drop, and other
 features from images.
 """
+
 from __future__ import annotations
 
 import logging
@@ -20,15 +21,17 @@ logger = logging.getLogger(__name__)
 try:
     import sys
     from pathlib import Path
+
     plugins_dir = Path(__file__).parent.parent.parent.parent / "plugins"
     if plugins_dir.exists() and str(plugins_dir) not in sys.path:
         sys.path.insert(0, str(plugins_dir))
-    
+
     import detect_needle
     import detect_roi
     import detect_substrate
     import detect_drop
     import detect_apex
+
     _PLUGINS_LOADED = True
 except ImportError as e:
     logger.warning(f"Detection plugins not available: {e}")
@@ -60,16 +63,16 @@ def auto_detect_features(
 ) -> Dict[str, Any]:
     """
     Run automatic feature detection for a pipeline.
-    
+
     Args:
         image: Input image (BGR or grayscale)
         pipeline: Pipeline name ("sessile" or "pendant")
         detect_*: Flags to enable/disable specific detections
-        
+
     Returns:
         Dictionary with detected features:
             - needle_rect: (x, y, w, h) or None
-        - substrate_line: ((x1, y1), (x2, y2)) or None  
+        - substrate_line: ((x1, y1), (x2, y2)) or None
         - drop_contour: Nx2 array or None
         - contact_points: ((left), (right)) or None
         - apex_point: (x, y) or None
@@ -78,10 +81,10 @@ def auto_detect_features(
     if not plugins_available():
         logger.warning("Detection plugins not loaded")
         return {}
-    
+
     results: Dict[str, Any] = {}
     pipeline = pipeline.lower()
-    
+
     # 1. Detect substrate (sessile only)
     substrate_y = None
     if detect_substrate and pipeline == "sessile":
@@ -91,27 +94,33 @@ def auto_detect_features(
                 results["substrate_line"] = substrate_line
                 # Extract Y for other detections
                 substrate_y = int((substrate_line[0][1] + substrate_line[1][1]) / 2)
-    
+
     # 2. Detect needle
     if detect_needle:
         detector_name = pipeline if pipeline in NEEDLE_DETECTORS else "sessile"
         if detector_name in NEEDLE_DETECTORS:
             needle_result = NEEDLE_DETECTORS[detector_name](image)
             if needle_result:
-                if pipeline == "pendant" and isinstance(needle_result, tuple) and len(needle_result) == 2:
+                if (
+                    pipeline == "pendant"
+                    and isinstance(needle_result, tuple)
+                    and len(needle_result) == 2
+                ):
                     # Pendant returns (needle_rect, contact_points)
                     results["needle_rect"] = needle_result[0]
                     results["contact_points"] = needle_result[1]
                 else:
                     results["needle_rect"] = needle_result
-    
+
     # 3. Detect drop contour
     drop_contour = None
     if detect_drop:
         detector_name = pipeline if pipeline in DROP_DETECTORS else "sessile"
         if detector_name in DROP_DETECTORS:
             if pipeline == "sessile":
-                drop_result = DROP_DETECTORS[detector_name](image, substrate_y=substrate_y)
+                drop_result = DROP_DETECTORS[detector_name](
+                    image, substrate_y=substrate_y
+                )
                 if drop_result:
                     if isinstance(drop_result, tuple) and len(drop_result) == 2:
                         drop_contour, contact_pts = drop_result
@@ -125,19 +134,21 @@ def auto_detect_features(
                 drop_contour = DROP_DETECTORS[detector_name](image)
                 if drop_contour is not None:
                     results["drop_contour"] = drop_contour
-    
+
     # 4. Detect apex
     apex_point = None
     if detect_apex and drop_contour is not None:
         detector_name = pipeline if pipeline in APEX_DETECTORS else "auto"
         if detector_name in APEX_DETECTORS:
             if pipeline == "sessile":
-                apex_point = APEX_DETECTORS[detector_name](drop_contour, substrate_y=substrate_y)
+                apex_point = APEX_DETECTORS[detector_name](
+                    drop_contour, substrate_y=substrate_y
+                )
             else:
                 apex_point = APEX_DETECTORS[detector_name](drop_contour)
             if apex_point:
                 results["apex_point"] = apex_point
-    
+
     # 5. Detect ROI
     if detect_roi:
         detector_name = pipeline if pipeline in ROI_DETECTORS else "auto"
@@ -154,11 +165,11 @@ def auto_detect_features(
                     "drop_contour": results.get("drop_contour"),
                     "apex_point": results.get("apex_point"),
                 }
-            
+
             roi_rect = ROI_DETECTORS[detector_name](image, **roi_kwargs)
             if roi_rect:
                 results["roi_rect"] = roi_rect
-    
+
     logger.info(f"Auto-detected features for {pipeline}: {list(results.keys())}")
     return results
 
@@ -169,16 +180,16 @@ def apply_roi_crop(
 ) -> np.ndarray:
     """
     Crop image to ROI region.
-    
+
     Args:
         image: Input image
         roi_rect: (x, y, width, height)
-        
+
     Returns:
         Cropped image.
     """
     x, y, w, h = roi_rect
-    return image[y:y+h, x:x+w].copy()
+    return image[y : y + h, x : x + w].copy()
 
 
 def adjust_coordinates_for_roi(
@@ -187,11 +198,11 @@ def adjust_coordinates_for_roi(
 ) -> np.ndarray:
     """
     Adjust point coordinates for ROI offset.
-    
+
     Args:
         points: Nx2 array of (x, y) coordinates
         roi_rect: (x, y, width, height)
-        
+
     Returns:
         Adjusted points with ROI offset subtracted.
     """
@@ -202,7 +213,7 @@ def adjust_coordinates_for_roi(
 
 
 # -----------------------------------------------------------------------------
-# Shared Edge Detection Helpers 
+# Shared Edge Detection Helpers
 # -----------------------------------------------------------------------------
 # Re-exporting from image_utils for backward compatibility if needed
 # (though ideally consumers should import from image_utils directly)

--- a/src/menipy/common/edge_detection.py
+++ b/src/menipy/common/edge_detection.py
@@ -42,7 +42,7 @@ def _load_plugin(name: str) -> Optional[Callable]:
 
 
 # -------- helpers --------
-# Helpers _ensure_gray and _edges_to_xy are kept for potential backward 
+# Helpers _ensure_gray and _edges_to_xy are kept for potential backward
 # compatibility but we prefer using the ones from detection_helpers.
 _ensure_gray = ensure_gray
 _edges_to_xy = edges_to_xy
@@ -54,13 +54,13 @@ def _fallback_canny(img: np.ndarray, settings: EdgeDetectionSettings) -> np.ndar
     canny_fn = EDGE_DETECTORS.get("canny")
     if canny_fn:
         return canny_fn(img, settings)
-    
+
     # Minimal hardcoded fallback if registry is empty
     g = ensure_gray(img)
     # Simple threshold around median
     v = float(np.median(g))
     edges = np.asarray((g > v).astype(np.uint8) * 255, dtype=np.uint8)
-    
+
     return edges_to_xy(edges, settings.min_contour_length, settings.max_contour_length)
 
 

--- a/src/menipy/common/geometry.py
+++ b/src/menipy/common/geometry.py
@@ -244,7 +244,9 @@ def detect_baseline_ransac(
             vec_to_points = candidates - p1
             dists = np.abs(np.cross(vec_to_points, unit_vec))
             inlier_count = int(np.sum(dists <= threshold))
-            confidence = float(inlier_count) / len(candidates) if len(candidates) > 0 else 0.0
+            confidence = (
+                float(inlier_count) / len(candidates) if len(candidates) > 0 else 0.0
+            )
 
     return p1, p2, confidence
 
@@ -351,9 +353,7 @@ def refine_apex_curvature(
                 ratio = peak_kappa / (mean_kappa + 1e-6)
                 # Scale ratio conservatively so flat contours yield moderate confidence
                 # and strong curvature peaks yield higher confidence up to ~0.99.
-                confidence = float(
-                    min(0.99, 0.5 + 0.5 * min(ratio / 5.0, 1.0))
-                )
+                confidence = float(min(0.99, 0.5 + 0.5 * min(ratio / 5.0, 1.0)))
 
     return apex, confidence
 
@@ -499,11 +499,7 @@ def _contact_branch_points(
     for factor in (1.0, 1.5, 2.0, 3.0):
         radius = float(window_px) * factor
         distances = np.linalg.norm(rel_all, axis=1)
-        mask = (
-            (distances <= radius)
-            & (h_all > 0.5)
-            & ((s_all * inward_sign) >= -1.0)
-        )
+        mask = (distances <= radius) & (h_all > 0.5) & ((s_all * inward_sign) >= -1.0)
         local_points = contour_2d[mask]
         if local_points.shape[0] >= 3:
             return local_points, substrate_vec, normal_vec

--- a/src/menipy/common/image_utils.py
+++ b/src/menipy/common/image_utils.py
@@ -1,4 +1,5 @@
 """Shared image processing utilities."""
+
 from __future__ import annotations
 import numpy as np
 
@@ -12,11 +13,11 @@ def ensure_gray(img: np.ndarray) -> np.ndarray:
     """Ensure image is grayscale."""
     if img.ndim == 2:
         return img
-    
+
     # Try using cv2 first
     if cv2 is not None and img.ndim == 3 and img.shape[2] == 3:
         return cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-        
+
     # Fallback to simple luminance
     if img.ndim == 3:
         return (0.114 * img[..., 0] + 0.587 * img[..., 1] + 0.299 * img[..., 2]).astype(
@@ -33,7 +34,7 @@ def edges_to_xy(
     """Convert a binary edges mask to an (N,2) contour array (largest external contour)."""
     if edges is None:
         return np.empty((0, 2), float)
-    
+
     if cv2 is None:
         # Simple fallback if no OpenCV
         ys, xs = np.nonzero(edges)
@@ -41,16 +42,16 @@ def edges_to_xy(
             return np.empty((0, 2), float)
         xy = np.column_stack([xs, ys]).astype(float)
         return xy
-    
+
     contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
     if not contours:
         return np.empty((0, 2), float)
-    
+
     # Filter by length
     valid_cnts = [c for c in contours if min_len <= len(c) <= max_len]
     if not valid_cnts:
         return np.empty((0, 2), float)
-    
+
     # Select largest by area
     c = max(valid_cnts, key=cv2.contourArea)
     xy = c.reshape(-1, 2).astype(float)

--- a/src/menipy/common/material_db.py
+++ b/src/menipy/common/material_db.py
@@ -3,6 +3,7 @@ Material Database
 
 SQLite database abstraction for managing materials, needles, and syringes.
 """
+
 from __future__ import annotations
 import sqlite3
 import json
@@ -16,13 +17,13 @@ DB_DEFAULT = Path("./menipy_materials.sqlite")
 class MaterialDB:
     """
     Database for storing material properties and equipment specifications.
-    
+
     Tables:
         - materials: Liquids, gases, solids with density and other properties
     - needles: Needle specifications (gauge, diameter)
     - syringes: Syringe specifications (volume, diameter)
     """
-    
+
     def __init__(self, db_path: Path = DB_DEFAULT):
         self.db_path = Path(db_path)
 
@@ -35,7 +36,7 @@ class MaterialDB:
 
     def init_schema(self) -> None:
         """Initialize the database schema."""
-        
+
         # Materials table
         ddl_materials = """
         CREATE TABLE IF NOT EXISTS materials (
@@ -52,7 +53,7 @@ class MaterialDB:
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
         """
-        
+
         # Needles table
         ddl_needles = """
         CREATE TABLE IF NOT EXISTS needles (
@@ -67,7 +68,7 @@ class MaterialDB:
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
         """
-        
+
         # Syringes table
         ddl_syringes = """
         CREATE TABLE IF NOT EXISTS syringes (
@@ -82,34 +83,48 @@ class MaterialDB:
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
         """
-        
+
         with self.connect() as con:
             con.executescript(ddl_materials)
             con.executescript(ddl_needles)
             con.executescript(ddl_syringes)
-            
+
             # Seed default data if empty
             self._seed_defaults(con)
 
     def _seed_defaults(self, con: sqlite3.Connection):
         """Seed default data if tables are empty."""
-        
+
         # Check if materials exist
         count = con.execute("SELECT count(*) FROM materials").fetchone()[0]
         if count == 0:
             defaults = [
-                ("Water (20°C)", "liquid", 998.2, 1.002, 72.8, "Standard water at 20°C"),
-                ("Water (25°C)", "liquid", 997.0, 0.890, 72.0, "Standard water at 25°C"),
+                (
+                    "Water (20°C)",
+                    "liquid",
+                    998.2,
+                    1.002,
+                    72.8,
+                    "Standard water at 20°C",
+                ),
+                (
+                    "Water (25°C)",
+                    "liquid",
+                    997.0,
+                    0.890,
+                    72.0,
+                    "Standard water at 25°C",
+                ),
                 ("Air (20°C)", "gas", 1.204, None, None, "Standard air"),
                 ("Ethanol", "liquid", 789.0, 1.2, 22.3, "Pure Ethanol"),
                 ("Hexadecane", "liquid", 773.0, 3.34, 27.5, "n-Hexadecane"),
                 ("Glycerol", "liquid", 1261.0, 1412, 64.0, "Pure Glycerol"),
             ]
-            
+
             for name, mtype, density, visc, st, desc in defaults:
                 con.execute(
                     "INSERT INTO materials (name, type, density, viscosity, surface_tension, description) VALUES (?, ?, ?, ?, ?, ?)",
-                    (name, mtype, density, visc, st, desc)
+                    (name, mtype, density, visc, st, desc),
                 )
 
         # Check if needles exist
@@ -130,16 +145,18 @@ class MaterialDB:
             for name, gauge, od, id_ in presets:
                 con.execute(
                     "INSERT INTO needles (name, gauge, outer_diameter, inner_diameter) VALUES (?, ?, ?, ?)",
-                    (name, gauge, od, id_)
+                    (name, gauge, od, id_),
                 )
 
     # -------------------------------------------------------------------------
     # Materials Operations
     # -------------------------------------------------------------------------
-    
+
     def get_material(self, name: str) -> Optional[Dict[str, Any]]:
         with self.connect() as con:
-            row = con.execute("SELECT * FROM materials WHERE name=?", (name,)).fetchone()
+            row = con.execute(
+                "SELECT * FROM materials WHERE name=?", (name,)
+            ).fetchone()
             return dict(row) if row else None
 
     def list_materials(self, mtype: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -149,25 +166,35 @@ class MaterialDB:
             query += " WHERE type=?"
             params.append(mtype)
         query += " ORDER BY name"
-        
+
         with self.connect() as con:
             rows = con.execute(query, params).fetchall()
             return [dict(row) for row in rows]
-            
+
     def upsert_material(self, name: str, data: Dict[str, Any]) -> int:
         """Insert or update a material. Returns row ID."""
-        keys = ["type", "density", "viscosity", "surface_tension", "description", "metadata", "is_favorite"]
+        keys = [
+            "type",
+            "density",
+            "viscosity",
+            "surface_tension",
+            "description",
+            "metadata",
+            "is_favorite",
+        ]
         valid_data = {k: data.get(k) for k in keys if k in data}
-        
-        if "metadata" in valid_data and isinstance(valid_data["metadata"], (dict, list)):
+
+        if "metadata" in valid_data and isinstance(
+            valid_data["metadata"], (dict, list)
+        ):
             valid_data["metadata"] = json.dumps(valid_data["metadata"])
-            
+
         columns = ", ".join(valid_data.keys())
         placeholders = ", ".join(["?"] * len(valid_data))
         updates = ", ".join([f"{k}=Excluded.{k}" for k in valid_data.keys()])
-        
+
         values = list(valid_data.values())
-        
+
         sql = f"""
         INSERT INTO materials (name, {columns}) 
         VALUES (?, {placeholders})
@@ -175,7 +202,7 @@ class MaterialDB:
             {updates},
             updated_at=CURRENT_TIMESTAMP
         """
-        
+
         with self.connect() as con:
             cur = con.execute(sql, [name] + values)
             return cur.lastrowid
@@ -191,23 +218,25 @@ class MaterialDB:
     # -------------------------------------------------------------------------
     # Needles Operations
     # -------------------------------------------------------------------------
-    
+
     def list_needles(self) -> List[Dict[str, Any]]:
         with self.connect() as con:
-            rows = con.execute("SELECT * FROM needles ORDER BY outer_diameter DESC").fetchall()
+            rows = con.execute(
+                "SELECT * FROM needles ORDER BY outer_diameter DESC"
+            ).fetchall()
             return [dict(row) for row in rows]
-            
+
     def upsert_needle(self, name: str, outer_diameter: float, **kwargs) -> int:
         keys = ["gauge", "inner_diameter", "description", "is_favorite"]
         valid_data = {k: kwargs.get(k) for k in keys if k in kwargs}
         valid_data["outer_diameter"] = outer_diameter
-        
+
         columns = ", ".join(valid_data.keys())
         placeholders = ", ".join(["?"] * len(valid_data))
         updates = ", ".join([f"{k}=Excluded.{k}" for k in valid_data.keys()])
-        
+
         values = list(valid_data.values())
-        
+
         sql = f"""
         INSERT INTO needles (name, {columns}) 
         VALUES (?, {placeholders})
@@ -215,15 +244,15 @@ class MaterialDB:
             {updates},
             updated_at=CURRENT_TIMESTAMP
         """
-        
+
         with self.connect() as con:
             cur = con.execute(sql, [name] + values)
             return cur.lastrowid
-            
+
     # -------------------------------------------------------------------------
     # Syringes Operations
     # -------------------------------------------------------------------------
-    
+
     def list_syringes(self) -> List[Dict[str, Any]]:
         """list syringes.
 

--- a/src/menipy/common/optimization.py
+++ b/src/menipy/common/optimization.py
@@ -1,5 +1,6 @@
 # src/menipy/common/optimization.py
 """Optimization stage utilities for refining solver results."""
+
 from __future__ import annotations
 
 

--- a/src/menipy/common/outputs.py
+++ b/src/menipy/common/outputs.py
@@ -1,5 +1,6 @@
 # src/menipy/common/outputs.py
 """Output formatting and normalization for pipeline results."""
+
 from __future__ import annotations
 
 

--- a/src/menipy/common/overlay.py
+++ b/src/menipy/common/overlay.py
@@ -1,5 +1,6 @@
 # src/menipy/common/overlay.py
 """Overlay drawing utilities for visualizing analysis results on images."""
+
 from __future__ import annotations
 from typing import Iterable, Tuple, Union, Dict, Any
 import numpy as np
@@ -90,7 +91,9 @@ def draw_overlay(
             cv2.line(overlay, p1, p2, color, th, lineType=cv2.LINE_AA)
 
         elif typ == "polyline":
-            pts_poly: np.ndarray = np.asarray(cmd["points"], dtype=np.int32).reshape(-1, 1, 2)
+            pts_poly: np.ndarray = np.asarray(cmd["points"], dtype=np.int32).reshape(
+                -1, 1, 2
+            )
             color = _bgr(cmd.get("color", "yellow"))
             th = int(cmd.get("thickness", 2))
             closed = bool(cmd.get("closed", True))
@@ -129,7 +132,9 @@ def draw_overlay(
             cv2.circle(overlay, c, r, color, th, cv2.LINE_AA)
 
         elif typ == "scatter":
-            pts_scatter: np.ndarray = np.asarray(cmd["points"], dtype=int).reshape(-1, 2)
+            pts_scatter: np.ndarray = np.asarray(cmd["points"], dtype=int).reshape(
+                -1, 2
+            )
             color = _bgr(cmd.get("color", "white"))
             r = int(cmd.get("radius", 2))
             th = int(cmd.get("thickness", -1))

--- a/src/menipy/common/physics.py
+++ b/src/menipy/common/physics.py
@@ -1,5 +1,6 @@
 # src/menipy/common/physics.py
 """Physics constants and parameter management."""
+
 from __future__ import annotations
 
 

--- a/src/menipy/common/plugin_db.py
+++ b/src/menipy/common/plugin_db.py
@@ -235,12 +235,10 @@ class PluginDB:
         import json
 
         with self.connect() as con:
-            rows = con.execute(
-                """
+            rows = con.execute("""
             SELECT pipeline_name, display_name, icon, color, stages, calibration_params, primary_metrics
             FROM pipeline_metadata ORDER BY display_name
-            """
-            ).fetchall()
+            """).fetchall()
 
             result = []
             for row in rows:

--- a/src/menipy/common/plugin_loader.py
+++ b/src/menipy/common/plugin_loader.py
@@ -101,13 +101,18 @@ from menipy.common import plugins
 
 from typing import Optional
 
-def get_solver(name: str, fallback: Optional[Callable[..., Any]] = None) -> Optional[Callable[..., Any]]:
+
+def get_solver(
+    name: str, fallback: Optional[Callable[..., Any]] = None
+) -> Optional[Callable[..., Any]]:
     """Get a solver by name from the registry (ensures plugins are loaded first)."""
     plugins.ensure_loaded()
     return registry.SOLVERS.get(name, fallback)
 
 
-def get_edge_detector(name: str, fallback: Optional[Callable[..., Any]] = None) -> Optional[Callable[..., Any]]:
+def get_edge_detector(
+    name: str, fallback: Optional[Callable[..., Any]] = None
+) -> Optional[Callable[..., Any]]:
     """Get an edge detector by name from the registry (ensures plugins are loaded first)."""
     plugins.ensure_loaded()
     return registry.EDGE_DETECTORS.get(name, fallback)

--- a/src/menipy/common/plugin_settings.py
+++ b/src/menipy/common/plugin_settings.py
@@ -4,6 +4,7 @@ Infrastructure for plugin-specific configuration settings.
 This module provides the registry and base classes for plugins to define their own
 settings models, decoupling them from the core configuration.
 """
+
 from __future__ import annotations
 
 from typing import Dict, Any, Type, Optional
@@ -27,27 +28,25 @@ def get_detector_settings_model(name: str) -> Optional[Type[BaseModel]]:
 
 
 def resolve_plugin_settings(
-    method: str,
-    generic_settings: Dict[str, Any],
-    **kwargs
+    method: str, generic_settings: Dict[str, Any], **kwargs
 ) -> Dict[str, Any]:
     """
     Resolve settings for a specific plugin method.
-    
+
     Tries to find a registered settings model for the method and validates
     the provided generic settings against it.
-    
+
     Args:
         method: The plugin method name (e.g. "log")
         generic_settings: Dictionary of generic/plugin-specific settings (from config)
         **kwargs: Additional overrides
-        
+
     Returns:
         Dictionary of validated settings
     """
     merged = generic_settings.copy()
     merged.update(kwargs)
-    
+
     model_cls = get_detector_settings_model(method)
     if model_cls:
         try:
@@ -59,5 +58,5 @@ def resolve_plugin_settings(
             # If validation fails, fallback to returning the unvalidated dict
             # or we could log a warning here.
             pass
-            
+
     return merged

--- a/src/menipy/common/plugins.py
+++ b/src/menipy/common/plugins.py
@@ -11,7 +11,6 @@ from .registry import register_edge, register_pendant_approximator, register_sol
 from .plugin_db import PluginDB
 from ._module_loader import load_module_from_path
 
-
 _loaded = False
 
 
@@ -42,8 +41,16 @@ def _register_from_module(mod) -> None:
     _plugin_types = [
         ("EDGE_DETECTORS", "get_edge_detectors", _reg.register_edge),
         ("SOLVERS", "get_solvers", _reg.register_solver),
-        ("PENDANT_APPROXIMATORS", "get_pendant_approximators", _reg.register_pendant_approximator),
-        ("ACQUISITIONS", "get_acquisitions", getattr(_reg, "register_acquisition", None)),
+        (
+            "PENDANT_APPROXIMATORS",
+            "get_pendant_approximators",
+            _reg.register_pendant_approximator,
+        ),
+        (
+            "ACQUISITIONS",
+            "get_acquisitions",
+            getattr(_reg, "register_acquisition", None),
+        ),
         ("OPTIMIZERS", "get_optimizers", getattr(_reg, "register_optimizer", None)),
         ("PHYSICS", "get_physics", getattr(_reg, "register_physics", None)),
         ("OUTPUTS", "get_outputs", getattr(_reg, "register_output", None)),
@@ -98,7 +105,7 @@ def discover_into_db(db: PluginDB, plugin_dirs: Iterable[Path]) -> int:
         for path in d.glob("*.py"):
             # naive introspection: prefer filename as name
             name = path.stem
-            
+
             # Detect kind by filename keywords
             if "approximator" in name or "approximation" in name:
                 kind = "pendant_approximator"
@@ -113,7 +120,7 @@ def discover_into_db(db: PluginDB, plugin_dirs: Iterable[Path]) -> int:
             elif "drop" in name and "detect" in name:
                 kind = "drop_detector"
             elif "apex" in name:
-                 kind = "apex_detector"
+                kind = "apex_detector"
             elif "edge" in name:
                 kind = "edge"
             else:
@@ -134,7 +141,7 @@ def discover_into_db(db: PluginDB, plugin_dirs: Iterable[Path]) -> int:
 def load_active_plugins(db: PluginDB) -> int:
     """Load all ACTIVE plugins from SQLite and register them in the in-memory registry."""
     count = 0
-    
+
     # helper to load a single plugin row
     def _load_plugin(row):
         """_load_plugin."""
@@ -148,14 +155,17 @@ def load_active_plugins(db: PluginDB) -> int:
             if not p.exists():
                 raise FileNotFoundError(str(p))
 
-            mod_name = f"menipy_plugins.{name}" # Use consistent module naming
+            mod_name = f"menipy_plugins.{name}"  # Use consistent module naming
             mod = load_module_from_path(p, mod_name)
             _register_from_module(mod)
             return True
         except Exception as exc:
             logging.error(
                 "Failed to load %s plugin '%s' from %s: %s",
-                kind, name, file_path, exc,
+                kind,
+                name,
+                file_path,
+                exc,
             )
             return False
 
@@ -172,9 +182,9 @@ def discover_and_load_from_db(
     db: PluginDB, *, settings_key: str = "plugin_dirs"
 ) -> int:
     """Placeholder docstring for discover_and_load_from_db.
-    
+
     TODO: Complete docstring with full description.
-    
+
     Returns
     -------
     type

--- a/src/menipy/common/preprocessing.py
+++ b/src/menipy/common/preprocessing.py
@@ -86,9 +86,17 @@ def run(
 
     # --- Finalize context with results ---
     # --- Finalize context with results ---
-    ctx.preprocessed_state = state.model_dump() if hasattr(state, "model_dump") else state
-    ctx.preprocessed_settings = resolved_settings.model_dump() if hasattr(resolved_settings, "model_dump") else resolved_settings
-    ctx.preprocessed_history = [record.model_dump() for record in getattr(state, "history", [])]
+    ctx.preprocessed_state = (
+        state.model_dump() if hasattr(state, "model_dump") else state
+    )
+    ctx.preprocessed_settings = (
+        resolved_settings.model_dump()
+        if hasattr(resolved_settings, "model_dump")
+        else resolved_settings
+    )
+    ctx.preprocessed_history = [
+        record.model_dump() for record in getattr(state, "history", [])
+    ]
     # Make `preprocessed_roi` reflect what is actually present in the
     # composed full image when possible so tests that compare the two see
     # identical data (handles grayscale->color conversions performed by

--- a/src/menipy/common/preprocessing_helpers.py
+++ b/src/menipy/common/preprocessing_helpers.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 """Helper utilities for Menipy preprocessing pipeline."""
@@ -99,7 +98,6 @@ class PreprocessingContext:
         Description.
         """
         self.state.normalized_roi = array
-
 
         # ---------------------------------------------------------------------------
         # Stage helpers

--- a/src/menipy/common/registry.py
+++ b/src/menipy/common/registry.py
@@ -1,5 +1,6 @@
 # src/menipy/common/registry.py
 """Central registry for pipeline components and plugins."""
+
 from __future__ import annotations
 from typing import Callable, Dict, Any, Optional, Iterator
 
@@ -148,22 +149,27 @@ def register_utility(name: str, fn: Callable[..., Any]) -> None:
     """Register a utility function for image testing/analysis."""
     UTILITIES.register(name, fn)
 
+
 # Detector registration functions
 def register_needle_detector(name: str, fn: Callable[..., Any]) -> None:
     """Register plugin."""
     NEEDLE_DETECTORS.register(name, fn)
 
+
 def register_roi_detector(name: str, fn: Callable[..., Any]) -> None:
     """Register plugin."""
     ROI_DETECTORS.register(name, fn)
+
 
 def register_substrate_detector(name: str, fn: Callable[..., Any]) -> None:
     """Register plugin."""
     SUBSTRATE_DETECTORS.register(name, fn)
 
+
 def register_drop_detector(name: str, fn: Callable[..., Any]) -> None:
     """Register plugin."""
     DROP_DETECTORS.register(name, fn)
+
 
 def register_apex_detector(name: str, fn: Callable[..., Any]) -> None:
     """Register plugin."""

--- a/src/menipy/common/scaling.py
+++ b/src/menipy/common/scaling.py
@@ -1,5 +1,6 @@
 # src/menipy/common/scaling.py
 """Scaling stage utilities for pixel-to-mm conversion."""
+
 from __future__ import annotations
 
 

--- a/src/menipy/common/solver.py
+++ b/src/menipy/common/solver.py
@@ -1,5 +1,6 @@
 # src/menipy/common/solver.py
 """Solver stage utilities for fitting physical models to contours."""
+
 from __future__ import annotations
 
 import math

--- a/src/menipy/common/units.py
+++ b/src/menipy/common/units.py
@@ -1,5 +1,6 @@
 # src/menipy/common/units.py
 """Unit registry configuration using Pint."""
+
 from pint import UnitRegistry
 from pydantic_pint import set_registry
 
@@ -17,27 +18,29 @@ Q_ = ureg.Quantity
 # Surface Tension: mN/m (SI) vs dyn/cm (CGS) -> 1 (identical)
 # Length: mm (SI) vs cm (CGS) -> 10
 
+
 def convert_to_si(value: float, quantity: str, source_system: str) -> float:
     """Convert display value to internal SI."""
     if source_system == "SI":
         return value
-    
+
     if quantity == "density":
         return value * 1000.0  # g/cm^3 -> kg/m^3
     if quantity == "length":
-        return value * 10.0    # cm -> mm (wait, internal is mm or m?)
+        return value * 10.0  # cm -> mm (wait, internal is mm or m?)
     # Most internal math uses mm for coordinates, but kg/m^3 for density
-    
+
     return value
+
 
 def convert_from_si(value: float, quantity: str, target_system: str) -> float:
     """Convert internal SI to display system."""
     if target_system == "SI":
         return value
-        
+
     if quantity == "density":
         return value / 1000.0  # kg/m^3 -> g/cm^3
     if quantity == "length":
-        return value / 10.0    # mm -> cm
-        
+        return value / 10.0  # mm -> cm
+
     return value

--- a/src/menipy/common/validation.py
+++ b/src/menipy/common/validation.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Any
 from menipy.models.context import Context
 
+
 @dataclass
 class QACheck:
     name: str
@@ -10,20 +11,23 @@ class QACheck:
     threshold: Optional[float]
     message: str
 
+
 @dataclass
 class QAResult:
     ok: bool
     score: float
     checks: Dict[str, QACheck] = field(default_factory=dict)
-    
+
     def to_dict(self) -> dict:
         from dataclasses import asdict
+
         return asdict(self)
+
 
 def validate(ctx: Context, thresholds: Optional[Dict[str, float]] = None) -> QAResult:
     """
     Run comprehensive QA checks on the analysis context.
-    
+
     Checks:
     1. Convergence: was the fit successful?
     2. Residual quality: is RMSE small enough?
@@ -33,11 +37,11 @@ def validate(ctx: Context, thresholds: Optional[Dict[str, float]] = None) -> QAR
     """
     if thresholds is None:
         thresholds = {}
-        
+
     checks = {}
     total_score = 0.0
     max_score = 0.0
-    
+
     # 1. Convergence
     fit_ok = bool(ctx.fit and ctx.fit.get("solver", {}).get("success", False))
     checks["convergence"] = QACheck(
@@ -45,23 +49,25 @@ def validate(ctx: Context, thresholds: Optional[Dict[str, float]] = None) -> QAR
         passed=fit_ok,
         value=1.0 if fit_ok else 0.0,
         threshold=1.0,
-        message="Solver converged successfully" if fit_ok else "Solver failed to converge"
+        message=(
+            "Solver converged successfully" if fit_ok else "Solver failed to converge"
+        ),
     )
     total_score += 1.0 if fit_ok else 0.0
     max_score += 1.0
-    
+
     # 2. Residuals
     rmse_thresh = thresholds.get("rmse", 5.0)
     rmse = None
     residuals_ok = False
-    
+
     if ctx.fit and "residuals" in ctx.fit:
         res = ctx.fit["residuals"]
         if hasattr(res, "rmse") and res.rmse is not None:
             rmse = float(res.rmse)
         elif isinstance(res, dict) and "rmse" in res:
             rmse = float(res["rmse"])
-            
+
     if rmse is not None:
         residuals_ok = rmse <= rmse_thresh
         checks["residuals"] = QACheck(
@@ -69,20 +75,20 @@ def validate(ctx: Context, thresholds: Optional[Dict[str, float]] = None) -> QAR
             passed=residuals_ok,
             value=rmse,
             threshold=rmse_thresh,
-            message=f"RMSE={rmse:.2f} px (threshold={rmse_thresh})"
+            message=f"RMSE={rmse:.2f} px (threshold={rmse_thresh})",
         )
     else:
         checks["residuals"] = QACheck(
             name="Residuals",
-            passed=True, # no residuals to check
+            passed=True,  # no residuals to check
             value=None,
             threshold=rmse_thresh,
-            message="No residuals reported"
+            message="No residuals reported",
         )
-        
+
     total_score += 1.0 if residuals_ok or rmse is None else 0.0
     max_score += 1.0
-        
+
     # 3. Contour quality
     min_pts = thresholds.get("min_contour_points", 50)
     pts_ok = False
@@ -90,24 +96,24 @@ def validate(ctx: Context, thresholds: Optional[Dict[str, float]] = None) -> QAR
     if ctx.contour and hasattr(ctx.contour, "xy"):
         pts_count = len(ctx.contour.xy)
         pts_ok = pts_count >= min_pts
-        
+
     checks["contour"] = QACheck(
         name="Contour Quality",
         passed=pts_ok,
         value=float(pts_count),
         threshold=float(min_pts),
-        message=f"Contour points={pts_count} (min={min_pts})"
+        message=f"Contour points={pts_count} (min={min_pts})",
     )
     total_score += 1.0 if pts_ok else 0.0
     max_score += 1.0
-    
+
     # Calculate final ok and score
     # Must have converged to be ok
-    all_passed = checks["convergence"].passed and checks["residuals"].passed and checks["contour"].passed
-    score = total_score / max_score if max_score > 0 else 0.0
-    
-    return QAResult(
-        ok=all_passed,
-        score=score,
-        checks=checks
+    all_passed = (
+        checks["convergence"].passed
+        and checks["residuals"].passed
+        and checks["contour"].passed
     )
+    score = total_score / max_score if max_score > 0 else 0.0
+
+    return QAResult(ok=all_passed, score=score, checks=checks)

--- a/src/menipy/gui/adsa_app.py
+++ b/src/menipy/gui/adsa_app.py
@@ -7,6 +7,7 @@ redesigned UI based on the experiment-selector workflow.
 Usage:
     python -m menipy.gui.adsa_app
 """
+
 import sys
 import logging
 from PySide6.QtCore import qInstallMessageHandler, QtMsgType
@@ -20,7 +21,7 @@ def main():
     # Set up logging
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
     logger = logging.getLogger(__name__)
 
@@ -34,12 +35,12 @@ def main():
         )
 
     qInstallMessageHandler(_qt_msg_filter)
-    
+
     # Enable high DPI scaling
     QApplication.setHighDpiScaleFactorRoundingPolicy(
         Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
     )
-    
+
     # Create application
     app = QApplication(sys.argv)
     app.setApplicationName("ADSA")
@@ -47,20 +48,21 @@ def main():
     app.setOrganizationName("Menipy")
     # Ensure a valid point size to avoid QFont warnings on some platforms
     from menipy.gui import theme
+
     f = app.font()
     if f.pointSize() <= 0:
         f.setPointSize(theme.FONT_SIZE_NORMAL)
         app.setFont(f)
-    
+
     # Import here to ensure QApplication exists first
     from menipy.gui.views.adsa_main_window import ADSAMainWindow
-    
+
     # Create and show main window
     window = ADSAMainWindow()
     window.show()
-    
+
     logger.info("ADSA application started")
-    
+
     # Run event loop
     sys.exit(app.exec())
 

--- a/src/menipy/gui/components/plugin_settings_widget.py
+++ b/src/menipy/gui/components/plugin_settings_widget.py
@@ -2,56 +2,74 @@
 Widget for embedding plugin configuration directly in the main UI.
 Reuses logic from PluginConfigDialog but as a dockable/embeddable widget.
 """
+
 from __future__ import annotations
 import json
 from typing import Dict, Any, Type, Optional
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QFormLayout, QScrollArea, 
-    QLabel, QSpinBox, QDoubleSpinBox, QCheckBox, 
-    QLineEdit, QComboBox, QGroupBox, QPushButton, QHBoxLayout
+    QWidget,
+    QVBoxLayout,
+    QFormLayout,
+    QScrollArea,
+    QLabel,
+    QSpinBox,
+    QDoubleSpinBox,
+    QCheckBox,
+    QLineEdit,
+    QComboBox,
+    QGroupBox,
+    QPushButton,
+    QHBoxLayout,
 )
 from PySide6.QtCore import Signal, Qt
 
 from pydantic import BaseModel
-from menipy.common.plugin_settings import get_detector_settings_model, resolve_plugin_settings
-from menipy.gui.dialogs.plugin_config_dialog import PluginConfigDialog # reusing _create_widget logic if possible, or duplicating for independence
+from menipy.common.plugin_settings import (
+    get_detector_settings_model,
+    resolve_plugin_settings,
+)
+from menipy.gui.dialogs.plugin_config_dialog import (
+    PluginConfigDialog,
+)  # reusing _create_widget logic if possible, or duplicating for independence
+
 
 class PluginSettingsWidget(QWidget):
     """
     A widget that displays configuration fields for a specific plugin method.
     Emits settingsChanged signal when values are modified.
     """
+
     settingsChanged = Signal(dict)
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._current_method: Optional[str] = None
         self._current_model: Optional[Type[BaseModel]] = None
         self._inputs: Dict[str, QWidget] = {}
         self._block_signals = False
-        
+
         # Layouts
         self.main_layout = QVBoxLayout(self)
         self.main_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Header / Title (Optional)
         self.header_label = QLabel("Settings")
         self.header_label.setStyleSheet("font-weight: bold; color: #555;")
         self.main_layout.addWidget(self.header_label)
-        
+
         # Scroll Area for Form
         self.scroll = QScrollArea()
         self.scroll.setWidgetResizable(True)
         self.scroll.setFrameShape(QScrollArea.NoFrame)
-        
+
         self.form_container = QWidget()
         self.form_layout = QFormLayout(self.form_container)
         self.form_layout.setContentsMargins(0, 5, 0, 5)
-        
+
         self.scroll.setWidget(self.form_container)
         self.main_layout.addWidget(self.scroll)
-        
+
         # Bottom Actions (Reset / Apply if needed? Or just live?)
         # For now, let's keep it live, but adding a "Reset to Defaults" is nice
         self.btn_layout = QHBoxLayout()
@@ -60,11 +78,11 @@ class PluginSettingsWidget(QWidget):
         self.btn_reset.setStyleSheet("text-align: left; padding: 4px;")
         self.btn_reset.setFlat(True)
         self.btn_reset.setCursor(Qt.PointingHandCursor)
-        
+
         self.btn_layout.addWidget(self.btn_reset)
         self.btn_layout.addStretch()
         self.main_layout.addLayout(self.btn_layout)
-        
+
         # Initial State
         self.set_empty_state()
 
@@ -90,10 +108,10 @@ class PluginSettingsWidget(QWidget):
         """Build the settings form for the given plugin method."""
         self._current_method = method_name
         self._current_model = get_detector_settings_model(method_name)
-        
+
         self._clear_form()
         self.header_label.setText(f"{method_name.replace('_', ' ').title()} Settings")
-        
+
         if not self._current_model:
             self.set_empty_state()
             return
@@ -102,17 +120,17 @@ class PluginSettingsWidget(QWidget):
 
         # If no settings provided, use defaults
         vals = current_settings or {}
-        
+
         # Generate fields based on Pydantic model
-        # We can reuse logic from PluginConfigDialog, but for now I'll duplicate the loop 
+        # We can reuse logic from PluginConfigDialog, but for now I'll duplicate the loop
         # to keep this widget self-contained and tweakable for side-panel use.
-        
+
         model = self._current_model
-        
+
         # Docstring as tooltip or description
         if model.__doc__:
             self.setToolTip(model.__doc__.strip())
-        
+
         for name, field in model.model_fields.items():
             # Get current value or default
             val = vals.get(name, field.default)
@@ -124,41 +142,42 @@ class PluginSettingsWidget(QWidget):
 
             # Create Widget
             widget = self._create_input_widget(field.annotation, val)
-            
+
             if widget:
                 self._inputs[name] = widget
                 # Connect change signal
                 self._connect_change_signal(widget)
-                
+
                 label_text = name.replace("_", " ").title()
                 self.form_layout.addRow(label_text, widget)
-                
+
                 # Add tooltip from field description
                 if field.description:
                     widget.setToolTip(field.description)
-        
+
     def _create_input_widget(self, type_annotation, value) -> QWidget | None:
         """Create appropriate widget for type."""
         # Reuse logic similar to PluginConfigDialog
         from menipy.gui.dialogs.plugin_config_dialog import PluginConfigDialog
+
         # We can actually just instantiate a temp dialog to use its method if we made it static?
         # Or just copy-paste for now to avoid refactoring the other file yet.
         # Let's verify PluginConfigDialog._create_widget is instance method. It is.
         # I'll implement a simplified version here.
-        
+
         from typing import get_origin, get_args
         from enum import Enum
-        
+
         # Unwrap Optional
         origin = get_origin(type_annotation)
         if origin is not None:
-             args = get_args(type_annotation)
-             if type(None) in args:
-                 for a in args:
-                     if a is not type(None):
-                         type_annotation = a
-                         break
-                         
+            args = get_args(type_annotation)
+            if type(None) in args:
+                for a in args:
+                    if a is not type(None):
+                        type_annotation = a
+                        break
+
         if isinstance(type_annotation, type) and issubclass(type_annotation, Enum):
             w = QComboBox()
             for member in type_annotation:
@@ -167,10 +186,12 @@ class PluginSettingsWidget(QWidget):
                 w.setCurrentText(value.name)
             elif value is not None:
                 idx = w.findData(value)
-                if idx >= 0: w.setCurrentIndex(idx)
-                else: 
-                     idx = w.findText(str(value))
-                     if idx >= 0: w.setCurrentIndex(idx)
+                if idx >= 0:
+                    w.setCurrentIndex(idx)
+                else:
+                    idx = w.findText(str(value))
+                    if idx >= 0:
+                        w.setCurrentIndex(idx)
             return w
 
         if type_annotation is int:
@@ -178,7 +199,7 @@ class PluginSettingsWidget(QWidget):
             w.setRange(-999999, 999999)
             w.setValue(int(value) if value is not None else 0)
             return w
-            
+
         elif type_annotation is float:
             w = QDoubleSpinBox()
             w.setRange(-999999.0, 999999.0)
@@ -186,18 +207,18 @@ class PluginSettingsWidget(QWidget):
             w.setDecimals(4)
             w.setValue(float(value) if value is not None else 0.0)
             return w
-            
+
         elif type_annotation is bool:
             w = QCheckBox()
-             # Right align checkbox for form layout
+            # Right align checkbox for form layout
             w.setChecked(bool(value) if value is not None else False)
             return w
-            
+
         elif type_annotation is str:
             w = QLineEdit()
             w.setText(str(value) if value is not None else "")
             return w
-            
+
         return None
 
     def _connect_change_signal(self, widget: QWidget):
@@ -240,37 +261,45 @@ class PluginSettingsWidget(QWidget):
     def _reset_to_defaults(self):
         if not self._current_model:
             return
-            
+
         # Block signals to prevent updates during batch update
         self._block_signals = True
         try:
             for name, widget in self._inputs.items():
                 field = self._current_model.model_fields.get(name)
-                if not field: continue
-                
+                if not field:
+                    continue
+
                 # Get default
                 val = field.default
                 if val is None and field.default_factory:
-                    try: val = field.default_factory()
-                    except Exception: pass
-                
+                    try:
+                        val = field.default_factory()
+                    except Exception:
+                        pass
+
                 # Set widget value
                 if isinstance(widget, (QSpinBox, QDoubleSpinBox)):
-                    if val is not None: widget.setValue(val)
+                    if val is not None:
+                        widget.setValue(val)
                 elif isinstance(widget, QCheckBox):
-                    if val is not None: widget.setChecked(bool(val))
+                    if val is not None:
+                        widget.setChecked(bool(val))
                 elif isinstance(widget, QLineEdit):
-                    if val is not None: widget.setText(str(val))
+                    if val is not None:
+                        widget.setText(str(val))
                 elif isinstance(widget, QComboBox):
                     # Handle enum default
                     from enum import Enum
+
                     if isinstance(val, Enum):
                         widget.setCurrentText(val.name)
                     elif val is not None:
                         idx = widget.findData(val)
-                        if idx >= 0: widget.setCurrentIndex(idx)
+                        if idx >= 0:
+                            widget.setCurrentIndex(idx)
         finally:
-             self._block_signals = False
-             
+            self._block_signals = False
+
         # Emit one signal at end
         self.settingsChanged.emit(self.get_current_settings())

--- a/src/menipy/gui/controllers/edge_detection_controller.py
+++ b/src/menipy/gui/controllers/edge_detection_controller.py
@@ -113,8 +113,7 @@ class EdgeDetectionPipelineController(QObject):
         self.previewRequested.emit(preview_image, metadata)
 
     def reset(self) -> None:
-        """reset.
-        """
+        """reset."""
         self._settings = EdgeDetectionSettings()
         self.settingsChanged.emit(self._settings)
         self.run()

--- a/src/menipy/gui/controllers/image_manager.py
+++ b/src/menipy/gui/controllers/image_manager.py
@@ -1,4 +1,5 @@
 """Image lifecycle and loading management."""
+
 from __future__ import annotations
 
 import logging
@@ -55,7 +56,7 @@ class ImageManager(QObject):
         self.setup_ctrl = setup_ctrl
         self.preview_panel = preview_panel
         self.preprocessing_ctrl = preprocessing_ctrl
-        
+
         self._cached_image_path: Optional[str] = None
         self._cached_image_data: Optional[np.ndarray] = None
 

--- a/src/menipy/gui/controllers/overlay_manager.py
+++ b/src/menipy/gui/controllers/overlay_manager.py
@@ -1,4 +1,5 @@
 """Overlay management logic extracted from MainController."""
+
 from __future__ import annotations
 
 import logging
@@ -49,9 +50,16 @@ class OverlayManager:
         if not self.image_view:
             return
         tags = (
-            'roi', 'needle', 'contact_line', 
-            'cal_roi', 'cal_needle', 'cal_substrate', 'cal_drop', 
-            'cal_contact_left', 'cal_contact_right', 'apex'
+            "roi",
+            "needle",
+            "contact_line",
+            "cal_roi",
+            "cal_needle",
+            "cal_substrate",
+            "cal_drop",
+            "cal_contact_left",
+            "cal_contact_right",
+            "apex",
         )
         for tag in tags:
             try:
@@ -73,8 +81,8 @@ class OverlayManager:
                 QRectF(x, y, w, h),
                 color=QColor(255, 255, 0),
                 width=2.0,
-                layer='markers',
-                tag='roi'
+                layer="markers",
+                tag="roi",
             )
 
         # Draw needle
@@ -84,8 +92,8 @@ class OverlayManager:
                 QRectF(x, y, w, h),
                 color=QColor(0, 0, 255),
                 width=2.0,
-                layer='markers',
-                tag='needle'
+                layer="markers",
+                tag="needle",
             )
 
         # Draw substrate line
@@ -95,8 +103,8 @@ class OverlayManager:
                 QPointF(p1[0], p1[1]),
                 QPointF(p2[0], p2[1]),
                 color=QColor(255, 0, 255),
-                layer='baseline',
-                tag='contact_line'
+                layer="baseline",
+                tag="contact_line",
             )
 
         # Draw contact points
@@ -106,15 +114,15 @@ class OverlayManager:
                 QPointF(left[0], left[1]),
                 color=QColor(255, 0, 0),
                 radius=5.0,
-                layer='markers',
-                tag='cal_contact_left'
+                layer="markers",
+                tag="cal_contact_left",
             )
             self.image_view.add_marker_point(
                 QPointF(right[0], right[1]),
                 color=QColor(255, 0, 0),
                 radius=5.0,
-                layer='markers',
-                tag='cal_contact_right'
+                layer="markers",
+                tag="cal_contact_right",
             )
 
         if getattr(result, "apex_point", None):
@@ -123,9 +131,9 @@ class OverlayManager:
                 QPointF(apex[0], apex[1]),
                 color=QColor(255, 0, 0),
                 radius=6.0,
-                shape='cross',
-                layer='markers',
-                tag='apex'
+                shape="cross",
+                layer="markers",
+                tag="apex",
             )
 
         # Draw drop contour
@@ -136,8 +144,8 @@ class OverlayManager:
                     contour,
                     color=QColor(0, 255, 0),
                     width=2.0,
-                    layer='contour',
-                    tag='cal_drop'
+                    layer="contour",
+                    tag="cal_drop",
                 )
 
     def draw_edge_detection_preview(self, metadata: dict):
@@ -146,94 +154,98 @@ class OverlayManager:
             return
 
         # Clear existing
-        for tag in ('detected_left', 'detected_right', 'detected_contour'):
+        for tag in ("detected_left", "detected_right", "detected_contour"):
             try:
                 self.image_view.remove_overlay(tag)
             except Exception:
                 pass
 
         # Draw contour
-        contour_xy = metadata.get('contour_xy')
+        contour_xy = metadata.get("contour_xy")
         if contour_xy is not None:
             self._draw_contour(contour_xy)
 
         # Draw contact points
-        contact_points = metadata.get('contact_points')
+        contact_points = metadata.get("contact_points")
         if contact_points is not None:
             self._draw_contact_points(contact_points)
 
     def _draw_contour(self, contour_xy):
         try:
-            overlay_cfg = getattr(self.settings, 'overlay_config', None) or {}
-            c_visible = bool(overlay_cfg.get('contour_visible', True))
+            overlay_cfg = getattr(self.settings, "overlay_config", None) or {}
+            c_visible = bool(overlay_cfg.get("contour_visible", True))
             if c_visible:
-                c_color = QColor(overlay_cfg.get('contour_color', '#ff0000'))
-                c_width = float(overlay_cfg.get('contour_thickness', 2.0))
-                c_dashed = bool(overlay_cfg.get('contour_dashed', False))
-                dash_len = float(overlay_cfg.get('contour_dash_length', 6.0))
-                dash_space = float(overlay_cfg.get('contour_dash_space', 6.0))
-                c_alpha = float(overlay_cfg.get('contour_alpha', 1.0))
+                c_color = QColor(overlay_cfg.get("contour_color", "#ff0000"))
+                c_width = float(overlay_cfg.get("contour_thickness", 2.0))
+                c_dashed = bool(overlay_cfg.get("contour_dashed", False))
+                dash_len = float(overlay_cfg.get("contour_dash_length", 6.0))
+                dash_space = float(overlay_cfg.get("contour_dash_space", 6.0))
+                c_alpha = float(overlay_cfg.get("contour_alpha", 1.0))
                 c_color.setAlphaF(max(0.0, min(1.0, c_alpha)))
                 dash = (dash_len, dash_space) if c_dashed else None
                 self.image_view.add_marker_contour(
-                    contour_xy, 
-                    color=c_color, 
-                    width=c_width, 
-                    dash_pattern=dash, 
-                    alpha=c_alpha, 
-                    layer='contour',
-                    tag='detected_contour'
+                    contour_xy,
+                    color=c_color,
+                    width=c_width,
+                    dash_pattern=dash,
+                    alpha=c_alpha,
+                    layer="contour",
+                    tag="detected_contour",
                 )
         except Exception:
-             logger.debug('Failed to add contour overlay', exc_info=True)
+            logger.debug("Failed to add contour overlay", exc_info=True)
 
     def _draw_contact_points(self, contact_points):
         try:
             left_pt, right_pt = contact_points
-            p_cfg = getattr(self.settings, 'overlay_config', None) or {}
-            p_visible = bool(p_cfg.get('points_visible', True))
+            p_cfg = getattr(self.settings, "overlay_config", None) or {}
+            p_visible = bool(p_cfg.get("points_visible", True))
             if not p_visible:
                 return
 
-            p_color = QColor(p_cfg.get('point_color', '#00ff00')) # Default green/red mix in original code
+            p_color = QColor(
+                p_cfg.get("point_color", "#00ff00")
+            )  # Default green/red mix in original code
             # But let's stick to config or defaults
-            p_alpha = float(p_cfg.get('point_alpha', 1.0))
-            p_radius = float(p_cfg.get('point_radius', 4.0))
-            
+            p_alpha = float(p_cfg.get("point_alpha", 1.0))
+            p_radius = float(p_cfg.get("point_radius", 4.0))
+
             # Left point
             if left_pt is not None:
-                color = QColor(p_cfg.get('point_color', '#00ff00')) # Use config color
+                color = QColor(p_cfg.get("point_color", "#00ff00"))  # Use config color
                 color.setAlphaF(max(0.0, min(1.0, p_alpha)))
                 self.image_view.add_marker_point(
-                    QPointF(left_pt[0], left_pt[1]), 
-                    color=color, 
-                    radius=p_radius, 
-                    layer='markers',
-                    tag='detected_left'
+                    QPointF(left_pt[0], left_pt[1]),
+                    color=color,
+                    radius=p_radius,
+                    layer="markers",
+                    tag="detected_left",
                 )
-            
+
             # Right point
             if right_pt is not None:
-                color = QColor(p_cfg.get('point_color', '#ff0000')) # Original code had red for right?
+                color = QColor(
+                    p_cfg.get("point_color", "#ff0000")
+                )  # Original code had red for right?
                 # Actually original code:
-                    # Left: #00ff00 (Green)
+                # Left: #00ff00 (Green)
                 # Right: #ff0000 (Red)
-                # But it read from config 'point_color' for both? 
+                # But it read from config 'point_color' for both?
                 # Original code:
-                    # left: p_color = QColor(p_cfg.get('point_color', '#00ff00'))
+                # left: p_color = QColor(p_cfg.get('point_color', '#00ff00'))
                 # right: p_color = QColor(p_cfg.get('point_color', '#ff0000'))
                 # This suggests if 'point_color' is in config, it overrides BOTH to the same color?
                 # Or maybe the default is different if key missing.
                 # Let's replicate exact behavior.
-                
-                color = QColor(p_cfg.get('point_color', '#ff0000'))
+
+                color = QColor(p_cfg.get("point_color", "#ff0000"))
                 color.setAlphaF(max(0.0, min(1.0, p_alpha)))
                 self.image_view.add_marker_point(
-                    QPointF(right_pt[0], right_pt[1]), 
-                    color=color, 
-                    radius=p_radius, 
-                    layer='markers',
-                    tag='detected_right'
+                    QPointF(right_pt[0], right_pt[1]),
+                    color=color,
+                    radius=p_radius,
+                    layer="markers",
+                    tag="detected_right",
                 )
         except Exception:
-            logger.debug('Failed to add contact point overlays', exc_info=True)
+            logger.debug("Failed to add contact point overlays", exc_info=True)

--- a/src/menipy/gui/controllers/pipeline_controller.py
+++ b/src/menipy/gui/controllers/pipeline_controller.py
@@ -17,7 +17,6 @@ from PySide6.QtWidgets import QMessageBox, QPlainTextEdit, QMainWindow
 
 from menipy.models.config import PhysicsParams
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -335,14 +334,26 @@ class PipelineController:
             # Get calibration params from the setup controller (normalized to SI)
             calibration_params = self.setup_ctrl.get_calibration_params()
             try:
-                needle_diameter_mm = float(calibration_params.get("needle_diameter_mm", 0.54))
+                needle_diameter_mm = float(
+                    calibration_params.get("needle_diameter_mm", 0.54)
+                )
             except (ValueError, TypeError):
                 needle_diameter_mm = 0.54
-            
+
             # Get actual needle width from detected needle_rect overlay
-            needle_rect = self.preview_panel.needle_rect() if hasattr(self.preview_panel, 'needle_rect') else None
-            if needle_rect and isinstance(needle_diameter_mm, (int, float)) and needle_diameter_mm > 0:
-                needle_diameter_px = needle_rect[2]  # (x, y, w, h) -> w (width = diameter)
+            needle_rect = (
+                self.preview_panel.needle_rect()
+                if hasattr(self.preview_panel, "needle_rect")
+                else None
+            )
+            if (
+                needle_rect
+                and isinstance(needle_diameter_mm, (int, float))
+                and needle_diameter_mm > 0
+            ):
+                needle_diameter_px = needle_rect[
+                    2
+                ]  # (x, y, w, h) -> w (width = diameter)
                 px_per_mm = needle_diameter_px / needle_diameter_mm
             else:
                 # Fallback: use approximate estimate
@@ -355,8 +366,12 @@ class PipelineController:
 
             # Set physics parameters from calibration
             ctx.physics = {
-                "rho1": calibration_params.get("drop_density_kg_m3", 1000.0),  # Drop density
-                "rho2": calibration_params.get("fluid_density_kg_m3", 1.2),  # Fluid density
+                "rho1": calibration_params.get(
+                    "drop_density_kg_m3", 1000.0
+                ),  # Drop density
+                "rho2": calibration_params.get(
+                    "fluid_density_kg_m3", 1.2
+                ),  # Fluid density
                 "g": 9.80665,  # Gravity
             }
 
@@ -406,17 +421,23 @@ class PipelineController:
         image = params.get("image")
         cam_id = params.get("cam_id")
         frames = params.get("frames")
-        
+
         # Calculate scale from detected needle diameter (width)
         # Get calibration params from the setup controller (normalized to SI)
         calibration_params = self.setup_ctrl.get_calibration_params()
         try:
-            needle_diameter_mm = float(calibration_params.get("needle_diameter_mm", 0.54))
+            needle_diameter_mm = float(
+                calibration_params.get("needle_diameter_mm", 0.54)
+            )
         except (ValueError, TypeError):
             needle_diameter_mm = 0.54
 
-        needle_rect = overlays.get('needle_rect')
-        if needle_rect and isinstance(needle_diameter_mm, (int, float)) and needle_diameter_mm > 0:
+        needle_rect = overlays.get("needle_rect")
+        if (
+            needle_rect
+            and isinstance(needle_diameter_mm, (int, float))
+            and needle_diameter_mm > 0
+        ):
             needle_diameter_px = needle_rect[2]  # (x, y, w, h) -> w (width = diameter)
             px_per_mm = needle_diameter_px / needle_diameter_mm
         else:
@@ -426,14 +447,14 @@ class PipelineController:
 
         run_kwargs = dict(overlays)
         # Pass structured context data
-        run_kwargs['calibration_params'] = calibration_params
-        run_kwargs['scale'] = {"px_per_mm": px_per_mm}
-        run_kwargs['physics'] = {
+        run_kwargs["calibration_params"] = calibration_params
+        run_kwargs["scale"] = {"px_per_mm": px_per_mm}
+        run_kwargs["physics"] = {
             "rho1": calibration_params.get("drop_density_kg_m3", 1000.0),
             "rho2": calibration_params.get("fluid_density_kg_m3", 1.2),
             "g": 9.80665,
         }
-        
+
         if image is not None:
             run_kwargs["image"] = image
         if cam_id is not None:
@@ -708,7 +729,11 @@ class PipelineController:
             file_name = None
         else:
             # Fallback to image string if available
-            if file_name is None and hasattr(ctx, "image") and isinstance(ctx.image, str):
+            if (
+                file_name is None
+                and hasattr(ctx, "image")
+                and isinstance(ctx.image, str)
+            ):
                 try:
                     from pathlib import Path
 
@@ -785,11 +810,11 @@ class PipelineController:
     def on_pipeline_error(self, message: str) -> None:
         """Handles pipeline errors by showing a dialog and logging the incident."""
         logger.error(f"Pipeline Error: {message}")
-        
+
         # Use the static method to maintain compatibility with existing test mocks
         display_msg = "An error occurred during the analysis pipeline.\n\n" + message
         QMessageBox.critical(None, "Pipeline Error", display_msg)
-        
+
         try:
             self.window.statusBar().showMessage(f"Error: {message[:50]}...", 5000)
         except Exception:

--- a/src/menipy/gui/controllers/preprocessing_controller.py
+++ b/src/menipy/gui/controllers/preprocessing_controller.py
@@ -136,7 +136,10 @@ class PreprocessingPipelineController(QObject):
         ctx.preprocessing_settings = self._settings
 
         # Run auto-detection if enabled in settings
-        if hasattr(self._settings, "auto_detect") and self._settings.auto_detect.enabled:
+        if (
+            hasattr(self._settings, "auto_detect")
+            and self._settings.auto_detect.enabled
+        ):
             detect_plugin = registry.PREPROCESSORS.get("auto_detect")
             if detect_plugin:
                 try:
@@ -144,7 +147,7 @@ class PreprocessingPipelineController(QObject):
                 except Exception as exc:
                     logger.warning("Auto-detection plugin failed: %s", exc)
                     # Don't fail the whole run, just continue with manual settings
-        
+
         try:
             preprocessing.run(ctx, self._settings)
         except Exception as exc:  # pragma: no cover - guard for runtime issues
@@ -207,6 +210,7 @@ class PreprocessingPipelineController(QObject):
         # ------------------------------------------------------------------
         # Internal helpers
         # ------------------------------------------------------------------
+
     def _emit_preview_from_state(self) -> None:
         """_emit_preview_from_state."""
         if self._image is None or self._state is None:

--- a/src/menipy/gui/controllers/setup_panel_controller.py
+++ b/src/menipy/gui/controllers/setup_panel_controller.py
@@ -140,7 +140,9 @@ class SetupPanelController(QObject):
         self.previewBtn: Optional[QToolButton] = panel.findChild(
             QToolButton, "previewBtn"
         )
-        self.autoCalibrateBtn: Optional[QPushButton] = panel.findChild(QPushButton, "autoCalibrateBtn")
+        self.autoCalibrateBtn: Optional[QPushButton] = panel.findChild(
+            QPushButton, "autoCalibrateBtn"
+        )
 
         self.drawPointBtn: Optional[QPushButton] = panel.findChild(
             QPushButton, "drawPointBtn"
@@ -158,15 +160,31 @@ class SetupPanelController(QObject):
         self.framesSpin: Optional[QSpinBox] = panel.findChild(QSpinBox, "framesSpin")
 
         # Calibration labels for unit dynamic updates
-        self.needleLengthLabel: Optional[QLabel] = panel.findChild(QLabel, "needleLengthLabel")
-        self.dropDensityLabel: Optional[QLabel] = panel.findChild(QLabel, "dropDensityLabel")
-        self.fluidDensityLabel: Optional[QLabel] = panel.findChild(QLabel, "fluidDensityLabel")
-        self.substrateAngleLabel: Optional[QLabel] = panel.findChild(QLabel, "substrateAngleLabel")
-        
-        self.needleLengthSpin: Optional[QDoubleSpinBox] = panel.findChild(QDoubleSpinBox, "needleLengthSpin")
-        self.dropDensitySpin: Optional[QDoubleSpinBox] = panel.findChild(QDoubleSpinBox, "dropDensitySpin")
-        self.fluidDensitySpin: Optional[QDoubleSpinBox] = panel.findChild(QDoubleSpinBox, "fluidDensitySpin")
-        self.substrateAngleSpin: Optional[QDoubleSpinBox] = panel.findChild(QDoubleSpinBox, "substrateAngleSpin")
+        self.needleLengthLabel: Optional[QLabel] = panel.findChild(
+            QLabel, "needleLengthLabel"
+        )
+        self.dropDensityLabel: Optional[QLabel] = panel.findChild(
+            QLabel, "dropDensityLabel"
+        )
+        self.fluidDensityLabel: Optional[QLabel] = panel.findChild(
+            QLabel, "fluidDensityLabel"
+        )
+        self.substrateAngleLabel: Optional[QLabel] = panel.findChild(
+            QLabel, "substrateAngleLabel"
+        )
+
+        self.needleLengthSpin: Optional[QDoubleSpinBox] = panel.findChild(
+            QDoubleSpinBox, "needleLengthSpin"
+        )
+        self.dropDensitySpin: Optional[QDoubleSpinBox] = panel.findChild(
+            QDoubleSpinBox, "dropDensitySpin"
+        )
+        self.fluidDensitySpin: Optional[QDoubleSpinBox] = panel.findChild(
+            QDoubleSpinBox, "fluidDensitySpin"
+        )
+        self.substrateAngleSpin: Optional[QDoubleSpinBox] = panel.findChild(
+            QDoubleSpinBox, "substrateAngleSpin"
+        )
         self.sopGroup: Optional[QGroupBox] = panel.findChild(QGroupBox, "sopGroup")
         self.stepsGroup: Optional[QGroupBox] = panel.findChild(QGroupBox, "stepsGroup")
         self.advancedToggleBtn: Optional[QToolButton] = panel.findChild(
@@ -295,13 +313,14 @@ class SetupPanelController(QObject):
     def get_calibration_params(self) -> dict[str, Any]:
         """Returns calibration parameters normalized to SI units."""
         from menipy.common.units import convert_to_si
+
         system = getattr(self.settings, "unit_system", "SI")
-        
+
         # Use defaults if widgets missing
         needle_diameter = 0.54
         drop_rho = 1000.0
         fluid_rho = 1.2
-        
+
         if self.needleLengthSpin:
             needle_val = self.needleLengthSpin.value()
             needle_diameter = convert_to_si(needle_val, "length", system)
@@ -311,7 +330,7 @@ class SetupPanelController(QObject):
         if self.fluidDensitySpin:
             fluid_val = self.fluidDensitySpin.value()
             fluid_rho = convert_to_si(fluid_val, "density", system)
-            
+
         return {
             "needle_diameter_mm": needle_diameter,
             "drop_density_kg_m3": drop_rho,
@@ -321,16 +340,22 @@ class SetupPanelController(QObject):
     def refresh_ui_labels(self) -> None:
         """Updates setup panel labels based on the current unit system."""
         system = getattr(self.settings, "unit_system", "SI")
-        
+
         if system == "SI":
-            if self.needleLengthLabel: self.needleLengthLabel.setText("Needle (mm)")
-            if self.dropDensityLabel: self.dropDensityLabel.setText("Drop rho")
-            if self.fluidDensityLabel: self.fluidDensityLabel.setText("Fluid rho")
+            if self.needleLengthLabel:
+                self.needleLengthLabel.setText("Needle (mm)")
+            if self.dropDensityLabel:
+                self.dropDensityLabel.setText("Drop rho")
+            if self.fluidDensityLabel:
+                self.fluidDensityLabel.setText("Fluid rho")
         else:
-            if self.needleLengthLabel: self.needleLengthLabel.setText("Needle (cm)")
-            if self.dropDensityLabel: self.dropDensityLabel.setText("Drop rho")
-            if self.fluidDensityLabel: self.fluidDensityLabel.setText("Fluid rho")
-            
+            if self.needleLengthLabel:
+                self.needleLengthLabel.setText("Needle (cm)")
+            if self.dropDensityLabel:
+                self.dropDensityLabel.setText("Drop rho")
+            if self.fluidDensityLabel:
+                self.fluidDensityLabel.setText("Fluid rho")
+
         # Optional: convert current spinbox values to stay consistent when units toggle
         # (This is tricky if done multiple times without precision loss, but helpful for UX)
         # For now, just refreshing the labels as requested.
@@ -439,7 +464,9 @@ class SetupPanelController(QObject):
         if self.previewBtn:
             self.previewBtn.clicked.connect(lambda: self.preview_requested.emit())
         if self.autoCalibrateBtn:
-            self.autoCalibrateBtn.clicked.connect(lambda: self.auto_calibrate_requested.emit())
+            self.autoCalibrateBtn.clicked.connect(
+                lambda: self.auto_calibrate_requested.emit()
+            )
         if self.advancedToggleBtn:
             self.advancedToggleBtn.toggled.connect(
                 lambda checked: self.set_advanced_visible(bool(checked))
@@ -480,7 +507,9 @@ class SetupPanelController(QObject):
             (self.cameraModeRadio, self.MODE_CAMERA),
         ):
             if btn:
-                btn.clicked.connect(lambda _checked=False, m=mode: self._apply_mode(m, emit=True))
+                btn.clicked.connect(
+                    lambda _checked=False, m=mode: self._apply_mode(m, emit=True)
+                )
         combo = self.testCombo or self.pipelineCombo
         if combo:
             combo.currentTextChanged.connect(self._on_pipeline_combo_changed)

--- a/src/menipy/gui/controllers/sop_controller.py
+++ b/src/menipy/gui/controllers/sop_controller.py
@@ -93,8 +93,7 @@ class SopController:
         return included
 
     def on_add_sop(self) -> None:
-        """Add on  sop.
-        """
+        """Add on  sop."""
         if not self.sops:
             QMessageBox.warning(self.window, "SOP", "SOP service is not available.")
             return

--- a/src/menipy/gui/dialogs/analysis_settings/captive_bubble_settings.py
+++ b/src/menipy/gui/dialogs/analysis_settings/captive_bubble_settings.py
@@ -1,7 +1,15 @@
 """Pipeline-specific settings panel for captive bubble pipeline (basic stub)."""
+
 from __future__ import annotations
 
-from PySide6.QtWidgets import QWidget, QFormLayout, QDoubleSpinBox, QVBoxLayout, QComboBox, QTextEdit
+from PySide6.QtWidgets import (
+    QWidget,
+    QFormLayout,
+    QDoubleSpinBox,
+    QVBoxLayout,
+    QComboBox,
+    QTextEdit,
+)
 
 
 class PipelineSettingsWidget(QWidget):

--- a/src/menipy/gui/dialogs/analysis_settings/pendant_settings.py
+++ b/src/menipy/gui/dialogs/analysis_settings/pendant_settings.py
@@ -1,7 +1,16 @@
 """Pipeline-specific settings panel for the pendant drop pipeline."""
+
 from __future__ import annotations
 
-from PySide6.QtWidgets import QWidget, QFormLayout, QDoubleSpinBox, QTextEdit, QVBoxLayout, QComboBox, QCheckBox
+from PySide6.QtWidgets import (
+    QWidget,
+    QFormLayout,
+    QDoubleSpinBox,
+    QTextEdit,
+    QVBoxLayout,
+    QComboBox,
+    QCheckBox,
+)
 from menipy.pipelines.pendant.stages import DEFAULT_PENDANT_APPROXIMATION_METHODS
 
 

--- a/src/menipy/gui/dialogs/analysis_settings/sessile_settings.py
+++ b/src/menipy/gui/dialogs/analysis_settings/sessile_settings.py
@@ -1,4 +1,5 @@
 """Pipeline-specific settings panel for the sessile drop pipeline."""
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import (
@@ -25,7 +26,11 @@ class PipelineSettingsWidget(QWidget):
 
         self._contact_method = QComboBox()
         self._contact_method.addItems(["tangent", "circle_fit", "spherical_cap"])
-        if settings.get("contact_angle_method") in ["tangent", "circle_fit", "spherical_cap"]:
+        if settings.get("contact_angle_method") in [
+            "tangent",
+            "circle_fit",
+            "spherical_cap",
+        ]:
             self._contact_method.setCurrentText(settings["contact_angle_method"])
         form.addRow("Contact angle method", self._contact_method)
 

--- a/src/menipy/gui/dialogs/analysis_settings_dialog.py
+++ b/src/menipy/gui/dialogs/analysis_settings_dialog.py
@@ -3,6 +3,7 @@ Analysis Settings Dialog
 
 Generic dialog that wraps waiting for pipeline steps selection and configuration.
 """
+
 from __future__ import annotations
 
 from importlib import import_module
@@ -26,7 +27,11 @@ from PySide6.QtWidgets import (
     QGroupBox,
 )
 
-from menipy.models.config import PreprocessingSettings, EdgeDetectionSettings, PhysicsParams
+from menipy.models.config import (
+    PreprocessingSettings,
+    EdgeDetectionSettings,
+    PhysicsParams,
+)
 from menipy.gui.dialogs.preprocessing_config_dialog import PreprocessingConfigDialog
 from menipy.gui.dialogs.physics_config_dialog import PhysicsConfigDialog
 from menipy.gui.dialogs.geometry_config_dialog import GeometryConfigDialog
@@ -58,22 +63,28 @@ class AnalysisSettingsDialog(QDialog):
         self._preproc = saved.get("preproc") or preprocessing or PreprocessingSettings()
         self._edge = saved.get("edge") or edge or EdgeDetectionSettings()
         self._pipeline_settings_dict = saved.get("pipeline") or pipeline_settings or {}
-        
+
         # Load other settings from dict if present, or defaults
-        self._physics_params = PhysicsParams(**self._pipeline_settings_dict.get("physics", {}))
+        self._physics_params = PhysicsParams(
+            **self._pipeline_settings_dict.get("physics", {})
+        )
         self._geometry_config = self._pipeline_settings_dict.get("geometry_config", {})
         self._overlay_config = self._pipeline_settings_dict.get("overlay_config", {})
-        
+
         # Pipeline metadata for steps
         self._pipeline_class = PIPELINE_MAP.get(self._pipeline_name.lower())
-        self._ui_metadata = getattr(self._pipeline_class, "ui_metadata", {}) if self._pipeline_class else {}
-        
+        self._ui_metadata = (
+            getattr(self._pipeline_class, "ui_metadata", {})
+            if self._pipeline_class
+            else {}
+        )
+
         # Determine available stages from pipeline metadata or fallback
         self._available_stages = self._ui_metadata.get("stages", [])
         if not self._available_stages and self._pipeline_class:
             # Fallback to DEFAULT_SEQ if no metadata
             self._available_stages = [n for n, _ in self._pipeline_class.DEFAULT_SEQ]
-            
+
         # Determine enabled stages
         # Default to all if not specified in settings
         self._enabled_stages = set(
@@ -81,7 +92,7 @@ class AnalysisSettingsDialog(QDialog):
         )
 
         self._tabs_map = {}  # Map stage name -> QWidget tab
-        
+
         self._build_ui()
         self._update_tabs_visibility()
 
@@ -97,7 +108,7 @@ class AnalysisSettingsDialog(QDialog):
         # Create tabs for all potential stages
         # We create them all once, then show/hide based on enabled status
         self._create_stage_tabs()
-        
+
         # Footer buttons
         buttons = QHBoxLayout()
         buttons.addStretch()
@@ -114,81 +125,82 @@ class AnalysisSettingsDialog(QDialog):
         """Iterate over available stages and create tabs for relevant ones."""
         # Define a consistent order or use the pipeline order
         # We can use _available_stages for order
-        
+
         seen_stages = set()
-        
+
         for stage in self._available_stages:
-            if stage in seen_stages: 
-                continue # Avoid dups
-            
+            if stage in seen_stages:
+                continue  # Avoid dups
+
             seen_stages.add(stage)
             tab_widget = None
             tab_title = stage.replace("_", " ").title()
-            
+
             if stage == "preprocessing":
                 tab_widget = self._build_preproc_tab()
-            
+
             elif stage in ("contour_extraction", "edge_detection"):
-                 # Share the same tab builder
-                 tab_widget = self._build_edge_tab()
-                 tab_title = "Edge Detection" # Nicer name
-                 
+                # Share the same tab builder
+                tab_widget = self._build_edge_tab()
+                tab_title = "Edge Detection"  # Nicer name
+
             elif stage == "geometric_features":
                 tab_widget = self._build_geometry_tab()
                 tab_title = "Geometry"
-            
+
             elif stage == "physics":
                 tab_widget = self._build_physics_tab()
                 tab_title = "Physics"
-                
+
             elif stage == "overlay":
-                 tab_widget = self._build_overlay_tab()
-                 tab_title = "Overlay"
-                 
+                tab_widget = self._build_overlay_tab()
+                tab_title = "Overlay"
+
             elif stage == "contour_refinement":
                 # For now optional, maybe just a placeholder or simple settings
                 # Leaving blank/None means no tab created for this stage
-                pass 
-                
+                pass
+
             elif stage == "calibration":
                 # Calibration usually happens via wizard, but maybe manual params?
                 pass
-                
+
             # Check for generic/custom if not handled above
             if tab_widget is None:
-                 # Try optional custom builder or pipeline-specific overrides?
-                 # For now, skip unhandled steps
-                 pass
-            
+                # Try optional custom builder or pipeline-specific overrides?
+                # For now, skip unhandled steps
+                pass
+
             if tab_widget:
                 self._tabs.addTab(tab_widget, tab_title)
                 self._tabs_map[stage] = tab_widget
-                
+
         # Finally, Pipeline-specific custom tab (always added if exists)
         self._pipeline_widget = self._build_pipeline_custom_tab()
         if self._pipeline_widget:
-            self._tabs.addTab(self._pipeline_widget, f"{self._pipeline_name.title()} specific")
+            self._tabs.addTab(
+                self._pipeline_widget, f"{self._pipeline_name.title()} specific"
+            )
             # Map this to a special key
             self._tabs_map["__pipeline_custom__"] = self._pipeline_widget
-
 
     def _build_steps_tab(self) -> QWidget:
         """Create the tab for selecting enabled pipeline steps."""
         w = QWidget()
         layout = QVBoxLayout(w)
         layout.setContentsMargins(16, 16, 16, 16)
-        
+
         info = QLabel("Select the analysis steps to perform:")
         info.setStyleSheet("font-weight: bold; margin-bottom: 8px;")
         layout.addWidget(info)
-        
+
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QScrollArea.Shape.NoFrame)
         content = QWidget()
         v = QVBoxLayout(content)
         v.setSpacing(10)
-        
+
         stage_names = {
             "acquisition": "Image Acquisition",
             "preprocessing": "Preprocessing",
@@ -203,26 +215,26 @@ class AnalysisSettingsDialog(QDialog):
             "overlay": "Result Overlay",
             "validation": "Validation",
         }
-        
+
         self._stage_checkboxes = {}
-        
+
         for stage in self._available_stages:
             name = stage_names.get(stage, stage.replace("_", " ").title())
             chk = QCheckBox(name)
             chk.setChecked(stage in self._enabled_stages)
             chk.stateChanged.connect(lambda s, st=stage: self._on_step_toggled(st, s))
-            
+
             if stage == "acquisition":
                 chk.setEnabled(False)
                 chk.setChecked(True)
-                
+
             v.addWidget(chk)
             self._stage_checkboxes[stage] = chk
-            
+
         v.addStretch()
         scroll.setWidget(content)
         layout.addWidget(scroll)
-        
+
         # Helper buttons
         btn_layout = QHBoxLayout()
         btn_all = QPushButton("Select All")
@@ -233,11 +245,11 @@ class AnalysisSettingsDialog(QDialog):
         btn_layout.addWidget(btn_none)
         btn_layout.addStretch()
         layout.addLayout(btn_layout)
-        
+
         return w
 
     def _on_step_toggled(self, stage: str, state: int):
-        checked = (state == Qt.CheckState.Checked.value)
+        checked = state == Qt.CheckState.Checked.value
         if checked:
             self._enabled_stages.add(stage)
         else:
@@ -263,16 +275,18 @@ class AnalysisSettingsDialog(QDialog):
                 # Or assume it relies on 'profile_fitting' or similar?
                 # For now let's always show it if it exists
                 continue
-                
+
             idx = self._tabs.indexOf(widget)
             if idx >= 0:
                 is_enabled = stage in self._enabled_stages
                 # Edge detection alias
-                if stage == "contour_extraction": 
-                    is_enabled = is_enabled or ("edge_detection" in self._enabled_stages)
-                
+                if stage == "contour_extraction":
+                    is_enabled = is_enabled or (
+                        "edge_detection" in self._enabled_stages
+                    )
+
                 self._tabs.setTabVisible(idx, is_enabled)
-                
+
     # --- Tab Builders ---
 
     def _build_preproc_tab(self) -> QWidget:
@@ -302,12 +316,19 @@ class AnalysisSettingsDialog(QDialog):
 
         # Import specific registry for edge detectors
         from menipy.common.registry import EDGE_DETECTORS
-        
+
         # Get available methods from registry, fallback to defaults if empty
         methods = sorted(EDGE_DETECTORS.keys())
         if not methods:
-            methods = ["canny", "sobel", "scharr", "laplacian", "threshold", "active_contour"]
-            
+            methods = [
+                "canny",
+                "sobel",
+                "scharr",
+                "laplacian",
+                "threshold",
+                "active_contour",
+            ]
+
         self._edge_method = QComboBox()
         self._edge_method.addItems(methods)
         self._edge_method.setCurrentText(self._edge.method)
@@ -320,7 +341,7 @@ class AnalysisSettingsDialog(QDialog):
 
         # Add some summary text or status if desired?
         # For now, just the button as requested.
-        
+
         return w
 
     def _configure_edge_parameters(self):
@@ -328,16 +349,19 @@ class AnalysisSettingsDialog(QDialog):
         # Ensure current method selection is synced
         method = self._edge_method.currentText()
         self._edge.method = method
-        
+
         from menipy.common.plugin_settings import get_detector_settings_model
         from menipy.gui.dialogs.plugin_config_dialog import PluginConfigDialog
-        
+
         plugin_model = get_detector_settings_model(method)
-        
+
         if not plugin_model:
             # Fallback for unconfigured methods
             from PySide6.QtWidgets import QMessageBox
-            QMessageBox.information(self, "Configuration", f"No specific settings for '{method}'.")
+
+            QMessageBox.information(
+                self, "Configuration", f"No specific settings for '{method}'."
+            )
             return
 
         # Prepare defaults from legacy fields to ensure UI reflects current state
@@ -348,138 +372,164 @@ class AnalysisSettingsDialog(QDialog):
                 "threshold1": s.canny_threshold1,
                 "threshold2": s.canny_threshold2,
                 "aperture_size": s.canny_aperture_size,
-                "L2gradient": s.canny_L2_gradient
+                "L2gradient": s.canny_L2_gradient,
             }
         elif method == "threshold":
             defaults = {
                 "threshold_value": s.threshold_value,
                 "max_value": s.threshold_max_value,
-                "type": s.threshold_type
+                "type": s.threshold_type,
             }
         elif method == "sobel":
             defaults = {
                 "kernel_size": s.sobel_kernel_size,
                 "threshold_value": s.threshold_value,
-                "max_value": s.threshold_max_value
+                "max_value": s.threshold_max_value,
             }
         elif method == "scharr":
             defaults = {
                 "threshold_value": s.threshold_value,
-                "max_value": s.threshold_max_value
+                "max_value": s.threshold_max_value,
             }
         elif method == "laplacian":
             defaults = {
                 "kernel_size": s.laplacian_kernel_size,
                 "threshold_value": s.threshold_value,
-                "max_value": s.threshold_max_value
+                "max_value": s.threshold_max_value,
             }
         elif method in ("legacy_snake", "active_contour", "improved_snake"):
             defaults = {
                 "iterations": s.snake_iterations,
                 "alpha": s.snake_alpha,
                 "beta": s.snake_beta,
-                "gamma": s.snake_gamma
+                "gamma": s.snake_gamma,
             }
 
         # Resolve current settings: plugin specific takes precedence?
         # Actually, legacy fields are the "true" state for core methods currently.
-        # So defaults (legacy) should override stored plugin_settings if present, 
+        # So defaults (legacy) should override stored plugin_settings if present,
         # unless we consider plugin_settings the new truth?
         # Let's assume legacy fields are strict master for now.
-        
+
         saved_data = s.plugin_settings.get(method, {})
         # Start with saved, update with legacy defaults
         current_data = saved_data.copy()
         current_data.update(defaults)
-        
+
         dlg = PluginConfigDialog(plugin_model, current_data, parent=self)
         if dlg.exec():
             new_settings = dlg.get_settings()
-            
+
             # 1. Update plugin_settings dict
             if self._edge.plugin_settings is None:
                 self._edge.plugin_settings = {}
             self._edge.plugin_settings[method] = new_settings
-            
+
             # 2. Scync BACK to legacy fields
             if method == "canny":
                 s.canny_threshold1 = new_settings.get("threshold1", s.canny_threshold1)
                 s.canny_threshold2 = new_settings.get("threshold2", s.canny_threshold2)
-                s.canny_aperture_size = new_settings.get("aperture_size", s.canny_aperture_size)
-                s.canny_L2_gradient = new_settings.get("L2gradient", s.canny_L2_gradient)
+                s.canny_aperture_size = new_settings.get(
+                    "aperture_size", s.canny_aperture_size
+                )
+                s.canny_L2_gradient = new_settings.get(
+                    "L2gradient", s.canny_L2_gradient
+                )
             elif method == "threshold":
-                s.threshold_value = new_settings.get("threshold_value", s.threshold_value)
-                s.threshold_max_value = new_settings.get("max_value", s.threshold_max_value)
+                s.threshold_value = new_settings.get(
+                    "threshold_value", s.threshold_value
+                )
+                s.threshold_max_value = new_settings.get(
+                    "max_value", s.threshold_max_value
+                )
                 s.threshold_type = new_settings.get("type", s.threshold_type)
             elif method == "sobel":
-                s.sobel_kernel_size = new_settings.get("kernel_size", s.sobel_kernel_size)
-                s.threshold_value = new_settings.get("threshold_value", s.threshold_value)
-                s.threshold_max_value = new_settings.get("max_value", s.threshold_max_value)
+                s.sobel_kernel_size = new_settings.get(
+                    "kernel_size", s.sobel_kernel_size
+                )
+                s.threshold_value = new_settings.get(
+                    "threshold_value", s.threshold_value
+                )
+                s.threshold_max_value = new_settings.get(
+                    "max_value", s.threshold_max_value
+                )
             elif method == "scharr":
-                s.threshold_value = new_settings.get("threshold_value", s.threshold_value)
-                s.threshold_max_value = new_settings.get("max_value", s.threshold_max_value)
+                s.threshold_value = new_settings.get(
+                    "threshold_value", s.threshold_value
+                )
+                s.threshold_max_value = new_settings.get(
+                    "max_value", s.threshold_max_value
+                )
             elif method == "laplacian":
-                s.laplacian_kernel_size = new_settings.get("kernel_size", s.laplacian_kernel_size)
-                s.threshold_value = new_settings.get("threshold_value", s.threshold_value)
-                s.threshold_max_value = new_settings.get("max_value", s.threshold_max_value)
+                s.laplacian_kernel_size = new_settings.get(
+                    "kernel_size", s.laplacian_kernel_size
+                )
+                s.threshold_value = new_settings.get(
+                    "threshold_value", s.threshold_value
+                )
+                s.threshold_max_value = new_settings.get(
+                    "max_value", s.threshold_max_value
+                )
             elif method in ("legacy_snake", "active_contour", "improved_snake"):
                 s.snake_iterations = new_settings.get("iterations", s.snake_iterations)
                 s.snake_alpha = new_settings.get("alpha", s.snake_alpha)
                 s.snake_beta = new_settings.get("beta", s.snake_beta)
                 s.snake_gamma = new_settings.get("gamma", s.snake_gamma)
-        
+
     def _build_physics_tab(self) -> QWidget:
         """Tab for PhysicsParams using PhysicsConfigDialog."""
         w = QWidget()
         v = QVBoxLayout(w)
         v.setContentsMargins(12, 12, 12, 12)
-        
+
         lbl = QLabel("Configure physical parameters (density, gravity, etc).")
         v.addWidget(lbl)
-        
-        self._physics_summary = QLabel(str(self._physics_params)) # Just basic str for now
+
+        self._physics_summary = QLabel(
+            str(self._physics_params)
+        )  # Just basic str for now
         self._physics_summary.setWordWrap(True)
         self._physics_summary.setStyleSheet("color: #7f8c8d;")
         v.addWidget(self._physics_summary)
-        
+
         btn = QPushButton("Configure Physics...")
         btn.clicked.connect(self._open_physics_dialog)
         v.addWidget(btn)
         v.addStretch(1)
         return w
-        
+
     def _build_geometry_tab(self) -> QWidget:
         """Tab for Geometry settings using GeometryConfigDialog."""
         w = QWidget()
         v = QVBoxLayout(w)
         v.setContentsMargins(12, 12, 12, 12)
-        
+
         lbl = QLabel("Configure geometry and detector options.")
         v.addWidget(lbl)
-        
+
         self._geometry_summary = QLabel(f"Config: {len(self._geometry_config)} keys")
         self._geometry_summary.setStyleSheet("color: #7f8c8d;")
         v.addWidget(self._geometry_summary)
-        
+
         btn = QPushButton("Configure Geometry...")
         btn.clicked.connect(self._open_geometry_dialog)
         v.addWidget(btn)
         v.addStretch(1)
         return w
-        
+
     def _build_overlay_tab(self) -> QWidget:
         """Tab for Overlay settings using OverlayConfigDialog."""
         w = QWidget()
         v = QVBoxLayout(w)
         v.setContentsMargins(12, 12, 12, 12)
-        
+
         lbl = QLabel("Configure result overlay styling.")
         v.addWidget(lbl)
-        
+
         self._overlay_summary = QLabel(f"Overlay style configured.")
         self._overlay_summary.setStyleSheet("color: #7f8c8d;")
         v.addWidget(self._overlay_summary)
-        
+
         btn = QPushButton("Configure Overlay...")
         btn.clicked.connect(self._open_overlay_dialog)
         v.addWidget(btn)
@@ -488,12 +538,16 @@ class AnalysisSettingsDialog(QDialog):
 
     def _build_pipeline_custom_tab(self) -> Optional[QWidget]:
         """Load pipeline-specific settings widget if available."""
-        module_name = f"menipy.gui.dialogs.analysis_settings.{self._pipeline_name}_settings"
+        module_name = (
+            f"menipy.gui.dialogs.analysis_settings.{self._pipeline_name}_settings"
+        )
         try:
             mod = import_module(module_name)
             widget_cls = getattr(mod, "PipelineSettingsWidget", None)
             if widget_cls:
-                self._pipeline_widget = widget_cls(parent=self, settings=self._pipeline_settings_dict)
+                self._pipeline_widget = widget_cls(
+                    parent=self, settings=self._pipeline_settings_dict
+                )
                 return self._pipeline_widget
         except ModuleNotFoundError:
             pass
@@ -518,23 +572,24 @@ class AnalysisSettingsDialog(QDialog):
     def _open_geometry_dialog(self):
         dlg = GeometryConfigDialog(parent=self)
         dlg.set_config(self._geometry_config)
-        dlg.configApplied.connect(lambda cfg: setattr(self, '_geometry_config', cfg))
+        dlg.configApplied.connect(lambda cfg: setattr(self, "_geometry_config", cfg))
         if dlg.exec():
             # Already handled by signal or just update on accept
-             pass
+            pass
         # After exec, assume configApplied handled it or get it
         self._geometry_config = dlg.get_config()
-        self._geometry_summary.setText(f"Detector: {self._geometry_config.get('detector')}")
+        self._geometry_summary.setText(
+            f"Detector: {self._geometry_config.get('detector')}"
+        )
 
     def _open_overlay_dialog(self):
         """_open_overlay_dialog."""
         dlg = OverlayConfigDialog(parent=self)
         dlg.set_config(self._overlay_config)
-        dlg.configApplied.connect(lambda cfg: setattr(self, '_overlay_config', cfg))
+        dlg.configApplied.connect(lambda cfg: setattr(self, "_overlay_config", cfg))
         if dlg.exec():
             pass
         self._overlay_config = dlg.get_config()
-
 
     def _preproc_summary(self) -> str:
         """_preproc_summary."""
@@ -551,8 +606,16 @@ class AnalysisSettingsDialog(QDialog):
             return {}
         try:
             data = json.loads(raw)
-            pre = PreprocessingSettings(**data.get("preproc", {})) if data.get("preproc") else None
-            edge = EdgeDetectionSettings(**data.get("edge", {})) if data.get("edge") else None
+            pre = (
+                PreprocessingSettings(**data.get("preproc", {}))
+                if data.get("preproc")
+                else None
+            )
+            edge = (
+                EdgeDetectionSettings(**data.get("edge", {}))
+                if data.get("edge")
+                else None
+            )
             pipe = data.get("pipeline") or {}
             # We don't unpack physics/overlay from 'pipeline' key here directly, caller init takes care of defaults
             return {"preproc": pre, "edge": edge, "pipeline": pipe}
@@ -563,7 +626,7 @@ class AnalysisSettingsDialog(QDialog):
         """Persist current selections to QSettings."""
         # Update pipeline settings with all sub-configs
         pipe_settings = self.pipeline_settings() or {}
-        
+
         payload = {
             "preproc": self._preproc.model_dump(),
             "edge": self.edge_settings().model_dump(),
@@ -594,11 +657,11 @@ class AnalysisSettingsDialog(QDialog):
         settings = {}
         if self._pipeline_widget and hasattr(self._pipeline_widget, "get_settings"):
             settings = self._pipeline_widget.get_settings() or {}
-        
+
         # Merge all our dynamic tabs
         settings["enabled_stages"] = list(self._enabled_stages)
         settings["physics"] = self._physics_params.model_dump()
         settings["geometry_config"] = self._geometry_config
         settings["overlay_config"] = self._overlay_config
-        
+
         return settings

--- a/src/menipy/gui/dialogs/calibration_wizard.py
+++ b/src/menipy/gui/dialogs/calibration_wizard.py
@@ -3,12 +3,21 @@ Calibration Wizard
 
 Dialog for performing spatial calibration (pixels -> mm).
 """
+
 from PySide6.QtCore import Qt, Signal, QPointF
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QPushButton, QStackedWidget, QDoubleSpinBox, QMessageBox,
-    QFileDialog, QWidget
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QStackedWidget,
+    QDoubleSpinBox,
+    QMessageBox,
+    QFileDialog,
+    QWidget,
 )
 import numpy as np
 
@@ -19,20 +28,22 @@ from menipy.gui.widgets.interactive_image_viewer import InteractiveImageViewer
 class CalibrationWizard(QDialog):
     """
     Wizard for calibrating spatial scale.
-    
+
     Stages:
         1. Select Image (skip if provided)
     2. Measure Reference (draw line)
     3. Enter Dimension
     4. Result & Apply
-    
+
     Signals:
         calibration_completed(scale_factor_px_mm): Emitted when calibration finishes.
     """
-    
+
     calibration_completed = Signal(float)
-    
-    def __init__(self, parent=None, pixmap: QPixmap = None, image_data: np.ndarray = None):
+
+    def __init__(
+        self, parent=None, pixmap: QPixmap = None, image_data: np.ndarray = None
+    ):
         """Initialize.
 
         Parameters
@@ -48,13 +59,13 @@ class CalibrationWizard(QDialog):
         self.setWindowTitle("Calibration Wizard")
         self.resize(900, 700)
         self._pixmap = pixmap
-        self._image_data = image_data # Raw numpy array (preferred for detection)
-        
+        self._image_data = image_data  # Raw numpy array (preferred for detection)
+
         self._current_dist_px = 0.0
-        
+
         # State
         self._calibration_result = 0.0  # px/mm
-        
+
         self._setup_ui()
         if self._pixmap:
             self._viewer.set_image(self._pixmap)
@@ -63,133 +74,143 @@ class CalibrationWizard(QDialog):
             # Page 0 is Load Image.
             self._pages.setCurrentIndex(1)
             self._update_buttons()
-    
+
     def _setup_ui(self):
         self.setStyleSheet(theme.get_stylesheet())
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(20)
-        
+
         # Header
         self._header = QLabel("Calibration Wizard")
         self._header.setProperty("title", True)
         layout.addWidget(self._header)
-        
+
         # Progress Steps (simplified)
         self._step_label = QLabel("Step 1: Measurement")
-        self._step_label.setStyleSheet(f"color: {theme.ACCENT_BLUE}; font-weight: bold;")
+        self._step_label.setStyleSheet(
+            f"color: {theme.ACCENT_BLUE}; font-weight: bold;"
+        )
         layout.addWidget(self._step_label)
-        
+
         # Content Pages
         self._pages = QStackedWidget()
-        
+
         # Page 0: Image Selection (if needed)
         self._page_image = self._create_page_image()
         self._pages.addWidget(self._page_image)
-        
+
         # Page 1: Auto Detect (New)
         self._page_auto_detect = self._create_page_auto_detect()
         self._pages.addWidget(self._page_auto_detect)
-        
+
         # Page 2: Measurement (Interactive)
         self._page_measure = self._create_page_measure()
         self._pages.addWidget(self._page_measure)
-        
+
         # Page 2: Dimension Input
         self._page_input = self._create_page_input()
         self._pages.addWidget(self._page_input)
-        
+
         layout.addWidget(self._pages, stretch=1)
-        
+
         # Footer Navigation
         footer = QHBoxLayout()
         footer.addStretch()
-        
+
         self._btn_back = QPushButton("Back")
         self._btn_back.setProperty("secondary", True)
         self._btn_back.clicked.connect(self._go_back)
         footer.addWidget(self._btn_back)
-        
+
         self._btn_next = QPushButton("Next")
         self._btn_next.clicked.connect(self._go_next)
         footer.addWidget(self._btn_next)
-        
+
         layout.addLayout(footer)
-        
+
         self._update_buttons()
-        
+
     def _create_page_image(self) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
-        
-        lbl = QLabel("Please load an image containing a known reference object (ruler, coin, etc).")
+
+        lbl = QLabel(
+            "Please load an image containing a known reference object (ruler, coin, etc)."
+        )
         lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(lbl)
-        
+
         btn = QPushButton("Load Image")
         btn.clicked.connect(self._load_image)
         layout.addWidget(btn, alignment=Qt.AlignmentFlag.AlignCenter)
-        
+
         return container
-        
+
     def _create_page_measure(self) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
-        
-        instruction = QLabel("Click and drag to draw a line along the known reference length.")
+
+        instruction = QLabel(
+            "Click and drag to draw a line along the known reference length."
+        )
         instruction.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(instruction)
-        
+
         self._viewer = InteractiveImageViewer()
         self._viewer.set_tool(InteractiveImageViewer.TOOL_LINE)
         self._viewer.line_drawn.connect(self._on_line_drawn)
-        
+
         # Frame for viewer
         frame = QFrame()
         frame.setStyleSheet(f"border: 1px solid {theme.BORDER_DEFAULT};")
         frame_layout = QVBoxLayout(frame)
-        frame_layout.setContentsMargins(0,0,0,0)
+        frame_layout.setContentsMargins(0, 0, 0, 0)
         frame_layout.addWidget(self._viewer)
         layout.addWidget(frame, stretch=1)
-        
+
         self._measure_status = QLabel("Draw a line to measure...")
         self._measure_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._measure_status)
-        
+
         return container
-        
+
     def _create_page_auto_detect(self) -> QWidget:
         """Page for auto-detecting needle width."""
         container = QWidget()
         layout = QVBoxLayout(container)
-        
+
         lbl = QLabel("Automatic Needle Detection")
-        lbl.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {theme.TEXT_PRIMARY};")
+        lbl.setStyleSheet(
+            f"font-size: 16px; font-weight: bold; color: {theme.TEXT_PRIMARY};"
+        )
         lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(lbl)
-        
-        desc = QLabel("The wizard can attempt to automatically detect the needle width in pixels.\n"
-                      "If successful, you can skip manual measurement.")
+
+        desc = QLabel(
+            "The wizard can attempt to automatically detect the needle width in pixels.\n"
+            "If successful, you can skip manual measurement."
+        )
         desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
         desc.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(desc)
-        
+
         btn_layout = QHBoxLayout()
         btn_layout.addStretch()
-        
+
         self._btn_run_detect = QPushButton("🔍 Run Auto-Detect")
         self._btn_run_detect.setMinimumHeight(40)
         self._btn_run_detect.clicked.connect(self._run_needle_detection)
         btn_layout.addWidget(self._btn_run_detect)
-        
+
         btn_layout.addStretch()
         layout.addLayout(btn_layout)
-        
+
         self._auto_status = QLabel("")
         self._auto_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._auto_status)
-        
+
         layout.addStretch()
         return container
 
@@ -197,116 +218,122 @@ class CalibrationWizard(QDialog):
         """Run the needle detection logic."""
         if not self._pixmap:
             return
-            
+
         self._auto_status.setText("Running detection...")
-        
+
         try:
             if self._image_data is not None:
-                 # Assume input is BGR or RGB depending on source.
-                 # menipy usually loads images via cv2 (BGR) or QImage (RGB/RGBA).
-                 # If passed from SessileDropWindow (cv2.imread), it is BGR.
-                 # Context expects BGR or gray usually.
-                 rgb = self._image_data
+                # Assume input is BGR or RGB depending on source.
+                # menipy usually loads images via cv2 (BGR) or QImage (RGB/RGBA).
+                # If passed from SessileDropWindow (cv2.imread), it is BGR.
+                # Context expects BGR or gray usually.
+                rgb = self._image_data
             elif self._pixmap:
                 # Convert pixmap to numpy (RGBA) -> BGR (standard for openCV)
                 image = self._pixmap.toImage()
                 width = image.width()
                 height = image.height()
-                
+
                 ptr = image.bits()
                 # ptr.setsize(image.sizeInBytes()) # Not needed for memoryview
-                
+
                 import numpy as np
+
                 # Expecting 4 bytes per pixel (RGBA) from QImage
                 flattened = np.array(ptr).reshape(height, width, 4)
                 # Convert RGBA to BGR for OpenCV
                 import cv2
+
                 rgb = cv2.cvtColor(flattened, cv2.COLOR_RGBA2BGR)
             else:
                 return
-            
+
             # Create Context
             from menipy.models.context import Context
+
             ctx = Context(image=rgb)
-            ctx.pipeline_name = "sessile" # Default to sessile or try to infer?
-            # Assuming sessile for now as it's the main use case. 
+            ctx.pipeline_name = "sessile"  # Default to sessile or try to infer?
+            # Assuming sessile for now as it's the main use case.
             # Could pass pipeline type into wizard logic if needed.
-            
+
             # Use the robust AutoCalibrator from the main implementation
             try:
                 from menipy.common.auto_calibrator import run_auto_calibration
-                
+
                 # Run full auto-calibration (detects substrate, needle, drop, ROI)
                 # This matches the "Auto-Calibrate" logic in the main application
-                calib_result = run_auto_calibration(
-                    rgb, 
-                    pipeline_name="sessile"
-                )
-                
+                calib_result = run_auto_calibration(rgb, pipeline_name="sessile")
+
                 if calib_result and calib_result.needle_rect:
                     x, y, w, h = calib_result.needle_rect
                     self._current_dist_px = float(w)
-                    
+
                     # Also update feedback with confidence if available
                     conf = calib_result.confidence_scores.get("needle", 0.0)
-                    self._auto_status.setText(f"Success! Detected width: {w:.1f} px (Conf: {conf*100:.0f}%)")
-                    self._auto_status.setStyleSheet(f"color: {theme.SUCCESS_GREEN}; font-weight: bold;")
-                    
+                    self._auto_status.setText(
+                        f"Success! Detected width: {w:.1f} px (Conf: {conf*100:.0f}%)"
+                    )
+                    self._auto_status.setStyleSheet(
+                        f"color: {theme.SUCCESS_GREEN}; font-weight: bold;"
+                    )
+
                     # Draw visual feedback
                     mid_y = y + h - 5
                     p1 = QPointF(x, mid_y)
                     p2 = QPointF(x + w, mid_y)
                     self._viewer.set_static_line(p1, p2)
-                    
+
                     # Advance to measure/dimension page
                     self._pages.setCurrentIndex(2)
                     self._update_buttons()
                     return
-                    
+
                 else:
-                     self._auto_status.setText("Needle not detected.")
-                     self._auto_status.setStyleSheet(f"color: {theme.WARNING_ORANGE};")
-                     return
+                    self._auto_status.setText("Needle not detected.")
+                    self._auto_status.setStyleSheet(f"color: {theme.WARNING_ORANGE};")
+                    return
 
             except ImportError:
-                 # Fallback if module not found (detected during dev/testing)
-                 self._auto_status.setText("Error: AutoCalibrator module not found.")
-                 return
+                # Fallback if module not found (detected during dev/testing)
+                self._auto_status.setText("Error: AutoCalibrator module not found.")
+                return
             except Exception as e:
-                 self._auto_status.setText(f"Detection error: {e}")
-                 import traceback
-                 traceback.print_exc()
-                 return
-                 
+                self._auto_status.setText(f"Detection error: {e}")
+                import traceback
+
+                traceback.print_exc()
+                return
+
         except Exception as e:
             self._auto_status.setText(f"Error: {e}")
             import traceback
+
             traceback.print_exc()
 
     def _on_db_requested(self):
         """Handle DB button click."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
+
         dialog = MaterialDialog(self, selection_mode=True, table_type="needles")
         dialog.item_selected.connect(self._on_needle_selected)
         dialog.exec()
-        
+
     def _on_needle_selected(self, data: dict):
         if diameter := data.get("outer_diameter"):
             self._length_spin.setValue(float(diameter))
 
-        
     def _create_page_input(self) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.setSpacing(20)
-        
+
         lbl = QLabel("Enter the physical length of the line you drew:")
         layout.addWidget(lbl)
-        
+
         input_row = QHBoxLayout()
         input_row.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
+
         self._length_spin = QDoubleSpinBox()
         self._length_spin.setRange(0.001, 1000.0)
         self._length_spin.setDecimals(3)
@@ -314,10 +341,10 @@ class CalibrationWizard(QDialog):
         self._length_spin.setFixedWidth(150)
         self._length_spin.valueChanged.connect(self._calculate_result)
         input_row.addWidget(self._length_spin)
-        
+
         self._unit_label = QLabel("mm")
         input_row.addWidget(self._unit_label)
-        
+
         # DB Button
         db_btn = QPushButton("📚 DB")
         db_btn.setFixedSize(50, 24)
@@ -325,55 +352,59 @@ class CalibrationWizard(QDialog):
         db_btn.setProperty("secondary", True)
         db_btn.clicked.connect(self._on_db_requested)
         input_row.addWidget(db_btn)
-        
+
         layout.addLayout(input_row)
-        
+
         # Result preview
         self._result_preview = QLabel("Result: -- px/mm")
-        self._result_preview.setStyleSheet(f"font-size: 18px; color: {theme.ACCENT_BLUE}; font-weight: bold;")
+        self._result_preview.setStyleSheet(
+            f"font-size: 18px; color: {theme.ACCENT_BLUE}; font-weight: bold;"
+        )
         layout.addWidget(self._result_preview)
-        
+
         return container
-        
+
     def _update_buttons(self):
         idx = self._pages.currentIndex()
         count = self._pages.count()
-        
+
         self._btn_back.setEnabled(idx > 0)
-        
+
         if idx == count - 1:
             self._btn_next.setText("Finish")
             self._step_label.setText(f"Step {idx+1}: Confirm")
         else:
             self._btn_next.setText("Next")
-            
+
             if idx == 0:
                 self._step_label.setText("Step 1: Load Image")
                 self._btn_next.setEnabled(self._pixmap is not None)
             elif idx == 1:
                 self._step_label.setText("Step 2: Measure Reference")
                 self._btn_next.setEnabled(self._current_dist_px > 0)
-    
+
     def _load_image(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Load Image", "", "Images (*.png *.jpg *.tif)")
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load Image", "", "Images (*.png *.jpg *.tif)"
+        )
         if path:
             self._pixmap = QPixmap(path)
             self._viewer.set_image(self._pixmap)
             self._update_buttons()
-            
+
     def _on_line_drawn(self, p1, p2, dist):
         self._current_dist_px = dist
         self._measure_status.setText(f"Measured Distance: {dist:.2f} px")
         self._calculate_result()
         self._update_buttons()
-        
+
     def _calculate_result(self):
         phys_len = self._length_spin.value()
         if phys_len > 0 and self._current_dist_px > 0:
             res = self._current_dist_px / phys_len
             self._calibration_result = res
             self._result_preview.setText(f"Result: {res:.2f} px/mm")
-            
+
     def _go_next(self):
         idx = self._pages.currentIndex()
         if idx < self._pages.count() - 1:
@@ -386,7 +417,7 @@ class CalibrationWizard(QDialog):
                 self.accept()
             else:
                 QMessageBox.warning(self, "Error", "Invalid calibration result.")
-                
+
     def _go_back(self):
         idx = self._pages.currentIndex()
         if idx > 0:

--- a/src/menipy/gui/dialogs/calibration_wizard_dialog.py
+++ b/src/menipy/gui/dialogs/calibration_wizard_dialog.py
@@ -4,6 +4,7 @@ Calibration Wizard Dialog for automatic region detection.
 This dialog provides a step-by-step wizard for automatic detection of
 substrate, needle, drop, and ROI regions with live preview.
 """
+
 from __future__ import annotations
 
 import logging
@@ -38,21 +39,21 @@ logger = logging.getLogger(__name__)
 class CalibrationWizardDialog(QDialog):
     """
     Modal wizard dialog for automatic calibration with preview.
-    
+
     Displays detected regions overlaid on the image and allows the user
     to accept, reject, or manually adjust each detected region.
     """
-    
+
     # Emitted when user accepts calibration results
     calibration_complete = Signal(object)  # CalibrationResult
-    
+
     # Colors for overlay visualization
-    SUBSTRATE_COLOR = QColor(255, 0, 255)     # Magenta
-    NEEDLE_COLOR = QColor(0, 0, 255)          # Blue
-    DROP_COLOR = QColor(0, 255, 0)            # Green
-    ROI_COLOR = QColor(255, 255, 0)           # Yellow
-    CONTACT_COLOR = QColor(255, 0, 0)         # Red
-    
+    SUBSTRATE_COLOR = QColor(255, 0, 255)  # Magenta
+    NEEDLE_COLOR = QColor(0, 0, 255)  # Blue
+    DROP_COLOR = QColor(0, 255, 0)  # Green
+    ROI_COLOR = QColor(255, 255, 0)  # Yellow
+    CONTACT_COLOR = QColor(255, 0, 0)  # Red
+
     def __init__(
         self,
         image: np.ndarray,
@@ -61,7 +62,7 @@ class CalibrationWizardDialog(QDialog):
     ) -> None:
         """
         Initialize the calibration wizard dialog.
-        
+
         Args:
             image: Input image (BGR format)
             pipeline_name: Pipeline type for detection strategy
@@ -71,11 +72,11 @@ class CalibrationWizardDialog(QDialog):
         self.setWindowTitle(f"Calibration Wizard - {pipeline_name.title()}")
         self.setMinimumSize(800, 600)
         self.setModal(True)
-        
+
         self.original_image = image.copy()
         self.pipeline_name = pipeline_name.lower()
         self.result: Optional[CalibrationResult] = None
-        
+
         # Region enable flags
         self._region_enabled = {
             "substrate": True,
@@ -84,25 +85,25 @@ class CalibrationWizardDialog(QDialog):
             "contact": True,  # Contact points
             "roi": True,
         }
-        
+
         # Drawing state for manual regions
         self._drawing_mode = None  # None, "substrate", "needle", or "roi"
         self._draw_start_point = None
         self._draw_end_point = None
-        
+
         # Legacy compatibility
         self._drawing_substrate = False
         self._substrate_start_point = None
         self._substrate_end_point = None
-        
+
         self._build_ui()
         self._wire_signals()
-    
+
     def _build_ui(self) -> None:
         """Build the dialog UI."""
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
-        
+
         # Header
         header = QLabel(
             f"<b>Auto-Calibration for {self.pipeline_name.title()} Pipeline</b><br>"
@@ -110,31 +111,31 @@ class CalibrationWizardDialog(QDialog):
         )
         header.setWordWrap(True)
         layout.addWidget(header)
-        
+
         # Progress bar (initially hidden)
         self._progress = QProgressBar()
         self._progress.setRange(0, 0)  # Indeterminate
         self._progress.hide()
         layout.addWidget(self._progress)
-        
+
         # Main content area
         content_layout = QHBoxLayout()
-        
+
         # Left: Image preview
         preview_group = QGroupBox("Preview")
         preview_layout = QVBoxLayout(preview_group)
-        
+
         # Scroll area for large images
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setMinimumSize(500, 400)
-        
+
         self._preview_label = QLabel()
         self._preview_label.setAlignment(Qt.AlignCenter)
         self._preview_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         scroll.setWidget(self._preview_label)
         preview_layout.addWidget(scroll)
-        
+
         zoom_layout = QHBoxLayout()
         self._fit_btn = QPushButton("Fit to Window")
         self._actual_btn = QPushButton("100%")
@@ -142,22 +143,22 @@ class CalibrationWizardDialog(QDialog):
         zoom_layout.addWidget(self._actual_btn)
         zoom_layout.addStretch()
         preview_layout.addLayout(zoom_layout)
-        
+
         # Enable mouse tracking for drawing
         self._preview_label.setMouseTracking(True)
         self._preview_label.mousePressEvent = self._on_preview_mouse_press
         self._preview_label.mouseMoveEvent = self._on_preview_mouse_move
         self._preview_label.mouseReleaseEvent = self._on_preview_mouse_release
-        
+
         content_layout.addWidget(preview_group, stretch=3)
-        
+
         # Right: Detection results
         results_group = QGroupBox("Detected Regions")
         results_layout = QVBoxLayout(results_group)
-        
+
         # Region checkboxes with status
         self._region_widgets = {}
-        
+
         regions = [
             ("substrate", "Substrate Line", self.SUBSTRATE_COLOR),
             ("needle", "Needle Region", self.NEEDLE_COLOR),
@@ -165,25 +166,25 @@ class CalibrationWizardDialog(QDialog):
             ("contact", "Contact Points", self.CONTACT_COLOR),
             ("roi", "ROI Rectangle", self.ROI_COLOR),
         ]
-        
+
         for region_id, label, color in regions:
             widget = self._create_region_widget(region_id, label, color)
             results_layout.addWidget(widget)
             self._region_widgets[region_id] = widget
-        
+
         results_layout.addStretch()
-        
+
         # Confidence display
         self._confidence_label = QLabel("Confidence: --")
         self._confidence_label.setStyleSheet("font-weight: bold;")
         results_layout.addWidget(self._confidence_label)
-        
+
         content_layout.addWidget(results_group, stretch=1)
         layout.addLayout(content_layout)
-        
+
         # Bottom buttons
         button_layout = QHBoxLayout()
-        
+
         self._detect_btn = QPushButton("🔍 Detect")
         self._detect_btn.setMinimumHeight(40)
         self._detect_btn.setStyleSheet("""
@@ -198,10 +199,10 @@ class CalibrationWizardDialog(QDialog):
                 background-color: #357ABD;
             }
         """)
-        
+
         self._cancel_btn = QPushButton("Cancel")
         self._cancel_btn.setMinimumHeight(35)
-        
+
         self._apply_btn = QPushButton("✓ Apply All")
         self._apply_btn.setMinimumHeight(40)
         self._apply_btn.setEnabled(False)
@@ -220,16 +221,16 @@ class CalibrationWizardDialog(QDialog):
                 background-color: #cccccc;
             }
         """)
-        
+
         button_layout.addWidget(self._detect_btn)
         button_layout.addStretch()
         button_layout.addWidget(self._cancel_btn)
         button_layout.addWidget(self._apply_btn)
         layout.addLayout(button_layout)
-        
+
         # Show original image initially
         self._show_original_image()
-    
+
     def _create_region_widget(
         self, region_id: str, label: str, color: QColor
     ) -> QWidget:
@@ -238,7 +239,7 @@ class CalibrationWizardDialog(QDialog):
         widget.setFrameShape(QFrame.StyledPanel)
         layout = QHBoxLayout(widget)
         layout.setContentsMargins(5, 5, 5, 5)
-        
+
         # Color indicator
         color_label = QLabel()
         color_label.setFixedSize(16, 16)
@@ -246,31 +247,31 @@ class CalibrationWizardDialog(QDialog):
             f"background-color: {color.name()}; border: 1px solid #333; border-radius: 3px;"
         )
         layout.addWidget(color_label)
-        
+
         # Checkbox
         checkbox = QCheckBox(label)
         checkbox.setChecked(True)
         checkbox.setProperty("region_id", region_id)
         layout.addWidget(checkbox)
-        
+
         # Status label
         status = QLabel("--")
         status.setAlignment(Qt.AlignRight)
         status.setMinimumWidth(60)
         layout.addWidget(status)
-        
+
         widget.checkbox = checkbox
         widget.status = status
         widget.color_label = color_label
         widget.draw_btn = None  # Will be set for drawable regions
-        
+
         # Add "Draw" button for drawable regions (substrate=line, needle=line, roi=rectangle)
         drawable_regions = {
             "substrate": ("✏ Draw", "Click to manually draw substrate line"),
             "needle": ("✏ Draw", "Click to manually draw needle line"),
             "roi": ("▢ Draw", "Click to manually draw ROI rectangle"),
         }
-        
+
         if region_id in drawable_regions:
             btn_text, tooltip = drawable_regions[region_id]
             draw_btn = QPushButton(btn_text)
@@ -295,9 +296,9 @@ class CalibrationWizardDialog(QDialog):
             draw_btn.clicked.connect(self._on_draw_region_clicked)
             layout.insertWidget(3, draw_btn)  # Insert before status
             widget.draw_btn = draw_btn
-        
+
         return widget
-    
+
     def _wire_signals(self) -> None:
         """Connect UI signals."""
         self._detect_btn.clicked.connect(self.run_detection)
@@ -305,101 +306,118 @@ class CalibrationWizardDialog(QDialog):
         self._apply_btn.clicked.connect(self._on_apply)
         self._fit_btn.clicked.connect(self._fit_preview)
         self._actual_btn.clicked.connect(self._actual_preview)
-        
+
         # Connect region checkboxes
         for region_id, widget in self._region_widgets.items():
             widget.checkbox.stateChanged.connect(self._on_region_toggled)
-    
+
     def _show_original_image(self) -> None:
         """Display the original image in the preview."""
         self._display_image(self.original_image)
-    
+
     def _display_image(self, image: np.ndarray) -> None:
         """Convert and display an image in the preview label."""
         if len(image.shape) == 2:
             # Grayscale
             qimg = QImage(
-                image.data, image.shape[1], image.shape[0],
-                image.strides[0], QImage.Format_Grayscale8
+                image.data,
+                image.shape[1],
+                image.shape[0],
+                image.strides[0],
+                QImage.Format_Grayscale8,
             )
         else:
             # BGR to RGB
             rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
             qimg = QImage(
-                rgb.data, rgb.shape[1], rgb.shape[0],
-                rgb.strides[0], QImage.Format_RGB888
+                rgb.data,
+                rgb.shape[1],
+                rgb.shape[0],
+                rgb.strides[0],
+                QImage.Format_RGB888,
             )
-        
+
         pixmap = QPixmap.fromImage(qimg)
         self._current_pixmap = pixmap
         self._fit_preview()
-    
+
     def _fit_preview(self) -> None:
         """Scale image to fit in preview area."""
-        if hasattr(self, '_current_pixmap'):
+        if hasattr(self, "_current_pixmap"):
             scaled = self._current_pixmap.scaled(
-                self._preview_label.size(),
-                Qt.KeepAspectRatio,
-                Qt.SmoothTransformation
+                self._preview_label.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation
             )
             self._preview_label.setPixmap(scaled)
-    
+
     def _actual_preview(self) -> None:
         """Show image at 100% scale."""
-        if hasattr(self, '_current_pixmap'):
+        if hasattr(self, "_current_pixmap"):
             self._preview_label.setPixmap(self._current_pixmap)
-    
+
     def run_detection(self) -> None:
         """Run automatic detection on the image.
-        
+
         Preserves manually drawn regions (substrate, ROI, needle) and only
         auto-detects regions that weren't manually specified.
         """
         self._progress.show()
         self._detect_btn.setEnabled(False)
-        
+
         # Preserve manually set values before auto-detection
         manual_substrate = None
         manual_roi = None
         manual_needle = None
-        
+
         if self.result:
             # Check if these were manually set (confidence = 1.0 indicates manual)
-            if self.result.substrate_line and self.result.confidence_scores.get("substrate", 0) >= 1.0:
+            if (
+                self.result.substrate_line
+                and self.result.confidence_scores.get("substrate", 0) >= 1.0
+            ):
                 manual_substrate = self.result.substrate_line
                 logger.info("Preserving manual substrate line")
-            if self.result.roi_rect and self.result.confidence_scores.get("roi", 0) >= 1.0:
+            if (
+                self.result.roi_rect
+                and self.result.confidence_scores.get("roi", 0) >= 1.0
+            ):
                 manual_roi = self.result.roi_rect
                 logger.info("Preserving manual ROI")
-            if self.result.needle_rect and self.result.confidence_scores.get("needle", 0) >= 1.0:
+            if (
+                self.result.needle_rect
+                and self.result.confidence_scores.get("needle", 0) >= 1.0
+            ):
                 manual_needle = self.result.needle_rect
                 logger.info("Preserving manual needle")
-        
+
         # Import here to avoid circular imports
         from menipy.common.auto_calibrator import run_auto_calibration, AutoCalibrator
-        
+
         try:
             logger.info(f"Running auto-calibration for {self.pipeline_name}...")
             self.result = self._run_best_auto_calibration(
                 run_auto_calibration,
                 allow_fallback=not (manual_substrate or manual_roi or manual_needle),
             )
-            
+
             # Restore manually set values
             need_redetect_drop = False
-            
+
             if manual_substrate:
                 self.result.substrate_line = manual_substrate
                 self.result.confidence_scores["substrate"] = 1.0
-                need_redetect_drop = True  # Need to re-detect drop with correct substrate
+                need_redetect_drop = (
+                    True  # Need to re-detect drop with correct substrate
+                )
             if manual_roi:
                 self.result.roi_rect = manual_roi
                 self.result.confidence_scores["roi"] = 1.0
             if manual_needle:
                 self.result.needle_rect = manual_needle
                 self.result.confidence_scores["needle"] = 1.0
-                need_redetect_drop = True  # Need to re-detect drop with correct needle filter
-            
+                need_redetect_drop = (
+                    True  # Need to re-detect drop with correct needle filter
+                )
+
             # Re-run drop detection if manual substrate/needle was set
             # This ensures drop is detected relative to correct substrate line
             if need_redetect_drop and manual_substrate:
@@ -421,7 +439,7 @@ class CalibrationWizardDialog(QDialog):
                     self.result.contact_points = contact_pts
                     self.result.confidence_scores["drop"] = drop_conf
                     logger.info(f"Drop re-detected with {len(drop_contour)} points")
-            
+
             self._show_results()
         except Exception as e:
             logger.exception("Auto-calibration failed")
@@ -445,9 +463,15 @@ class CalibrationWizardDialog(QDialog):
                     (detector_name, runner(self.original_image, detector_name))
                 )
             except Exception:
-                logger.debug("Fallback auto-calibration failed for %s", detector_name, exc_info=True)
+                logger.debug(
+                    "Fallback auto-calibration failed for %s",
+                    detector_name,
+                    exc_info=True,
+                )
 
-        best_name, best = max(candidates, key=lambda item: self._calibration_score(item[1]))
+        best_name, best = max(
+            candidates, key=lambda item: self._calibration_score(item[1])
+        )
         primary_score = self._calibration_score(primary)
         best_score = self._calibration_score(best)
         if best is not primary and best_score > primary_score + 0.15:
@@ -483,71 +507,69 @@ class CalibrationWizardDialog(QDialog):
         if result.substrate_line:
             score += 0.06
         return score
-    
+
     def _show_results(self) -> None:
         """Display detection results with overlays."""
         if self.result is None:
             return
-        
+
         # Create overlay image
         overlay = self._draw_overlays()
         self._display_image(overlay)
-        
+
         # Update status labels
         self._update_region_statuses()
-        
+
         # Update confidence
         overall = self.result.confidence_scores.get("overall", 0.0)
         self._confidence_label.setText(f"Overall Confidence: {overall * 100:.0f}%")
-        
+
         # Enable apply button
         self._apply_btn.setEnabled(True)
-    
+
     def _draw_overlays(self) -> np.ndarray:
         """Draw detection overlays on the image."""
         overlay = self.original_image.copy()
         result = self.result
-        
+
         if result is None:
             return overlay
-        
+
         # Draw substrate line
         if result.substrate_line and self._region_enabled.get("substrate", True):
             p1, p2 = result.substrate_line
-            cv2.line(
-                overlay,
-                p1, p2,
-                (255, 0, 255),  # Magenta (BGR)
-                2
-            )
+            cv2.line(overlay, p1, p2, (255, 0, 255), 2)  # Magenta (BGR)
             cv2.putText(
-                overlay, "Substrate",
+                overlay,
+                "Substrate",
                 (10, p1[1] - 10),
-                cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 0, 255), 1
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (255, 0, 255),
+                1,
             )
-        
+
         # Draw needle region
         if result.needle_rect and self._region_enabled.get("needle", True):
             x, y, w, h = result.needle_rect
-            cv2.rectangle(
-                overlay,
-                (x, y), (x + w, y + h),
-                (255, 0, 0),  # Blue (BGR)
-                2
-            )
+            cv2.rectangle(overlay, (x, y), (x + w, y + h), (255, 0, 0), 2)  # Blue (BGR)
             cv2.putText(
-                overlay, "Needle",
+                overlay,
+                "Needle",
                 (x + w + 5, y + h // 2),
-                cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 0, 0), 1
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (255, 0, 0),
+                1,
             )
-        
+
         # Draw drop contour
         if result.drop_contour is not None and self._region_enabled.get("drop", True):
             contour = np.asarray(result.drop_contour, dtype=np.int32)
             if contour.ndim == 2:
                 contour = contour.reshape(-1, 1, 2)
             cv2.drawContours(overlay, [contour], -1, (0, 255, 0), 2)  # Green (BGR)
-        
+
         # Draw contact points (separate from drop contour for independent visibility)
         if result.contact_points and self._region_enabled.get("contact", True):
             left, right = result.contact_points
@@ -555,81 +577,86 @@ class CalibrationWizardDialog(QDialog):
             cv2.circle(overlay, right, 5, (0, 0, 255), -1)
             # Draw connecting line for visibility
             cv2.line(overlay, left, right, (0, 0, 255), 1)
-        
+
         # Draw ROI rectangle
         if result.roi_rect and self._region_enabled.get("roi", True):
             x, y, w, h = result.roi_rect
             cv2.rectangle(
-                overlay,
-                (x, y), (x + w, y + h),
-                (0, 255, 255),  # Yellow (BGR)
-                2
+                overlay, (x, y), (x + w, y + h), (0, 255, 255), 2  # Yellow (BGR)
             )
             cv2.putText(
-                overlay, "ROI",
+                overlay,
+                "ROI",
                 (x + 5, y - 5),
-                cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 255), 1
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (0, 255, 255),
+                1,
             )
-        
+
         # Blend overlay
         alpha = 0.7
         blended = cv2.addWeighted(overlay, alpha, self.original_image, 1 - alpha, 0)
-        
+
         return blended
-    
+
     def _update_region_statuses(self) -> None:
         """Update region status labels based on detection results."""
         if self.result is None:
             return
-        
+
         statuses = {
             "substrate": (
                 "✓ Found" if self.result.substrate_line else "✗ Not found",
-                self.result.confidence_scores.get("substrate", 0.0)
+                self.result.confidence_scores.get("substrate", 0.0),
             ),
             "needle": (
                 "✓ Found" if self.result.needle_rect else "✗ Not found",
-                self.result.confidence_scores.get("needle", 0.0)
+                self.result.confidence_scores.get("needle", 0.0),
             ),
             "drop": (
                 "✓ Found" if self.result.drop_contour is not None else "✗ Not found",
-                self.result.confidence_scores.get("drop", 0.0)
+                self.result.confidence_scores.get("drop", 0.0),
             ),
             "contact": (
                 "✓ Found" if self.result.contact_points else "✗ Not found",
                 # Contact points share drop confidence as they're detected together
-                self.result.confidence_scores.get("drop", 0.0) if self.result.contact_points else 0.0
+                (
+                    self.result.confidence_scores.get("drop", 0.0)
+                    if self.result.contact_points
+                    else 0.0
+                ),
             ),
             "roi": (
                 "✓ Found" if self.result.roi_rect else "✗ Not found",
-                self.result.confidence_scores.get("roi", 0.0)
+                self.result.confidence_scores.get("roi", 0.0),
             ),
         }
-        
+
         for region_id, (text, conf) in statuses.items():
             widget = self._region_widgets.get(region_id)
             if widget:
                 conf_text = f"{conf * 100:.0f}%" if conf > 0 else ""
                 widget.status.setText(f"{text} {conf_text}")
-    
+
     def _on_region_toggled(self, state: int) -> None:
         """Handle region checkbox toggle."""
         sender = self.sender()
         if sender:
             region_id = sender.property("region_id")
             self._region_enabled[region_id] = state == Qt.Checked
-            
+
             # Redraw overlays with updated visibility
             if self.result:
                 overlay = self._draw_overlays()
                 self._display_image(overlay)
-    
+
     def _on_apply(self) -> None:
         """Apply calibration results and close dialog."""
         if self.result is None:
             self.reject()
             return
-        
+
         # Filter result based on enabled regions
         if not self._region_enabled.get("substrate", True):
             self.result.substrate_line = None
@@ -640,89 +667,90 @@ class CalibrationWizardDialog(QDialog):
             self.result.contact_points = None
         if not self._region_enabled.get("roi", True):
             self.result.roi_rect = None
-        
+
         self.calibration_complete.emit(self.result)
         self.accept()
-    
+
     def get_result(self) -> Optional[CalibrationResult]:
         """Get the calibration result after dialog closes."""
         return self.result
-    
+
     def _on_draw_region_clicked(self, checked: bool) -> None:
         """Handle draw button click - enter/exit drawing mode for any region."""
         sender = self.sender()
         if not sender:
             return
-        
+
         region_id = sender.property("region_id")
-        
+
         if checked:
             # Uncheck any other draw buttons first
             for rid, widget in self._region_widgets.items():
                 if widget.draw_btn and rid != region_id:
                     widget.draw_btn.setChecked(False)
-            
+
             self._drawing_mode = region_id
             self._draw_start_point = None
             self._draw_end_point = None
             self._preview_label.setCursor(Qt.CrossCursor)
-            
+
             shape = "rectangle" if region_id == "roi" else "line"
-            logger.info(f"Entering {region_id} drawing mode - click and drag to draw {shape}")
+            logger.info(
+                f"Entering {region_id} drawing mode - click and drag to draw {shape}"
+            )
         else:
             self._drawing_mode = None
             self._preview_label.setCursor(Qt.ArrowCursor)
-    
+
     # Legacy compatibility
     def _on_draw_substrate_clicked(self, checked: bool) -> None:
         """Legacy handler - redirects to unified handler."""
         widget = self._region_widgets.get("substrate")
         if widget and widget.draw_btn:
             widget.draw_btn.setChecked(checked)
-    
+
     def _on_preview_mouse_press(self, event) -> None:
         """Handle mouse press in preview - start drawing region."""
         if not self._drawing_mode:
             return
-        
+
         pos = event.pos()
         img_point = self._widget_to_image_coords(pos.x(), pos.y())
         if img_point:
             self._draw_start_point = img_point
             self._draw_end_point = img_point
-    
+
     def _on_preview_mouse_move(self, event) -> None:
         """Handle mouse move in preview - update region endpoint."""
         if not self._drawing_mode or self._draw_start_point is None:
             return
-        
+
         pos = event.pos()
         img_point = self._widget_to_image_coords(pos.x(), pos.y())
         if img_point:
             self._draw_end_point = img_point
             self._draw_region_preview()
-    
+
     def _on_preview_mouse_release(self, event) -> None:
         """Handle mouse release - finalize region."""
         if not self._drawing_mode or self._draw_start_point is None:
             return
-        
+
         pos = event.pos()
         img_point = self._widget_to_image_coords(pos.x(), pos.y())
         if img_point:
             self._draw_end_point = img_point
-        
+
         # Validate and save the region
         if self._draw_start_point and self._draw_end_point:
             p1 = self._draw_start_point
             p2 = self._draw_end_point
-            
+
             from menipy.common.auto_calibrator import CalibrationResult
+
             if self.result is None:
-                self.result = CalibrationResult(
-                    confidence_scores={"overall": 0.5}
-                )
-            
+                self.result = CalibrationResult(confidence_scores={"overall": 0.5})
+
             if self._drawing_mode == "substrate":
                 # Ensure left-to-right order for substrate line
                 if p1[0] > p2[0]:
@@ -730,7 +758,7 @@ class CalibrationWizardDialog(QDialog):
                 self.result.substrate_line = (p1, p2)
                 self.result.confidence_scores["substrate"] = 1.0
                 logger.info(f"Manual substrate line set: {p1} -> {p2}")
-                
+
             elif self._drawing_mode == "needle":
                 # Store needle as rect from line (x, y, width, height)
                 x = min(p1[0], p2[0])
@@ -744,7 +772,7 @@ class CalibrationWizardDialog(QDialog):
                 self.result.needle_rect = (x, y, w, h)
                 self.result.confidence_scores["needle"] = 1.0
                 logger.info(f"Manual needle rect set: ({x}, {y}, {w}, {h})")
-                
+
             elif self._drawing_mode == "roi":
                 # Store ROI as rect (x, y, width, height)
                 x = min(p1[0], p2[0])
@@ -754,90 +782,90 @@ class CalibrationWizardDialog(QDialog):
                 self.result.roi_rect = (x, y, w, h)
                 self.result.confidence_scores["roi"] = 1.0
                 logger.info(f"Manual ROI rect set: ({x}, {y}, {w}, {h})")
-            
+
             # Update UI
             self._show_results()
             self._apply_btn.setEnabled(True)
-        
+
         # Exit drawing mode
         current_mode = self._drawing_mode
         self._drawing_mode = None
         self._preview_label.setCursor(Qt.ArrowCursor)
-        
+
         # Uncheck draw button
         if current_mode:
             widget = self._region_widgets.get(current_mode)
             if widget and widget.draw_btn:
                 widget.draw_btn.setChecked(False)
-    
+
     def _widget_to_image_coords(self, wx: int, wy: int) -> Optional[tuple]:
         """Convert widget coordinates to image coordinates."""
-        if not hasattr(self, '_current_pixmap') or self._current_pixmap is None:
+        if not hasattr(self, "_current_pixmap") or self._current_pixmap is None:
             return None
-        
+
         # Get the displayed pixmap (may be scaled)
         displayed_pm = self._preview_label.pixmap()
         if displayed_pm is None:
             return None
-        
+
         # Calculate offset (pixmap is centered in label)
         label_size = self._preview_label.size()
         pm_size = displayed_pm.size()
-        
+
         offset_x = (label_size.width() - pm_size.width()) // 2
         offset_y = (label_size.height() - pm_size.height()) // 2
-        
+
         # Adjust for offset
         px = wx - offset_x
         py = wy - offset_y
-        
+
         # Check bounds
         if px < 0 or px >= pm_size.width() or py < 0 or py >= pm_size.height():
             return None
-        
+
         # Scale to original image size
         orig_w = self.original_image.shape[1]
         orig_h = self.original_image.shape[0]
-        
+
         img_x = int(px * orig_w / pm_size.width())
         img_y = int(py * orig_h / pm_size.height())
-        
+
         return (img_x, img_y)
-    
+
     def _draw_region_preview(self) -> None:
         """Draw region preview during dragging."""
         if self._draw_start_point is None or self._draw_end_point is None:
             return
-        
+
         # Draw on a copy of the current overlay
         overlay = self.original_image.copy()
-        
+
         # Draw existing detections (except the one being drawn)
         if self.result:
             overlay = self._draw_overlays()
-        
+
         p1 = self._draw_start_point
         p2 = self._draw_end_point
-        
+
         if self._drawing_mode == "substrate":
             # Draw line in magenta
             cv2.line(overlay, p1, p2, (255, 0, 255), 2)
             cv2.circle(overlay, p1, 4, (255, 0, 255), -1)
             cv2.circle(overlay, p2, 4, (255, 0, 255), -1)
-            
+
         elif self._drawing_mode == "needle":
             # Draw line/rect in blue
             cv2.line(overlay, p1, p2, (255, 0, 0), 2)
             cv2.circle(overlay, p1, 4, (255, 0, 0), -1)
             cv2.circle(overlay, p2, 4, (255, 0, 0), -1)
-            
+
         elif self._drawing_mode == "roi":
             # Draw rectangle in yellow
             cv2.rectangle(overlay, p1, p2, (0, 255, 255), 2)
-        
+
         # Display
         self._display_image(overlay)
-    
+
     # Legacy compatibility
     def _draw_substrate_preview(self) -> None:
         """Legacy handler - redirects to unified handler."""
@@ -848,23 +876,23 @@ class CalibrationWizardDialog(QDialog):
 if __name__ == "__main__":
     import sys
     from PySide6.QtWidgets import QApplication
-    
+
     app = QApplication(sys.argv)
-    
+
     # Create test image
     test_image = np.zeros((480, 640, 3), dtype=np.uint8)
     test_image[:] = 200  # Light gray background
-    
+
     # Draw fake drop
     cv2.ellipse(test_image, (320, 350), (80, 60), 0, 0, 360, (50, 50, 50), -1)
-    
+
     # Draw fake substrate
     cv2.line(test_image, (0, 400), (640, 400), (30, 30, 30), 3)
-    
+
     # Draw fake needle
     cv2.rectangle(test_image, (300, 0), (340, 300), (40, 40, 40), -1)
-    
+
     dlg = CalibrationWizardDialog(test_image, "sessile")
     dlg.show()
-    
+
     sys.exit(app.exec())

--- a/src/menipy/gui/dialogs/detector_test_dialog.py
+++ b/src/menipy/gui/dialogs/detector_test_dialog.py
@@ -1,22 +1,39 @@
 """Dialog for testing and visualizing detector plugins."""
+
 from pathlib import Path
 import cv2
 import numpy as np
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QComboBox, QPushButton, 
-    QLabel, QFileDialog, QCheckBox, QFrame, QSizePolicy, QMessageBox, QWidget
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QComboBox,
+    QPushButton,
+    QLabel,
+    QFileDialog,
+    QCheckBox,
+    QFrame,
+    QSizePolicy,
+    QMessageBox,
+    QWidget,
 )
 from PySide6.QtGui import QImage, QPainter, QPen, QColor, QFont
 from PySide6.QtCore import Qt, QRect, QLineF
 
 from menipy.common.registry import (
-    EDGE_DETECTORS, NEEDLE_DETECTORS, ROI_DETECTORS, 
-    SUBSTRATE_DETECTORS, DROP_DETECTORS, APEX_DETECTORS
+    EDGE_DETECTORS,
+    NEEDLE_DETECTORS,
+    ROI_DETECTORS,
+    SUBSTRATE_DETECTORS,
+    DROP_DETECTORS,
+    APEX_DETECTORS,
 )
 from menipy.models.config import EdgeDetectionSettings
 
+
 class DetectorTestCanvas(QWidget):
     """Canvas widget to display image and detection results."""
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -29,9 +46,9 @@ class DetectorTestCanvas(QWidget):
         self.image = None
         self.result = None
         self.result_type = None  # 'contour', 'line', 'point', 'mask'
-        
+
         self.show_overlay = True
-        
+
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setMinimumSize(400, 300)
 
@@ -60,14 +77,16 @@ class DetectorTestCanvas(QWidget):
                 img_data = cv2.cvtColor(img_data, cv2.COLOR_GRAY2RGB)
             else:
                 img_data = cv2.cvtColor(img_data, cv2.COLOR_BGR2RGB)
-                
+
             qimg = QImage(img_data.data, w, h, ch * w, QImage.Format_RGB888)
-            
-            scaled_img = qimg.scaled(self.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation)
-            
+
+            scaled_img = qimg.scaled(
+                self.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation
+            )
+
             x_off = (self.width() - scaled_img.width()) // 2
             y_off = (self.height() - scaled_img.height()) // 2
-            
+
             painter.drawImage(x_off, y_off, scaled_img)
 
             # Scales
@@ -79,7 +98,7 @@ class DetectorTestCanvas(QWidget):
 
             # Overlay
             if self.show_overlay:
-                if getattr(self, 'debug_info', None):
+                if getattr(self, "debug_info", None):
                     self._draw_debug_info(painter, to_screen)
                 if self.result is not None:
                     self._draw_overlay(painter, to_screen, w, h)
@@ -90,7 +109,7 @@ class DetectorTestCanvas(QWidget):
         font = painter.font()
         font.setPointSize(8)
         painter.setFont(font)
-        
+
         for item in self.debug_info:
             # item is (xy, area, label)
             if len(item) >= 3:
@@ -99,22 +118,28 @@ class DetectorTestCanvas(QWidget):
                     pts = [to_screen(p[0], p[1]) for p in xy]
                     if len(pts) > 1:
                         for i in range(len(pts) - 1):
-                            painter.drawLine(pts[i][0], pts[i][1], pts[i+1][0], pts[i+1][1])
+                            painter.drawLine(
+                                pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1]
+                            )
                         # Draw label at first point
                         painter.drawText(pts[0][0], pts[0][1], label)
 
     def _draw_overlay(self, painter, to_screen, img_w, img_h):
         painter.setPen(QPen(QColor(0, 255, 0), 2))
-        
-        if self.result_type == 'contour':
+
+        if self.result_type == "contour":
             # Expecting (N, 2) array of (x, y)
             contour = self.result
-            if isinstance(contour, np.ndarray) and contour.ndim == 2 and contour.shape[1] == 2:
+            if (
+                isinstance(contour, np.ndarray)
+                and contour.ndim == 2
+                and contour.shape[1] == 2
+            ):
                 pts = [to_screen(p[0], p[1]) for p in contour]
                 for i in range(len(pts) - 1):
-                    painter.drawLine(pts[i][0], pts[i][1], pts[i+1][0], pts[i+1][1])
-                    
-        elif self.result_type == 'mask':
+                    painter.drawLine(pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1])
+
+        elif self.result_type == "mask":
             # Expecting binary image mask
             # For visualization, we can find contours of the mask and draw them
             mask = self.result
@@ -123,22 +148,26 @@ class DetectorTestCanvas(QWidget):
                 if mask.dtype != np.uint8:
                     # Normalize if needed or just cast
                     if mask.dtype == bool:
-                         mask = mask.astype(np.uint8) * 255
+                        mask = mask.astype(np.uint8) * 255
                     else:
-                         # Assume it might be float 0..1 or 0..255
-                         if mask.max() <= 1.0:
-                             mask = (mask * 255).astype(np.uint8)
-                         else:
-                             mask = mask.astype(np.uint8)
-                
-                contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+                        # Assume it might be float 0..1 or 0..255
+                        if mask.max() <= 1.0:
+                            mask = (mask * 255).astype(np.uint8)
+                        else:
+                            mask = mask.astype(np.uint8)
+
+                contours, _ = cv2.findContours(
+                    mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+                )
                 for cnt in contours:
                     # cnt is (N, 1, 2)
                     pts = [to_screen(p[0][0], p[0][1]) for p in cnt]
                     for i in range(len(pts) - 1):
-                        painter.drawLine(pts[i][0], pts[i][1], pts[i+1][0], pts[i+1][1])
+                        painter.drawLine(
+                            pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1]
+                        )
 
-        elif self.result_type == 'line':
+        elif self.result_type == "line":
             # Expecting y-coordinate (int or float) or (pt1, pt2)
             if isinstance(self.result, (int, float)):
                 y = float(self.result)
@@ -147,7 +176,7 @@ class DetectorTestCanvas(QWidget):
                 painter.drawLine(p1[0], p1[1], p2[0], p2[1])
                 painter.drawText(p1[0] + 5, p1[1] - 5, f"Y={y:.1f}")
 
-        elif self.result_type == 'point':
+        elif self.result_type == "point":
             # Expecting (x, y)
             pt = self.result
             if len(pt) == 2:
@@ -160,79 +189,80 @@ class DetectorTestCanvas(QWidget):
 
 class DetectorTestDialog(QDialog):
     """Dialog to test detector plugins."""
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Detector Test Utility")
         self.resize(1000, 700)
-        
+
         self.image = None
         self.image_path = None
-        
+
         self.detector_categories = {
             "Drop Detector": DROP_DETECTORS,
             "Edge Detector": EDGE_DETECTORS,
             "Needle Detector": NEEDLE_DETECTORS,
             "Substrate Detector": SUBSTRATE_DETECTORS,
             "ROI Detector": ROI_DETECTORS,
-            "Apex Detector": APEX_DETECTORS
+            "Apex Detector": APEX_DETECTORS,
         }
-        
+
         self._setup_ui()
         self._populate_detectors()
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
-        
+
         # 1. Canvas
         self.canvas = DetectorTestCanvas()
         layout.addWidget(self.canvas, stretch=1)
-        
+
         # 2. Controls Area
         controls = QFrame()
-        # controls.setStyleSheet("background-color: #f0f0f0; border-top: 1px solid #ccc;") 
+        # controls.setStyleSheet("background-color: #f0f0f0; border-top: 1px solid #ccc;")
         # Use theme-compatible style or just a border
         controls.setFrameShape(QFrame.StyledPanel)
-        
+
         c_layout = QHBoxLayout(controls)
         c_layout.setContentsMargins(10, 10, 10, 10)
-        
+
         # Image Loading
         btn_load = QPushButton("📂 Load")
         btn_load.clicked.connect(self._on_load_image)
         c_layout.addWidget(btn_load)
-        
+
         # Category Selector
         c_layout.addWidget(QLabel("Type:"))
         self.combo_category = QComboBox()
         self.combo_category.addItems(self.detector_categories.keys())
         self.combo_category.currentTextChanged.connect(self._on_category_changed)
         c_layout.addWidget(self.combo_category)
-        
+
         # Algorithm Selector
         c_layout.addWidget(QLabel("Algorithm:"))
         self.combo_algo = QComboBox()
         self.combo_algo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         c_layout.addWidget(self.combo_algo, stretch=1)
-        
+
         # Run Button
         btn_run = QPushButton("▶ Run")
         btn_run.clicked.connect(self._on_run_detector)
         c_layout.addWidget(btn_run)
-        
+
         # Options
         self.chk_overlay = QCheckBox("Overlay")
         self.chk_overlay.setChecked(True)
         self.chk_overlay.toggled.connect(self._on_toggle_overlay)
         c_layout.addWidget(self.chk_overlay)
-        
+
         self.chk_debug = QCheckBox("Debug")
         self.chk_debug.setToolTip("Show all candidate contours (Snake only)")
         c_layout.addWidget(self.chk_debug)
-        
+
         c_layout.addStretch()
-        
+
         layout.addWidget(controls)
-        
+
         # Status Label
         self.lbl_status = QLabel("Ready")
         layout.addWidget(self.lbl_status)
@@ -254,8 +284,10 @@ class DetectorTestDialog(QDialog):
     def _on_load_image(self):
         """_on_load_image."""
         path, _ = QFileDialog.getOpenFileName(
-            self, "Open Test Image", "", 
-            "Images (*.png *.jpg *.jpeg *.tiff *.bmp);;All Files (*)"
+            self,
+            "Open Test Image",
+            "",
+            "Images (*.png *.jpg *.jpeg *.tiff *.bmp);;All Files (*)",
         )
         if path:
             self._load_image_file(path)
@@ -267,7 +299,7 @@ class DetectorTestDialog(QDialog):
         if img is None:
             QMessageBox.warning(self, "Error", f"Could not read image: {path}")
             return
-            
+
         self.image = img
         self.image_path = path
         self.canvas.set_image(img)
@@ -281,38 +313,40 @@ class DetectorTestDialog(QDialog):
 
         cat_name = self.combo_category.currentText()
         algo_name = self.combo_algo.currentText()
-        
+
         registry = self.detector_categories.get(cat_name)
         if not registry:
             return
-            
+
         detector_fn = registry.get(algo_name)
         if not detector_fn:
-            QMessageBox.warning(self, "Error", f"Could not find algorithm '{algo_name}'")
+            QMessageBox.warning(
+                self, "Error", f"Could not find algorithm '{algo_name}'"
+            )
             return
-            
+
         try:
             # Most detectors take image as first arg.
             # However some might need grayscale.
             # We'll try to be smart or generic.
-            
+
             # Prepare input
             input_img = self.image
             # If edge detector usually expects grayscale
             if cat_name == "Edge Detector":
                 if len(input_img.shape) == 3:
-                     input_img = cv2.cvtColor(input_img, cv2.COLOR_BGR2GRAY)
-            
+                    input_img = cv2.cvtColor(input_img, cv2.COLOR_BGR2GRAY)
+
             self.lbl_status.setText(f"Running {algo_name}...")
-            
+
             # Execute
             result = None
-            
+
             # Helper to invoke with flexible args
             # Try passing settings if it's an edge detector
             debug_mode = self.chk_debug.isChecked()
             debug_info = []
-            
+
             if cat_name == "Edge Detector":
                 settings = EdgeDetectionSettings()
                 # Try calling with return_debug first
@@ -323,61 +357,63 @@ class DetectorTestDialog(QDialog):
                         if isinstance(result, tuple) and len(result) == 2:
                             result, debug_info = result
                     except TypeError:
-                         # Fallback to no debug arg
-                         try:
+                        # Fallback to no debug arg
+                        try:
                             result = detector_fn(input_img, settings)
-                         except TypeError:
+                        except TypeError:
                             result = detector_fn(input_img)
                 else:
                     try:
                         result = detector_fn(input_img, settings)
                     except TypeError:
-                         # Fallback for functions not accepting settings
-                         result = detector_fn(input_img)
+                        # Fallback for functions not accepting settings
+                        result = detector_fn(input_img)
             else:
-                 result = detector_fn(input_img)
-            
+                result = detector_fn(input_img)
+
             # Determine visualization type
-            vis_type = 'mask' # Default fallback
-            
+            vis_type = "mask"  # Default fallback
+
             if cat_name == "Drop Detector":
                 # Plugins like detect_drop return contour or mask?
                 # Usually contour (N, 2) or mask
                 if isinstance(result, np.ndarray):
                     if result.ndim == 2 and result.shape[1] == 2:
-                        vis_type = 'contour'
+                        vis_type = "contour"
                     else:
-                        vis_type = 'mask'
-                        
+                        vis_type = "mask"
+
             elif cat_name == "Edge Detector":
                 # Plugins in edge_detectors.py return (N, 2) coords
-                vis_type = 'contour'
-                
+                vis_type = "contour"
+
             elif cat_name == "Substrate Detector":
-                 # Usually returns int (y-coord) or line params
-                 vis_type = 'line'
-                 
+                # Usually returns int (y-coord) or line params
+                vis_type = "line"
+
             elif cat_name == "Apex Detector":
-                vis_type = 'point'
-            
+                vis_type = "point"
+
             elif cat_name == "ROI Detector":
-                 # Returns (x, y, w, h) ?
-                 # If so we need to handle it. 
-                 # Let's assume it might return a mask or rect.
-                 if isinstance(result, tuple) and len(result) == 4:
-                     # Convert rect to contour for drawing
-                     x, y, w, h = result
-                     rect_cnt = np.array([
-                         [x, y], [x+w, y], [x+w, y+h], [x, y+h], [x, y]
-                     ])
-                     result = rect_cnt
-                     vis_type = 'contour'
-                 else:
-                     vis_type = 'mask'
-            
+                # Returns (x, y, w, h) ?
+                # If so we need to handle it.
+                # Let's assume it might return a mask or rect.
+                if isinstance(result, tuple) and len(result) == 4:
+                    # Convert rect to contour for drawing
+                    x, y, w, h = result
+                    rect_cnt = np.array(
+                        [[x, y], [x + w, y], [x + w, y + h], [x, y + h], [x, y]]
+                    )
+                    result = rect_cnt
+                    vis_type = "contour"
+                else:
+                    vis_type = "mask"
+
             self.canvas.set_result(result, vis_type, debug_info)
-            self.lbl_status.setText(f"Finished {algo_name}. Result type: {type(result)}")
-            
+            self.lbl_status.setText(
+                f"Finished {algo_name}. Result type: {type(result)}"
+            )
+
         except Exception as e:
             QMessageBox.critical(self, "Detector Error", str(e))
             self.lbl_status.setText(f"Error: {e}")

--- a/src/menipy/gui/dialogs/edge_detection_config_dialog.py
+++ b/src/menipy/gui/dialogs/edge_detection_config_dialog.py
@@ -73,7 +73,7 @@ class EdgeDetectionConfigDialog(QDialog):
         # Indices: 0=General, 1=Canny, 2=Threshold, 3=Sobel/etc, 4=Result?, 5=Refinement?, 6=Interface
         # This is brittle relying on order, but _build_ui defines order.
         # General=0, Canny=1, Threshold=2, Sobel=3, Active=4, Refinement=5, Interface=6
-        
+
         if method == "canny":
             self.pages.setCurrentIndex(1)
         elif method == "threshold":
@@ -153,8 +153,7 @@ class EdgeDetectionConfigDialog(QDialog):
         self.preview_label.setScaledContents(True)
         pages_layout.addWidget(self.preview_label)
 
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QFrame#navFrame, QFrame#pagesFrame {
                 background-color: palette(base);
                 border: 1px solid palette(mid);
@@ -174,8 +173,7 @@ class EdgeDetectionConfigDialog(QDialog):
             QPushButton {
                 min-width: 110px;
             }
-            """
-        )
+            """)
 
         self._build_general_page()
         self._build_canny_page()
@@ -219,11 +217,16 @@ class EdgeDetectionConfigDialog(QDialog):
         self.method_combo = QComboBox(widget)
         # Core methods
         core_methods = [
-            "canny", "sobel", "scharr", "laplacian", "threshold", "active_contour"
+            "canny",
+            "sobel",
+            "scharr",
+            "laplacian",
+            "threshold",
+            "active_contour",
         ]
         for label in core_methods:
             self.method_combo.addItem(label)
-            
+
         # Plugin methods
         for name in EDGE_DETECTORS.keys():
             if name not in core_methods:
@@ -384,7 +387,9 @@ class EdgeDetectionConfigDialog(QDialog):
     def _build_plugin_page(self) -> None:
         """Page for dynamic plugin settings."""
         self.plugin_settings_widget = PluginSettingsWidget(self)
-        self.plugin_settings_widget.settingsChanged.connect(self._on_plugin_settings_changed)
+        self.plugin_settings_widget.settingsChanged.connect(
+            self._on_plugin_settings_changed
+        )
         self.pages.addWidget(self.plugin_settings_widget)
 
     # ------------------------------------------------------------------
@@ -415,7 +420,14 @@ class EdgeDetectionConfigDialog(QDialog):
 
         # Load plugin settings into widget if current method is a plugin
         current_method = s.method
-        if current_method not in ["canny", "sobel", "scharr", "laplacian", "threshold", "active_contour"]:
+        if current_method not in [
+            "canny",
+            "sobel",
+            "scharr",
+            "laplacian",
+            "threshold",
+            "active_contour",
+        ]:
             # It's a plugin or unhandled
             plugin_config = s.plugin_settings.get(current_method, {})
             self.plugin_settings_widget.set_plugin(current_method, plugin_config)
@@ -585,22 +597,29 @@ class EdgeDetectionConfigDialog(QDialog):
         self.solid_interface_proximity_spin.setEnabled(
             enabled and self.detect_solid_interface_checkbox.isChecked()
         )
-        
+
         # Check if we should switch to plugin page
-        core_methods = {"canny", "sobel", "scharr", "laplacian", "threshold", "active_contour"}
+        core_methods = {
+            "canny",
+            "sobel",
+            "scharr",
+            "laplacian",
+            "threshold",
+            "active_contour",
+        }
         if method not in core_methods and enabled:
-             # It is a plugin
-             if self.pages.currentWidget() != self.plugin_settings_widget:
-                 self.pages.setCurrentWidget(self.plugin_settings_widget)
-                 # Also refresh the widget content if needed, though usually handled by load_settings or manual trigger
-                 # We trigger a reload of settings for this plugin
-                 current_config = self._settings.plugin_settings.get(method, {})
-                 self.plugin_settings_widget.set_plugin(method, current_config)
-             
-             # Disable other pages in list? Or just let stacked widget handle view.
-             # Ideally we highlight "Plugin Settings" in list if we added it, but we didn't add it to the list.
-             # Instead we are hijacking the view.
-             
+            # It is a plugin
+            if self.pages.currentWidget() != self.plugin_settings_widget:
+                self.pages.setCurrentWidget(self.plugin_settings_widget)
+                # Also refresh the widget content if needed, though usually handled by load_settings or manual trigger
+                # We trigger a reload of settings for this plugin
+                current_config = self._settings.plugin_settings.get(method, {})
+                self.plugin_settings_widget.set_plugin(method, current_config)
+
+            # Disable other pages in list? Or just let stacked widget handle view.
+            # Ideally we highlight "Plugin Settings" in list if we added it, but we didn't add it to the list.
+            # Instead we are hijacking the view.
+
         elif enabled:
             # If it's a core method, ensure we are not on plugin page (unless user clicked it?)
             # The list widget drives the page, but we want method combo to ALSO drive the page?
@@ -619,10 +638,9 @@ class EdgeDetectionConfigDialog(QDialog):
             if self._settings.plugin_settings is None:
                 self._settings.plugin_settings = {}
             self._settings.plugin_settings[method] = new_settings
-            
-            # Trigger preview if auto-preview is desired?
-            # self._on_preview() 
 
+            # Trigger preview if auto-preview is desired?
+            # self._on_preview()
 
     # ------------------------------------------------------------------
     # Public accessors

--- a/src/menipy/gui/dialogs/help_dialog.py
+++ b/src/menipy/gui/dialogs/help_dialog.py
@@ -3,6 +3,7 @@ Help Dialog
 
 Loads Markdown help files and renders them as HTML inside a QTextBrowser.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -53,7 +54,9 @@ class HelpDialog(QDialog):
         layout.setSpacing(10)
 
         header = QLabel("Select a topic:")
-        header.setStyleSheet(f"font-size: {theme.FONT_SIZE_LARGE}px; font-weight: bold;")
+        header.setStyleSheet(
+            f"font-size: {theme.FONT_SIZE_LARGE}px; font-weight: bold;"
+        )
         layout.addWidget(header)
 
         body = QHBoxLayout()
@@ -83,6 +86,7 @@ class HelpDialog(QDialog):
             self.list_widget.setCurrentRow(0)
 
         # ------------------------------------------------------------------ helpers
+
     def _find_markdown_files(self, root: Path) -> List[Path]:
         if not root.exists():
             return []

--- a/src/menipy/gui/dialogs/marker_config_dialog.py
+++ b/src/menipy/gui/dialogs/marker_config_dialog.py
@@ -24,7 +24,6 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-
 MARKER_TYPES = (
     ("default", "Default markers"),
     ("roi", "ROI"),
@@ -115,7 +114,9 @@ class MarkerConfigDialog(QDialog):
             label_color_btn = QPushButton("Choose...", group)
             label_color_preview = QLabel(group)
             label_color_preview.setFixedSize(34, 18)
-            form.addRow("Label color:", self._color_row(label_color_btn, label_color_preview))
+            form.addRow(
+                "Label color:", self._color_row(label_color_btn, label_color_preview)
+            )
 
             self._widgets[key] = {
                 "visible": visible,
@@ -132,7 +133,9 @@ class MarkerConfigDialog(QDialog):
                 "_color": QColor(DEFAULT_MARKER_CONFIG[key]["color"]),
                 "_label_color": QColor(DEFAULT_MARKER_CONFIG[key]["label_color"]),
             }
-            color_btn.clicked.connect(lambda _=False, k=key: self._choose_color(k, "color"))
+            color_btn.clicked.connect(
+                lambda _=False, k=key: self._choose_color(k, "color")
+            )
             label_color_btn.clicked.connect(
                 lambda _=False, k=key: self._choose_color(k, "label_color")
             )
@@ -181,7 +184,9 @@ class MarkerConfigDialog(QDialog):
             widgets["visible"].setChecked(bool(values.get("visible", True)))
             widgets["shape"].setCurrentText(str(values.get("shape", "circle")))
             widgets["radius"].setValue(int(values.get("radius", 5)))
-            widgets["label_visible"].setChecked(bool(values.get("label_visible", False)))
+            widgets["label_visible"].setChecked(
+                bool(values.get("label_visible", False))
+            )
             widgets["label_text"].setText(str(values.get("label_text", "")))
             widgets["font_size"].setValue(int(values.get("font_size", 10)))
             font_family = values.get("font_family")
@@ -207,7 +212,9 @@ class MarkerConfigDialog(QDialog):
 
     def _choose_color(self, marker_key: str, color_key: str) -> None:
         widgets = self._widgets[marker_key]
-        initial = widgets["_label_color"] if color_key == "label_color" else widgets["_color"]
+        initial = (
+            widgets["_label_color"] if color_key == "label_color" else widgets["_color"]
+        )
         color = QColorDialog.getColor(initial, self)
         if color.isValid():
             self._set_color(marker_key, color, color_key)
@@ -215,7 +222,9 @@ class MarkerConfigDialog(QDialog):
     def _set_color(self, marker_key: str, color: QColor, color_key: str) -> None:
         widgets = self._widgets[marker_key]
         store_key = "_label_color" if color_key == "label_color" else "_color"
-        preview_key = "label_color_preview" if color_key == "label_color" else "color_preview"
+        preview_key = (
+            "label_color_preview" if color_key == "label_color" else "color_preview"
+        )
         widgets[store_key] = color
         widgets[preview_key].setStyleSheet(
             f"background-color: {color.name()}; border: 1px solid #222;"

--- a/src/menipy/gui/dialogs/material_dialog.py
+++ b/src/menipy/gui/dialogs/material_dialog.py
@@ -3,12 +3,25 @@ Material Database Dialog
 
 Dialog for managing and selecting materials.
 """
+
 from PySide6.QtCore import Qt, Signal, QSize
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
-    QPushButton, QTableWidget, QTableWidgetItem, QHeaderView,
-    QComboBox, QMessageBox, QFrame, QAbstractItemView, QFormLayout,
-    QDoubleSpinBox, QTextEdit
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+    QComboBox,
+    QMessageBox,
+    QFrame,
+    QAbstractItemView,
+    QFormLayout,
+    QDoubleSpinBox,
+    QTextEdit,
 )
 
 from menipy.gui import theme
@@ -19,17 +32,17 @@ class MaterialDialog(QDialog):
     """
     Dialog for viewing, editing, and selecting items from the database.
     Supports materials, needles, and syringes.
-    
+
     Modes:
         - Manager: View/Edit/Delete items
     - Selector: Select an item and return it
     """
-    
+
     item_selected = Signal(dict)
-    
+
     # Alias for backward compatibility (users might expect material_selected)
     material_selected = item_selected
-    
+
     def __init__(self, parent=None, selection_mode=False, table_type="materials"):
         super().__init__(parent)
         self.setWindowTitle(f"{table_type.title()} Database")
@@ -38,18 +51,18 @@ class MaterialDialog(QDialog):
         self._table_type = table_type
         self._db = MaterialDB()
         self._db.init_schema()
-        
+
         self._setup_ui()
         self._load_data()
-    
+
     def _setup_ui(self):
         """Set up the dialog UI."""
         self.setStyleSheet(theme.get_stylesheet())
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(12)
-        
+
         # Header
         header_layout = QHBoxLayout()
         title = QLabel(self._table_type.title())
@@ -57,16 +70,16 @@ class MaterialDialog(QDialog):
         header_layout.addWidget(title)
         header_layout.addStretch()
         layout.addLayout(header_layout)
-        
+
         # Toolbar
         toolbar = QHBoxLayout()
-        
+
         # Search
         self._search_input = QLineEdit()
         self._search_input.setPlaceholderText(f"Search {self._table_type}...")
         self._search_input.textChanged.connect(self._filter_data)
         toolbar.addWidget(self._search_input)
-        
+
         # Filter (only for materials)
         self._type_filter = QComboBox()
         if self._table_type == "materials":
@@ -75,55 +88,77 @@ class MaterialDialog(QDialog):
             toolbar.addWidget(self._type_filter)
         else:
             self._type_filter.hide()
-        
+
         toolbar.addStretch()
-        
+
         # Actions
         add_btn = QPushButton(f"+ New {self._table_type[:-1].title()}")
         add_btn.clicked.connect(self._on_add)
         toolbar.addWidget(add_btn)
-        
+
         layout.addLayout(toolbar)
-        
+
         # Table configuration based on type
         self._table = QTableWidget()
         if self._table_type == "materials":
-            headers = ["Name", "Type", "Density\n(kg/m³)", "Suff. Tens.\n(mN/m)", "Description"]
+            headers = [
+                "Name",
+                "Type",
+                "Density\n(kg/m³)",
+                "Suff. Tens.\n(mN/m)",
+                "Description",
+            ]
             stretch_col = 4
         elif self._table_type == "needles":
-            headers = ["Name", "Gauge", "Outer Dia.\n(mm)", "Inner Dia.\n(mm)", "Description"]
+            headers = [
+                "Name",
+                "Gauge",
+                "Outer Dia.\n(mm)",
+                "Inner Dia.\n(mm)",
+                "Description",
+            ]
             stretch_col = 4
         elif self._table_type == "syringes":
-            headers = ["Name", "Volume\n(μL)", "Diameter\n(mm)", "Manufacturer", "Description"]
+            headers = [
+                "Name",
+                "Volume\n(μL)",
+                "Diameter\n(mm)",
+                "Manufacturer",
+                "Description",
+            ]
             stretch_col = 4
         else:
             headers = ["Name", "Description"]
             stretch_col = 1
-            
+
         self._table.setColumnCount(len(headers))
         self._table.setHorizontalHeaderLabels(headers)
-        self._table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-        self._table.horizontalHeader().setSectionResizeMode(stretch_col, QHeaderView.ResizeMode.Stretch)
+        self._table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            stretch_col, QHeaderView.ResizeMode.Stretch
+        )
         self._table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self._table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self._table.setAlternatingRowColors(True)
         self._table.verticalHeader().setVisible(False)
-        
+
         if self._selection_mode:
             self._table.doubleClicked.connect(self._on_select)
-        
+
         layout.addWidget(self._table)
-        
+
         # Footer buttons
         footer = QHBoxLayout()
         footer.addStretch()
-        
+
         if self._selection_mode:
             cancel_btn = QPushButton("Cancel")
             cancel_btn.setProperty("secondary", True)
             cancel_btn.clicked.connect(self.reject)
             footer.addWidget(cancel_btn)
-            
+
             select_btn = QPushButton("Select")
             select_btn.clicked.connect(self._on_select)
             footer.addWidget(select_btn)
@@ -132,9 +167,9 @@ class MaterialDialog(QDialog):
             close_btn.setProperty("secondary", True)
             close_btn.clicked.connect(self.accept)
             footer.addWidget(close_btn)
-        
+
         layout.addLayout(footer)
-    
+
     def _load_data(self):
         """Load data from database."""
         if self._table_type == "materials":
@@ -146,11 +181,11 @@ class MaterialDialog(QDialog):
         else:
             self._items = []
         self._filter_data()
-    
+
     def _filter_data(self):
         """Filter and display data in table."""
         search = self._search_input.text().lower()
-        
+
         filtered = []
         for item in self._items:
             # Type filter (materials only)
@@ -158,59 +193,81 @@ class MaterialDialog(QDialog):
                 type_filter = self._type_filter.currentText().lower()
                 if type_filter != "all types" and item.get("type") != type_filter:
                     continue
-            
+
             # Simple search
             text = f"{item.get('name', '')} {item.get('description', '')}".lower()
             if search and search not in text:
                 continue
-                
+
             filtered.append(item)
-        
+
         self._populate_table(filtered)
-    
+
     def _populate_table(self, items: list):
         """Populate table widget."""
         self._table.setRowCount(0)
         for row, item in enumerate(items):
             self._table.insertRow(row)
-            
+
             # Common: Name (0)
             name = QTableWidgetItem(str(item.get("name", "")))
             name.setData(Qt.ItemDataRole.UserRole, item)
             self._table.setItem(row, 0, name)
-            
+
             # Specific columns
             if self._table_type == "materials":
                 self._table.setItem(row, 1, QTableWidgetItem(str(item.get("type", ""))))
-                
-                dens = f"{item.get('density', 0):.1f}" if item.get("density") is not None else "-"
+
+                dens = (
+                    f"{item.get('density', 0):.1f}"
+                    if item.get("density") is not None
+                    else "-"
+                )
                 self._table.setItem(row, 2, QTableWidgetItem(dens))
-                
-                st = f"{item.get('surface_tension', 0):.1f}" if item.get("surface_tension") is not None else "-"
+
+                st = (
+                    f"{item.get('surface_tension', 0):.1f}"
+                    if item.get("surface_tension") is not None
+                    else "-"
+                )
                 self._table.setItem(row, 3, QTableWidgetItem(st))
-                
-                self._table.setItem(row, 4, QTableWidgetItem(str(item.get("description", ""))))
-                
+
+                self._table.setItem(
+                    row, 4, QTableWidgetItem(str(item.get("description", "")))
+                )
+
             elif self._table_type == "needles":
-                self._table.setItem(row, 1, QTableWidgetItem(str(item.get("gauge", ""))))
-                
+                self._table.setItem(
+                    row, 1, QTableWidgetItem(str(item.get("gauge", "")))
+                )
+
                 od = f"{item.get('outer_diameter', 0):.2f}"
                 self._table.setItem(row, 2, QTableWidgetItem(od))
-                
-                id_ = f"{item.get('inner_diameter', 0):.2f}" if item.get("inner_diameter") else "-"
+
+                id_ = (
+                    f"{item.get('inner_diameter', 0):.2f}"
+                    if item.get("inner_diameter")
+                    else "-"
+                )
                 self._table.setItem(row, 3, QTableWidgetItem(id_))
-                
-                self._table.setItem(row, 4, QTableWidgetItem(str(item.get("description", ""))))
-                
+
+                self._table.setItem(
+                    row, 4, QTableWidgetItem(str(item.get("description", "")))
+                )
+
             elif self._table_type == "syringes":
                 vol = f"{item.get('volume_ul', 0):.1f}"
                 self._table.setItem(row, 1, QTableWidgetItem(vol))
-                
+
                 dia = f"{item.get('diameter_mm', 0):.2f}"
                 self._table.setItem(row, 2, QTableWidgetItem(dia))
-                
-                self._table.setItem(row, 3, QTableWidgetItem(str(item.get("manufacturer", ""))))
-                self._table.setItem(row, 4, QTableWidgetItem(str(item.get("description", ""))))
+
+                self._table.setItem(
+                    row, 3, QTableWidgetItem(str(item.get("manufacturer", "")))
+                )
+                self._table.setItem(
+                    row, 4, QTableWidgetItem(str(item.get("description", "")))
+                )
 
     def _on_select(self):
         """Handle selection."""
@@ -220,7 +277,7 @@ class MaterialDialog(QDialog):
             data = item.data(Qt.ItemDataRole.UserRole)
             self.item_selected.emit(data)
             self.accept()
-            
+
     def _on_add(self):
         """Handle add button."""
         if self._table_type == "materials":
@@ -252,7 +309,11 @@ class MaterialDialog(QDialog):
                 except Exception as e:
                     QMessageBox.warning(self, "Error", f"Failed to save syringe: {e}")
         else:
-            QMessageBox.information(self, "Not Implemented", f"Adding new {self._table_type} is not implemented yet.")
+            QMessageBox.information(
+                self,
+                "Not Implemented",
+                f"Adding new {self._table_type} is not implemented yet.",
+            )
 
 
 class _AddMaterialDialog(QDialog):
@@ -327,9 +388,13 @@ class _AddMaterialDialog(QDialog):
         return {
             "name": self._name.text().strip(),
             "type": self._type.currentText(),
-            "density": float(self._density.value()) if self._density.value() > 0 else None,
+            "density": (
+                float(self._density.value()) if self._density.value() > 0 else None
+            ),
             "viscosity": float(self._visc.value()) if self._visc.value() > 0 else None,
-            "surface_tension": float(self._st.value()) if self._st.value() > 0 else None,
+            "surface_tension": (
+                float(self._st.value()) if self._st.value() > 0 else None
+            ),
             "description": self._desc.toPlainText().strip() or None,
         }
 
@@ -400,6 +465,7 @@ class _AddNeedleDialog(QDialog):
             "inner_diameter": inner,
             "description": self._desc.toPlainText().strip() or None,
         }
+
 
 class _AddSyringeDialog(QDialog):
     """Simple form to add a syringe entry."""

--- a/src/menipy/gui/dialogs/overlay_config_dialog.py
+++ b/src/menipy/gui/dialogs/overlay_config_dialog.py
@@ -147,9 +147,7 @@ class OverlayConfigDialog(QDialog):
         outer.setSpacing(8)
 
         grid_host = QWidget(group)
-        grid_host.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
-        )
+        grid_host.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         layout = QGridLayout(grid_host)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setHorizontalSpacing(10)
@@ -292,9 +290,7 @@ class OverlayConfigDialog(QDialog):
         self.preview_label.setStyleSheet("background: #eeeeee; color: #555;")
         layout.addWidget(self.preview_label)
 
-        hint = QLabel(
-            "Screen-constant strokes stay readable while zooming.", group
-        )
+        hint = QLabel("Screen-constant strokes stay readable while zooming.", group)
         hint.setWordWrap(True)
         hint.setStyleSheet("color: #666;")
         layout.addWidget(hint)
@@ -320,8 +316,12 @@ class OverlayConfigDialog(QDialog):
             controls["alpha"].valueChanged.connect(self._maybe_emit_live_preview)
             if "dashed" in controls:
                 controls["dashed"].toggled.connect(self._maybe_emit_live_preview)
-                controls["dash_length"].valueChanged.connect(self._maybe_emit_live_preview)
-                controls["dash_space"].valueChanged.connect(self._maybe_emit_live_preview)
+                controls["dash_length"].valueChanged.connect(
+                    self._maybe_emit_live_preview
+                )
+                controls["dash_space"].valueChanged.connect(
+                    self._maybe_emit_live_preview
+                )
 
     def _on_ok(self) -> None:
         cfg = self.get_config()
@@ -531,7 +531,11 @@ class OverlayConfigDialog(QDialog):
             marker_color.setAlphaF(
                 max(0.0, min(1.0, float(config.get("marker_alpha", 1))))
             )
-            painter.setPen(self._preview_pen(marker_color, float(config.get("marker_thickness", 2)), 1))
+            painter.setPen(
+                self._preview_pen(
+                    marker_color, float(config.get("marker_thickness", 2)), 1
+                )
+            )
             painter.drawLine(151, 185, 169, 203)
             painter.drawLine(151, 203, 169, 185)
         if config.get("points_visible", True):

--- a/src/menipy/gui/dialogs/plugin_config_dialog.py
+++ b/src/menipy/gui/dialogs/plugin_config_dialog.py
@@ -1,16 +1,29 @@
 """Dialog for configuring plugin settings based on Pydantic models."""
+
 from typing import Type, Any, Dict, get_origin, get_args
 from enum import Enum
 from pydantic import BaseModel
 from PySide6.QtWidgets import (
-    QDialog, QFormLayout, QDialogButtonBox, QVBoxLayout,
-    QSpinBox, QDoubleSpinBox, QCheckBox, QLineEdit, QComboBox,
-    QLabel, QWidget, QScrollArea
+    QDialog,
+    QFormLayout,
+    QDialogButtonBox,
+    QVBoxLayout,
+    QSpinBox,
+    QDoubleSpinBox,
+    QCheckBox,
+    QLineEdit,
+    QComboBox,
+    QLabel,
+    QWidget,
+    QScrollArea,
 )
 from PySide6.QtCore import Qt
 
+
 class PluginConfigDialog(QDialog):
-    def __init__(self, model_class: Type[BaseModel], current_values: Dict[str, Any], parent=None):
+    def __init__(
+        self, model_class: Type[BaseModel], current_values: Dict[str, Any], parent=None
+    ):
         super().__init__(parent)
         self.setWindowTitle(f"Configure {model_class.__name__}")
         self.model_class = model_class
@@ -37,11 +50,11 @@ class PluginConfigDialog(QDialog):
             value = current_values.get(name, field.default)
             # Handle PydanticUndefined or factory
             if value is None and field.default_factory:
-                 try:
+                try:
                     value = field.default_factory()
-                 except Exception:
+                except Exception:
                     pass
-            
+
             # If still PydanticUndefined (required field missing), set sensible default for type
             # (Though passed current_values should ideally have it or we rely on type defaults)
 
@@ -58,7 +71,7 @@ class PluginConfigDialog(QDialog):
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         main_layout.addWidget(buttons)
-        
+
         self.resize(500, 400)
 
     def _create_widget(self, type_annotation, value) -> QWidget | None:
@@ -79,7 +92,7 @@ class PluginConfigDialog(QDialog):
             # Populate with Enum members
             for member in type_annotation:
                 w.addItem(member.name, member.value)
-            
+
             # Set current
             if isinstance(value, Enum):
                 w.setCurrentText(value.name)
@@ -115,7 +128,7 @@ class PluginConfigDialog(QDialog):
             w = QLineEdit()
             w.setText(str(value) if value is not None else "")
             return w
-        
+
         # Fallback for complex types (e.g. lists/tuples) -> Text Edit?
         # For now, simplistic approach: use QLineEdit and try to eval/repr?
         # Or just skip

--- a/src/menipy/gui/dialogs/plugin_manager_dialog.py
+++ b/src/menipy/gui/dialogs/plugin_manager_dialog.py
@@ -7,9 +7,16 @@ from pathlib import Path
 
 from PySide6.QtCore import Qt, QSize
 from PySide6.QtWidgets import (
-    QDialog, QTableWidgetItem, QMessageBox, QAbstractItemView, 
-    QPushButton, QStyle, QWidget, QHBoxLayout, QToolButton,
-    QInputDialog
+    QDialog,
+    QTableWidgetItem,
+    QMessageBox,
+    QAbstractItemView,
+    QPushButton,
+    QStyle,
+    QWidget,
+    QHBoxLayout,
+    QToolButton,
+    QInputDialog,
 )
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtCore import QFile
@@ -19,7 +26,9 @@ from menipy.gui.services.settings_service import AppSettings
 from menipy.common.plugin_settings import get_detector_settings_model, DETECTOR_SETTINGS
 from menipy.gui.dialogs.plugin_config_dialog import PluginConfigDialog
 
-_COL_ACTIVE, _COL_NAME, _COL_KIND, _COL_CONFIG, _COL_PATH, _COL_DESC, _COL_VER = range(7)
+_COL_ACTIVE, _COL_NAME, _COL_KIND, _COL_CONFIG, _COL_PATH, _COL_DESC, _COL_VER = range(
+    7
+)
 
 
 class PluginManagerDialog(QDialog):
@@ -75,7 +84,7 @@ class PluginManagerDialog(QDialog):
         t.setColumnWidth(_COL_ACTIVE, 60)
         t.setColumnWidth(_COL_NAME, 150)
         t.setColumnWidth(_COL_KIND, 90)
-        t.setColumnWidth(_COL_CONFIG, 60) # Small width for button
+        t.setColumnWidth(_COL_CONFIG, 60)  # Small width for button
         t.setColumnWidth(_COL_PATH, 280)
         t.horizontalHeader().setStretchLastSection(True)
         t.cellChanged.connect(self._on_cell_changed)
@@ -96,8 +105,7 @@ class PluginManagerDialog(QDialog):
     # --------------------------- actions -------------------------------------
 
     def refresh(self):
-        """refresh.
-        """
+        """refresh."""
         self._updating = True
         rows = self.vm.rows()  # list of tuples from DB
         t = self.ui.pluginsTable
@@ -115,7 +123,7 @@ class PluginManagerDialog(QDialog):
             # Name / Kind / Path / Desc / Version
             t.setItem(i, _COL_NAME, QTableWidgetItem(str(name)))
             t.setItem(i, _COL_KIND, QTableWidgetItem(str(kind)))
-            
+
             # Config Button
             # Use a container widget to center the button and avoid full-cell stretch
             container = QWidget()
@@ -124,19 +132,23 @@ class PluginManagerDialog(QDialog):
             layout = QHBoxLayout(container)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.setAlignment(Qt.AlignCenter)
-            
+
             btn = QToolButton()
             btn.setIcon(self.style().standardIcon(QStyle.SP_FileDialogDetailedView))
             btn.setToolTip("Configure Plugin")
-            btn.setAutoRaise(True) # Make it look cleaner (flat)
-            btn.setFixedSize(28, 28) # Slightly larger touch target
-            btn.setIconSize(QSize(18, 18)) # Ensure icon is readable
+            btn.setAutoRaise(True)  # Make it look cleaner (flat)
+            btn.setFixedSize(28, 28)  # Slightly larger touch target
+            btn.setIconSize(QSize(18, 18))  # Ensure icon is readable
             # Add a style for the button to ensure it doesn't look like a solid block
-            btn.setStyleSheet("QToolButton { border: none; background: transparent; } QToolButton:hover { background: rgba(255, 255, 255, 30); border-radius: 4px; }")
+            btn.setStyleSheet(
+                "QToolButton { border: none; background: transparent; } QToolButton:hover { background: rgba(255, 255, 255, 30); border-radius: 4px; }"
+            )
 
             # Connect using closure to capture variables
-            btn.clicked.connect(lambda checked=False, n=name, k=kind: self._on_configure(n, k))
-            
+            btn.clicked.connect(
+                lambda checked=False, n=name, k=kind: self._on_configure(n, k)
+            )
+
             layout.addWidget(btn)
             t.setCellWidget(i, _COL_CONFIG, container)
 
@@ -207,10 +219,13 @@ class PluginManagerDialog(QDialog):
         matches = {}
         # Expected module name for the plugin
         module_name = f"menipy_plugins.{plugin_name}"
-        
+
         # Iterate all registered detector settings
         # We access the internal dict of the Registry
-        for method_name, model_cls in DETECTOR_SETTINGS.items(): # Registry supports items()
+        for (
+            method_name,
+            model_cls,
+        ) in DETECTOR_SETTINGS.items():  # Registry supports items()
             if model_cls.__module__ == module_name:
                 matches[method_name] = model_cls
         return matches
@@ -219,15 +234,15 @@ class PluginManagerDialog(QDialog):
         """Open configuration dialog for the plugin."""
         # 1. Try to find settings models associated with this plugin name (module)
         models = self._find_settings_models_for_plugin(name)
-        
+
         target_name = name
         model_cls = None
-        
+
         if not models:
-             # Fallback: maybe the name itself IS the method name (unlikely given naming convention, but possible)
-             model_cls = get_detector_settings_model(name)
-             if model_cls:
-                 target_name = name
+            # Fallback: maybe the name itself IS the method name (unlikely given naming convention, but possible)
+            model_cls = get_detector_settings_model(name)
+            if model_cls:
+                target_name = name
         elif len(models) == 1:
             # Only one configurable item, auto-select
             target_name, model_cls = list(models.items())[0]
@@ -235,12 +250,12 @@ class PluginManagerDialog(QDialog):
             # Multiple items, ask user
             items = list(models.keys())
             item, ok = QInputDialog.getItem(
-                self, 
-                "Select Configuration", 
-                "Choose component to configure:", 
-                items, 
-                0, 
-                False
+                self,
+                "Select Configuration",
+                "Choose component to configure:",
+                items,
+                0,
+                False,
             )
             if ok and item:
                 target_name = item
@@ -250,21 +265,21 @@ class PluginManagerDialog(QDialog):
 
         if not model_cls:
             QMessageBox.information(
-                self, 
-                "No Configuration", 
-                f"No configurable settings found for plugin '{name}'."
+                self,
+                "No Configuration",
+                f"No configurable settings found for plugin '{name}'.",
             )
             return
- 
+
         # Load existing settings from DB (key uses the *target_name*, i.e., the method name)
         # We use a specific key format for method-specific defaults
         conf_key = f"plugin:{target_name}:config"
-        
+
         current_values = {}
         try:
             db_val = None
             if hasattr(self.vm, "svc") and hasattr(self.vm.svc, "db"):
-                 db_val = self.vm.svc.db.get_setting(conf_key)
+                db_val = self.vm.svc.db.get_setting(conf_key)
             if db_val:
                 current_values = json.loads(db_val)
         except Exception as e:
@@ -279,5 +294,6 @@ class PluginManagerDialog(QDialog):
                 if hasattr(self.vm, "svc") and hasattr(self.vm.svc, "db"):
                     self.vm.svc.db.set_setting(conf_key, json.dumps(new_settings))
             except Exception as e:
-                QMessageBox.critical(self, "Save Failed", f"Could not save settings: {e}")
-
+                QMessageBox.critical(
+                    self, "Save Failed", f"Could not save settings: {e}"
+                )

--- a/src/menipy/gui/dialogs/preprocessing_config_dialog.py
+++ b/src/menipy/gui/dialogs/preprocessing_config_dialog.py
@@ -112,8 +112,7 @@ class PreprocessingConfigDialog(QDialog):
         content_layout.addLayout(right_panel_layout, 1)
         # --- End of changes ---
 
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QFrame#navFrame, QFrame#pagesFrame {
                 background-color: palette(base);
                 border: 1px solid palette(mid);
@@ -133,8 +132,7 @@ class PreprocessingConfigDialog(QDialog):
             QPushButton {
                 min-width: 110px;
             }
-            """
-        )
+            """)
 
         self._build_auto_detect_page()
         self._build_crop_page()
@@ -171,28 +169,30 @@ class PreprocessingConfigDialog(QDialog):
     def _build_auto_detect_page(self) -> None:
         widget = QWidget(self)
         layout = QVBoxLayout(widget)
-        
+
         self.auto_enable = QCheckBox("Enable Automatic Feature Detection", widget)
         layout.addWidget(self.auto_enable)
-        
+
         group = QFrame(widget)
         group.setFrameShape(QFrame.StyledPanel)
         group_layout = QVBoxLayout(group)
-        
+
         self.auto_detect_roi = QCheckBox("Detect Region of Interest (ROI)", group)
         self.auto_detect_needle = QCheckBox("Detect Needle/Nozzle", group)
         self.auto_detect_substrate = QCheckBox("Detect Substrate/Baseline", group)
-        
+
         group_layout.addWidget(self.auto_detect_roi)
         group_layout.addWidget(self.auto_detect_needle)
         group_layout.addWidget(self.auto_detect_substrate)
-        
+
         layout.addWidget(group)
-        
+
         self.btn_run_auto = QPushButton("Run Auto Detect", widget)
-        self.btn_run_auto.clicked.connect(self._on_preview) # Reuse preview logic which runs pipeline
+        self.btn_run_auto.clicked.connect(
+            self._on_preview
+        )  # Reuse preview logic which runs pipeline
         layout.addWidget(self.btn_run_auto)
-        
+
         layout.addStretch(1)
         self.pages.addWidget(widget)
 
@@ -399,7 +399,9 @@ class PreprocessingConfigDialog(QDialog):
         self._preview_btn.clicked.connect(self._on_preview)
         self._reset_btn.clicked.connect(self._on_reset)
 
-        self.auto_enable.toggled.connect(self._update_auto_detect_controls) # Wire signal
+        self.auto_enable.toggled.connect(
+            self._update_auto_detect_controls
+        )  # Wire signal
 
         self.filter_method.currentTextChanged.connect(self._update_filter_controls)
         self.norm_method.currentTextChanged.connect(self._update_norm_controls)
@@ -413,14 +415,14 @@ class PreprocessingConfigDialog(QDialog):
 
     def _load_settings(self) -> None:
         s = self._settings
-        
+
         if hasattr(s, "auto_detect"):
             ad = s.auto_detect
             self.auto_enable.setChecked(ad.enabled)
             self.auto_detect_roi.setChecked(ad.detect_roi)
             self.auto_detect_needle.setChecked(ad.detect_needle)
             self.auto_detect_substrate.setChecked(ad.detect_substrate)
-            
+
         self.crop_checkbox.setChecked(s.crop_to_roi)
         self.grayscale_checkbox.setChecked(s.convert_to_grayscale)
         self.mask_checkbox.setChecked(s.work_on_roi_mask)
@@ -482,15 +484,17 @@ class PreprocessingConfigDialog(QDialog):
     def _collect_settings(self) -> PreprocessingSettings:
         """_collect_settings."""
         s = self._settings.model_copy(deep=True)
-        
+
         if hasattr(s, "auto_detect"):
             ad = s.auto_detect
-            ad.enabled = self.auto_enable.setChecked(self.auto_enable.isChecked()) # Fix side effect
+            ad.enabled = self.auto_enable.setChecked(
+                self.auto_enable.isChecked()
+            )  # Fix side effect
             ad.enabled = self.auto_enable.isChecked()
             ad.detect_roi = self.auto_detect_roi.isChecked()
             ad.detect_needle = self.auto_detect_needle.isChecked()
             ad.detect_substrate = self.auto_detect_substrate.isChecked()
-            
+
         s.crop_to_roi = self.crop_checkbox.isChecked()
         s.convert_to_grayscale = self.grayscale_checkbox.isChecked()
         s.work_on_roi_mask = self.mask_checkbox.isChecked()
@@ -545,6 +549,7 @@ class PreprocessingConfigDialog(QDialog):
         # ------------------------------------------------------------------
         # Slots
         # ------------------------------------------------------------------
+
     def _on_preview(self) -> None:
         """_on_preview."""
         settings = self._collect_settings()
@@ -562,6 +567,7 @@ class PreprocessingConfigDialog(QDialog):
 
         # Control enablement helpers
         # ------------------------------------------------------------------
+
     def _update_auto_detect_controls(self) -> None:
         """_update_auto_detect_controls."""
         enabled = self.auto_enable.isChecked()
@@ -656,10 +662,14 @@ class PreprocessingConfigDialog(QDialog):
         pixmap = QPixmap.fromImage(q_image)
 
         # Draw overlays if metadata present
-        if metadata and (metadata.get("roi") or metadata.get("needle_rect") or metadata.get("substrate_line")):
+        if metadata and (
+            metadata.get("roi")
+            or metadata.get("needle_rect")
+            or metadata.get("substrate_line")
+        ):
             painter = QPainter(pixmap)
             painter.setRenderHint(QPainter.Antialiasing)
-            
+
             # Determine offset if cropped
             offset_x, offset_y = 0, 0
             # If cropped, the image represents the ROI, so valid coordinates are shifted
@@ -671,9 +681,10 @@ class PreprocessingConfigDialog(QDialog):
 
             def to_local_rect(r):
                 """To_local_rect."""
-                if not r: return None
+                if not r:
+                    return None
                 return (r[0] - offset_x, r[1] - offset_y, r[2], r[3])
-                
+
             def to_local_line(l):
                 """to local line.
 
@@ -687,14 +698,18 @@ class PreprocessingConfigDialog(QDialog):
                 type
                 Description.
                 """
-                if not l: return None
+                if not l:
+                    return None
                 p1, p2 = l
-                return ((p1[0] - offset_x, p1[1] - offset_y), (p2[0] - offset_x, p2[1] - offset_y))
+                return (
+                    (p1[0] - offset_x, p1[1] - offset_y),
+                    (p2[0] - offset_x, p2[1] - offset_y),
+                )
 
                 # Draw ROI (if not cropped, or if we want to show it anyway - if cropped it's the border)
                 if roi:
                     rx, ry, rw, rh = to_local_rect(roi)
-                pen = QPen(QColor(255, 255, 0)) # Yellow
+                pen = QPen(QColor(255, 255, 0))  # Yellow
                 pen.setWidth(2)
                 pen.setStyle(Qt.DashLine)
                 painter.setPen(pen)
@@ -704,7 +719,7 @@ class PreprocessingConfigDialog(QDialog):
                 needle = metadata.get("needle_rect")
                 if needle:
                     nx, ny, nw, nh = to_local_rect(needle)
-                pen = QPen(QColor(0, 255, 255)) # Cyan
+                pen = QPen(QColor(0, 255, 255))  # Cyan
                 pen.setWidth(2)
                 painter.setPen(pen)
                 painter.drawRect(nx, ny, nw, nh)
@@ -713,7 +728,7 @@ class PreprocessingConfigDialog(QDialog):
                 sub = metadata.get("substrate_line")
                 if sub:
                     (x1, y1), (x2, y2) = to_local_line(sub)
-                pen = QPen(QColor(255, 0, 255)) # Magenta
+                pen = QPen(QColor(255, 0, 255))  # Magenta
                 pen.setWidth(2)
                 painter.setPen(pen)
                 painter.drawLine(x1, y1, x2, y2)
@@ -721,7 +736,9 @@ class PreprocessingConfigDialog(QDialog):
                 painter.end()
 
                 self.preview_label.setPixmap(
-                pixmap.scaled(
-                self.preview_label.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation
-                )
+                    pixmap.scaled(
+                        self.preview_label.size(),
+                        Qt.KeepAspectRatio,
+                        Qt.SmoothTransformation,
+                    )
                 )

--- a/src/menipy/gui/dialogs/settings_dialog.py
+++ b/src/menipy/gui/dialogs/settings_dialog.py
@@ -3,11 +3,22 @@ Settings Dialog
 
 Configuration dialog for global application settings.
 """
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QPushButton, QTabWidget, QCheckBox, QComboBox,
-    QLineEdit, QFileDialog, QFormLayout, QWidget
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QTabWidget,
+    QCheckBox,
+    QComboBox,
+    QLineEdit,
+    QFileDialog,
+    QFormLayout,
+    QWidget,
 )
 
 from menipy.gui import theme
@@ -15,7 +26,7 @@ from menipy.gui import theme
 
 class SettingsDialog(QDialog):
     """Global settings dialog."""
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -28,55 +39,55 @@ class SettingsDialog(QDialog):
         self.setWindowTitle("Settings")
         self.resize(600, 500)
         self._setup_ui()
-        
+
     def _setup_ui(self):
         self.setStyleSheet(theme.get_stylesheet())
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
-        
+
         # Tabs
         self._tabs = QTabWidget()
         self._tabs.addTab(self._create_general_tab(), "General")
         self._tabs.addTab(self._create_analysis_tab(), "Analysis Defaults")
         self._tabs.addTab(self._create_experiment_tab(), "Experiments")
         layout.addWidget(self._tabs)
-        
+
         # Footer
         footer = QHBoxLayout()
         footer.addStretch()
-        
+
         btn_cancel = QPushButton("Cancel")
         btn_cancel.setProperty("secondary", True)
         btn_cancel.clicked.connect(self.reject)
         footer.addWidget(btn_cancel)
-        
+
         btn_save = QPushButton("Save")
         btn_save.clicked.connect(self.accept)
         footer.addWidget(btn_save)
-        
+
         layout.addLayout(footer)
-        
+
     def _create_general_tab(self) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setSpacing(16)
         layout.setContentsMargins(16, 16, 16, 16)
-        
+
         # Appearance
         group_app = self._create_group("Appearance")
         fl = QFormLayout(group_app)
-        
+
         self._theme_combo = QComboBox()
         self._theme_combo.addItems(["Dark (Default)", "Light (Not implemented)"])
         fl.addRow("Theme:", self._theme_combo)
-        
+
         layout.addWidget(group_app)
-        
+
         # Paths
         group_paths = self._create_group("Default Paths")
         fl_paths = QFormLayout(group_paths)
-        
+
         path_row = QHBoxLayout()
         self._data_path = QLineEdit()
         self._data_path.setPlaceholderText("D:/Data/ADSA")
@@ -85,51 +96,51 @@ class SettingsDialog(QDialog):
         btn_browse.clicked.connect(lambda: self._browse_path(self._data_path))
         path_row.addWidget(self._data_path)
         path_row.addWidget(btn_browse)
-        
+
         fl_paths.addRow("Data Directory:", path_row)
         layout.addWidget(group_paths)
-        
+
         layout.addStretch()
         return container
-        
+
     def _create_analysis_tab(self) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setSpacing(16)
         layout.setContentsMargins(16, 16, 16, 16)
-        
+
         group_perf = self._create_group("Performance")
         fl = QFormLayout(group_perf)
-        
+
         self._use_gpu = QCheckBox("Enable GPU Acceleration")
         self._use_gpu.setChecked(True)
         fl.addRow(self._use_gpu)
-        
+
         self._parallel = QCheckBox("Use Multithreading")
         self._parallel.setChecked(True)
         fl.addRow(self._parallel)
-        
+
         layout.addWidget(group_perf)
         layout.addStretch()
         return container
-        
+
     def _create_experiment_tab(self) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setSpacing(16)
         layout.setContentsMargins(16, 16, 16, 16)
-        
+
         group_sessile = self._create_group("Sessile Drop")
         fl = QFormLayout(group_sessile)
-        
+
         self._auto_save = QCheckBox("Auto-save results after analysis")
         self._auto_save.setChecked(True)
         fl.addRow(self._auto_save)
-        
+
         layout.addWidget(group_sessile)
         layout.addStretch()
         return container
-        
+
     def _create_group(self, title):
         group = QFrame()
         group.setStyleSheet(f"""
@@ -144,12 +155,12 @@ class SettingsDialog(QDialog):
         lbl.setStyleSheet("font-weight: bold; font-size: 14px;")
         l.addWidget(lbl)
         return group
-        
+
     def _browse_path(self, line_edit):
         path = QFileDialog.getExistingDirectory(self, "Select Directory")
         if path:
             line_edit.setText(path)
-            
+
     def get_settings(self) -> dict:
         """Return dict of settings."""
         return {
@@ -157,5 +168,5 @@ class SettingsDialog(QDialog):
             "data_path": self._data_path.text(),
             "gpu": self._use_gpu.isChecked(),
             "parallel": self._parallel.isChecked(),
-            "auto_save": self._auto_save.isChecked()
+            "auto_save": self._auto_save.isChecked(),
         }

--- a/src/menipy/gui/dialogs/utilities_dialog.py
+++ b/src/menipy/gui/dialogs/utilities_dialog.py
@@ -7,9 +7,18 @@ Lists all registered utilities and allows running them on the current image.
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QListWidget, QListWidgetItem, QTextEdit, QSplitter,
-    QFrame, QGroupBox, QMessageBox
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QListWidget,
+    QListWidgetItem,
+    QTextEdit,
+    QSplitter,
+    QFrame,
+    QGroupBox,
+    QMessageBox,
 )
 from PySide6.QtGui import QPixmap, QImage
 
@@ -24,13 +33,13 @@ logger = logging.getLogger(__name__)
 
 class UtilitiesDialog(QDialog):
     """Dialog for running image testing utilities.
-    
+
     Shows a list of registered utilities with descriptions,
     allows running them on the current image, and displays results.
     """
-    
+
     utility_run = Signal(str, dict)  # utility_name, results
-    
+
     def __init__(self, image: np.ndarray | None = None, parent=None):
         """Initialize.
 
@@ -44,13 +53,13 @@ class UtilitiesDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("🔧 Utilities")
         self.setMinimumSize(700, 500)
-        
+
         self._image = image
         self._current_utility = None
-        
+
         self._setup_ui()
         self._populate_utilities()
-        
+
         # Apply theme
         self.setStyleSheet(f"""
             QDialog {{
@@ -90,38 +99,38 @@ class UtilitiesDialog(QDialog):
                 padding: 0 4px;
             }}
         """)
-    
+
     def _setup_ui(self):
         """Set up the dialog UI."""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(12)
-        
+
         # Main splitter
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        
+
         # Left: Utilities list
         left_panel = QWidget()
         left_layout = QVBoxLayout(left_panel)
         left_layout.setContentsMargins(0, 0, 0, 0)
         left_layout.setSpacing(8)
-        
+
         list_label = QLabel("Available Utilities")
         list_label.setStyleSheet(f"font-weight: bold; color: {theme.TEXT_PRIMARY};")
         left_layout.addWidget(list_label)
-        
+
         self._utility_list = QListWidget()
         self._utility_list.currentItemChanged.connect(self._on_utility_selected)
         left_layout.addWidget(self._utility_list)
-        
+
         splitter.addWidget(left_panel)
-        
+
         # Right: Details and results
         right_panel = QWidget()
         right_layout = QVBoxLayout(right_panel)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(8)
-        
+
         # Description
         desc_group = QGroupBox("Description")
         desc_layout = QVBoxLayout(desc_group)
@@ -130,7 +139,7 @@ class UtilitiesDialog(QDialog):
         self._description_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         desc_layout.addWidget(self._description_label)
         right_layout.addWidget(desc_group)
-        
+
         # Results
         results_group = QGroupBox("Results")
         results_layout = QVBoxLayout(results_group)
@@ -139,7 +148,7 @@ class UtilitiesDialog(QDialog):
         self._results_text.setPlaceholderText("Run a utility to see results...")
         results_layout.addWidget(self._results_text)
         right_layout.addWidget(results_group, stretch=1)
-        
+
         # Run button
         self._run_button = QPushButton("▶ Run Utility")
         self._run_button.setEnabled(False)
@@ -162,81 +171,83 @@ class UtilitiesDialog(QDialog):
             }}
         """)
         right_layout.addWidget(self._run_button)
-        
+
         splitter.addWidget(right_panel)
         splitter.setSizes([250, 450])
-        
+
         layout.addWidget(splitter)
-        
+
         # Bottom buttons
         button_layout = QHBoxLayout()
         button_layout.addStretch()
-        
+
         close_btn = QPushButton("Close")
         close_btn.clicked.connect(self.close)
         button_layout.addWidget(close_btn)
-        
+
         layout.addLayout(button_layout)
-    
+
     def _populate_utilities(self):
         """Populate the utilities list from registry."""
         self._utility_list.clear()
-        
+
         for name in UTILITIES.keys():
             fn = UTILITIES.get(name)
             desc = getattr(fn, "__doc__", None) or "No description available."
             # Get first line of docstring
             short_desc = desc.strip().split("\n")[0]
-            
+
             item = QListWidgetItem(f"🔧 {name}")
             item.setData(Qt.ItemDataRole.UserRole, name)
             item.setToolTip(short_desc)
             self._utility_list.addItem(item)
-        
+
         if self._utility_list.count() == 0:
             item = QListWidgetItem("(No utilities registered)")
             item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
             self._utility_list.addItem(item)
-    
+
     def _on_utility_selected(self, current, previous):
         """Handle utility selection."""
         if current is None:
             self._run_button.setEnabled(False)
             self._description_label.setText("Select a utility to see its description.")
             return
-        
+
         name = current.data(Qt.ItemDataRole.UserRole)
         if not name:
             self._run_button.setEnabled(False)
             return
-        
+
         self._current_utility = name
         fn = UTILITIES.get(name)
-        
+
         # Show full docstring
         desc = getattr(fn, "__doc__", "No description available.")
         self._description_label.setText(desc.strip())
-        
+
         # Enable run button only if we have an image
         self._run_button.setEnabled(self._image is not None)
         if self._image is None:
-            self._results_text.setText("⚠️ No image loaded. Load an image to run this utility.")
-    
+            self._results_text.setText(
+                "⚠️ No image loaded. Load an image to run this utility."
+            )
+
     def _on_run_utility(self):
         """Run the selected utility."""
         if not self._current_utility or self._image is None:
             return
-        
+
         fn = UTILITIES.get(self._current_utility)
         if not fn:
             return
-        
+
         self._results_text.setText("Running...")
-        
+
         try:
             # Call the utility function
             result = fn(self._image)
-            
+
             # Format results
             if isinstance(result, dict):
                 lines = [f"{self._current_utility} Results", "=" * 40]
@@ -250,14 +261,17 @@ class UtilitiesDialog(QDialog):
                 self._results_text.setText(result)
             else:
                 self._results_text.setText(str(result))
-            
+
             # Emit signal
-            self.utility_run.emit(self._current_utility, result if isinstance(result, dict) else {"result": result})
-            
+            self.utility_run.emit(
+                self._current_utility,
+                result if isinstance(result, dict) else {"result": result},
+            )
+
         except Exception as e:
             logger.exception(f"Error running utility {self._current_utility}")
             self._results_text.setText(f"❌ Error: {str(e)}")
-    
+
     def set_image(self, image: np.ndarray):
         """Set the image to analyze."""
         self._image = image

--- a/src/menipy/gui/helpers/image_marking.py
+++ b/src/menipy/gui/helpers/image_marking.py
@@ -17,7 +17,6 @@ from menipy.gui.controllers.preprocessing_controller import (
 )
 from menipy.gui.panels.preview_panel import PreviewPanel
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -70,6 +69,7 @@ class ImageMarkerHelper(QObject):
         # ------------------------------------------------------------------
         # Slots
         # ------------------------------------------------------------------
+
     def _on_point_clicked(self, point: QPointF, button: int, modifiers: int) -> None:
         if self._view is None:
             return

--- a/src/menipy/gui/main_controller.py
+++ b/src/menipy/gui/main_controller.py
@@ -72,7 +72,7 @@ class MainController(QObject):
             setup_ctrl=self.setup_ctrl,
             preview_panel=self.preview_panel,
             preprocessing_ctrl=self.preprocessing_ctrl,
-            parent=self
+            parent=self,
         )
 
         self.layout_manager = LayoutManager(window=self.window, settings=self.settings)
@@ -87,8 +87,8 @@ class MainController(QObject):
         )
 
         self.overlay_manager = OverlayManager(
-            image_view=getattr(self.preview_panel, 'image_view', None),
-            settings=self.settings
+            image_view=getattr(self.preview_panel, "image_view", None),
+            settings=self.settings,
         )
 
         self._wire_signals()
@@ -117,7 +117,9 @@ class MainController(QObject):
         """Connect signals from child controllers to main controller slots."""
         # Setup Panel
         self.setup_ctrl.browse_requested.connect(self.image_manager.browse_image)
-        self.setup_ctrl.browse_batch_requested.connect(self.image_manager.browse_batch_folder)
+        self.setup_ctrl.browse_batch_requested.connect(
+            self.image_manager.browse_batch_folder
+        )
         self.setup_ctrl.preview_requested.connect(self.on_preview_requested)
         self.setup_ctrl.run_all_requested.connect(self.run_full_pipeline)
         self.setup_ctrl.play_stage_requested.connect(self.pipeline_ctrl.run_stage)
@@ -126,7 +128,9 @@ class MainController(QObject):
             self.dialog_coordinator.show_dialog_for_stage
         )
         self.setup_ctrl.pipeline_changed.connect(self.on_pipeline_changed)
-        self.setup_ctrl.auto_calibrate_requested.connect(self.on_auto_calibrate_requested)
+        self.setup_ctrl.auto_calibrate_requested.connect(
+            self.on_auto_calibrate_requested
+        )
 
         # Preview Panel
         self.setup_ctrl.draw_mode_requested.connect(self.preview_panel.set_draw_mode)
@@ -244,35 +248,38 @@ class MainController(QObject):
         """Launch auto-calibration wizard."""
         image = self.image_manager.load_preprocessing_image()
         if image is None:
-            self.window.statusBar().showMessage('No image loaded for calibration', 2000)
+            self.window.statusBar().showMessage("No image loaded for calibration", 2000)
             QMessageBox.warning(
                 self.window,
-                'Auto-Calibrate',
-                'Please load an image before running auto-calibration.'
+                "Auto-Calibrate",
+                "Please load an image before running auto-calibration.",
             )
             return
-        
-        pipeline_name = self.setup_ctrl.current_pipeline_name() or 'sessile'
-        
+
+        pipeline_name = self.setup_ctrl.current_pipeline_name() or "sessile"
+
         try:
-            from menipy.gui.dialogs.calibration_wizard_dialog import CalibrationWizardDialog
-            
+            from menipy.gui.dialogs.calibration_wizard_dialog import (
+                CalibrationWizardDialog,
+            )
+
             wizard = CalibrationWizardDialog(image, pipeline_name, self.window)
             wizard.calibration_complete.connect(self._on_calibration_complete)
             wizard.exec()
         except Exception as exc:
-            logger.exception('Failed to open calibration wizard')
+            logger.exception("Failed to open calibration wizard")
             QMessageBox.critical(
                 self.window,
-                'Auto-Calibrate Error',
-                f'Failed to open calibration wizard:\n{exc}'
+                "Auto-Calibrate Error",
+                f"Failed to open calibration wizard:\n{exc}",
             )
-    
+
     @Slot(object)
     def _on_calibration_complete(self, result) -> None:
         """Apply calibration results to preview and settings."""
         try:
             from menipy.common.auto_calibrator import CalibrationResult
+
             if not isinstance(result, CalibrationResult):
                 return
             self._last_calibration_result = result
@@ -285,29 +292,35 @@ class MainController(QObject):
                 if result.substrate_line or result.contact_points:
                     self.preview_panel.set_layer_visible("baseline", True)
             except Exception:
-                logger.debug("Could not reveal calibration overlay layers", exc_info=True)
-            
+                logger.debug(
+                    "Could not reveal calibration overlay layers", exc_info=True
+                )
+
             # Delegate drawing to OverlayManager
             self.overlay_manager.draw_calibration_result(result)
-            
+
             # Update controllers with calibration data
             if result.roi_rect and self.preprocessing_ctrl:
                 self.preprocessing_ctrl.update_geometry(roi=result.roi_rect)
-                logger.info(f'Calibration: ROI set to {result.roi_rect}')
-            
+                logger.info(f"Calibration: ROI set to {result.roi_rect}")
+
             if result.substrate_line and self.preprocessing_ctrl:
-                self.preprocessing_ctrl.update_geometry(contact_line=result.substrate_line)
-            
+                self.preprocessing_ctrl.update_geometry(
+                    contact_line=result.substrate_line
+                )
+
             # Report success
-            conf = result.confidence_scores.get('overall', 0.0)
+            conf = result.confidence_scores.get("overall", 0.0)
             self.window.statusBar().showMessage(
-                f'Calibration complete (confidence: {conf*100:.0f}%)', 3000
+                f"Calibration complete (confidence: {conf*100:.0f}%)", 3000
             )
-            logger.info(f'Calibration applied: ROI={result.roi_rect}, needle={result.needle_rect}, substrate={result.substrate_line is not None}')
-            
+            logger.info(
+                f"Calibration applied: ROI={result.roi_rect}, needle={result.needle_rect}, substrate={result.substrate_line is not None}"
+            )
+
         except Exception as exc:
-            logger.exception('Failed to apply calibration results')
-            self.window.statusBar().showMessage('Failed to apply calibration', 2000)
+            logger.exception("Failed to apply calibration results")
+            self.window.statusBar().showMessage("Failed to apply calibration", 2000)
 
     @Slot()
     def stop_pipeline(self):
@@ -359,7 +372,9 @@ class MainController(QObject):
                     self.settings.marker_config
                 )
         except Exception:
-            logger.debug("Failed to apply marker config to overlay manager", exc_info=True)
+            logger.debug(
+                "Failed to apply marker config to overlay manager", exc_info=True
+            )
         self.window.statusBar().showMessage("Marker configuration saved", 1500)
 
     @Slot()
@@ -439,20 +454,24 @@ class MainController(QObject):
     def export_results_csv(self) -> None:
         """Opens a file dialog and exports the results history to CSV."""
         from menipy.models.results import get_results_history
-        
+
         file_path, _ = QFileDialog.getSaveFileName(
             self.window, "Export Results to CSV", "", "CSV Files (*.csv)"
         )
         if not file_path:
             return
-            
+
         history = get_results_history()
         success = history.export_csv(file_path)
-        
+
         if success:
-            self.window.statusBar().showMessage(f"Results exported to {Path(file_path).name}", 3000)
+            self.window.statusBar().showMessage(
+                f"Results exported to {Path(file_path).name}", 3000
+            )
         else:
-            QMessageBox.critical(self.window, "Export Error", "Failed to export results to CSV.")
+            QMessageBox.critical(
+                self.window, "Export Error", "Failed to export results to CSV."
+            )
 
     @Slot(str)
     def change_unit_system(self, system: str) -> None:
@@ -477,6 +496,7 @@ class MainController(QObject):
         if self.results_panel:
             try:
                 from menipy.models.results import get_results_history
+
                 history = get_results_history()
                 self.results_panel.update_history_table(
                     history,
@@ -484,14 +504,13 @@ class MainController(QObject):
                 )
             except Exception as e:
                 logger.error(f"Failed to refresh results panel: {e}")
-        
+
         # 2. Update setup panel labels
         if self.setup_ctrl:
             try:
                 self.setup_ctrl.refresh_ui_labels()
             except Exception as e:
                 logger.error(f"Failed to refresh setup panel labels: {e}")
-
 
     @Slot(object)
     def _on_roi_selected(self, rect) -> None:
@@ -569,7 +588,7 @@ class MainController(QObject):
             ):
                 # Delegate overlay drawing to OverlayManager
                 self.overlay_manager.draw_edge_detection_preview(metadata)
-            
+
         except Exception:
             logger.debug(
                 "Error while handling edge detection preview image", exc_info=True

--- a/src/menipy/gui/main_window.py
+++ b/src/menipy/gui/main_window.py
@@ -83,6 +83,7 @@ def _preview_dominant_sizes(
     vertical = _workbench_vertical_sizes(available, None)
     return [root[0], vertical[0], vertical[1]]
 
+
 # --- promoted preview widget (registered into QUiLoader) ---
 try:
     from .views.image_view import ImageView
@@ -574,9 +575,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         if show_setup and show_inspector:
             target_sizes = self._splitter_sizes_full or sizes
-            target_vertical_sizes = getattr(
-                self, "_workbench_splitter_sizes_full", None
-            ) or vertical_sizes
+            target_vertical_sizes = (
+                getattr(self, "_workbench_splitter_sizes_full", None) or vertical_sizes
+            )
         elif show_setup and not show_inspector:
             total = max(1, sum(sizes))
             target_sizes = [max(200, sizes[0]), max(1, total - sizes[0])]

--- a/src/menipy/gui/mainwindow.py
+++ b/src/menipy/gui/mainwindow.py
@@ -4,6 +4,7 @@ Compatibility shim for tests expecting menipy.gui.mainwindow.MainWindow.
 Provides a lightweight MainWindow with just enough UI wiring for
 `tests/test_setup_panel.py` to exercise controller signals.
 """
+
 from __future__ import annotations
 
 from PySide6.QtCore import QObject, Signal, QTimer
@@ -89,7 +90,9 @@ class _DummySetupController(QObject):
         self.browseBtn.clicked.connect(self.browse_requested)
         self.batchBrowseBtn.clicked.connect(self.browse_batch_requested)
         self.previewBtn.clicked.connect(self.preview_requested)
-        self.drawPointBtn.clicked.connect(lambda: self.draw_mode_requested.emit("point"))
+        self.drawPointBtn.clicked.connect(
+            lambda: self.draw_mode_requested.emit("point")
+        )
         self.drawLineBtn.clicked.connect(lambda: self.draw_mode_requested.emit("line"))
         self.drawRectBtn.clicked.connect(lambda: self.draw_mode_requested.emit("rect"))
         self.clearOverlayBtn.clicked.connect(self.clear_overlays_requested)
@@ -101,6 +104,7 @@ class _DummySetupController(QObject):
         self.testCombo.currentTextChanged.connect(
             lambda txt: self.pipeline_changed.emit(txt.lower().replace(" ", "_"))
         )
+
         def _throttled_refresh():
             if self._refresh_guard:
                 return

--- a/src/menipy/gui/panels/__init__.py
+++ b/src/menipy/gui/panels/__init__.py
@@ -3,6 +3,7 @@ GUI panels package.
 
 Contains reusable panel components for the ADSA application.
 """
+
 from menipy.gui.panels.image_source_panel import ImageSourcePanel
 from menipy.gui.panels.calibration_panel import CalibrationPanel
 from menipy.gui.panels.parameters_panel import ParametersPanel
@@ -18,4 +19,3 @@ __all__ = [
     "NeedleCalibrationPanel",
     "TiltStagePanel",
 ]
-

--- a/src/menipy/gui/panels/action_panel.py
+++ b/src/menipy/gui/panels/action_panel.py
@@ -3,9 +3,16 @@ Action Panel
 
 Panel containing the main analysis action button with progress indicator.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame, QPushButton, QProgressBar
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QProgressBar,
 )
 
 from menipy.gui import theme
@@ -14,25 +21,25 @@ from menipy.gui import theme
 class ActionPanel(QFrame):
     """
     Panel with the main analyze button and progress indicator.
-    
+
     States:
         - Ready: Show "Analyze" button
     - Processing: Show progress bar with cancel button
     - Complete: Show "Analyze" button again
-    
+
     Signals:
         analyze_requested: User clicked analyze button.
         cancel_requested: User clicked cancel button.
     """
-    
+
     analyze_requested = Signal()
     settings_requested = Signal()
     cancel_requested = Signal()
-    
+
     STATE_READY = "ready"
     STATE_PROCESSING = "processing"
     STATE_COMPLETE = "complete"
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -45,7 +52,7 @@ class ActionPanel(QFrame):
         self.setObjectName("actionPanel")
         self._state = self.STATE_READY
         self._setup_ui()
-    
+
     def _setup_ui(self):
         """Set up the panel UI."""
         self.setStyleSheet(f"""
@@ -55,17 +62,17 @@ class ActionPanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
-        
+
         # Ready state widgets
         self._ready_container = QWidget()
         ready_layout = QVBoxLayout(self._ready_container)
         ready_layout.setContentsMargins(0, 0, 0, 0)
         ready_layout.setSpacing(8)
-        
+
         self._analyze_button = QPushButton("▶ Analyze Current Frame")
         self._analyze_button.setMinimumHeight(44)
         self._analyze_button.setStyleSheet(f"""
@@ -104,22 +111,24 @@ class ActionPanel(QFrame):
         """)
         self._settings_button.clicked.connect(self.settings_requested.emit)
         button_layout.addWidget(self._settings_button)
-        
+
         ready_layout.addLayout(button_layout)
-        
+
         shortcut_label = QLabel("Ctrl+R to run")
         shortcut_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        shortcut_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY}; font-style: italic;")
+        shortcut_label.setStyleSheet(
+            f"color: {theme.TEXT_SECONDARY}; font-style: italic;"
+        )
         ready_layout.addWidget(shortcut_label)
-        
+
         layout.addWidget(self._ready_container)
-        
+
         # Processing state widgets
         self._processing_container = QWidget()
         processing_layout = QVBoxLayout(self._processing_container)
         processing_layout.setContentsMargins(0, 0, 0, 0)
         processing_layout.setSpacing(8)
-        
+
         self._status_label = QLabel("⏸️ Processing...")
         self._status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._status_label.setStyleSheet(f"""
@@ -128,50 +137,50 @@ class ActionPanel(QFrame):
             font-weight: bold;
         """)
         processing_layout.addWidget(self._status_label)
-        
+
         self._progress_bar = QProgressBar()
         self._progress_bar.setRange(0, 100)
         self._progress_bar.setValue(0)
         self._progress_bar.setTextVisible(True)
         self._progress_bar.setFormat("%p%")
         processing_layout.addWidget(self._progress_bar)
-        
+
         self._cancel_button = QPushButton("✕ Cancel")
         self._cancel_button.setProperty("secondary", True)
         self._cancel_button.clicked.connect(self.cancel_requested.emit)
         processing_layout.addWidget(self._cancel_button)
-        
+
         self._processing_container.hide()
         layout.addWidget(self._processing_container)
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_state(self, state: str):
         """
         Set the panel state.
-        
+
         Args:
             state: One of STATE_READY, STATE_PROCESSING, STATE_COMPLETE
         """
         self._state = state
-        
+
         if state == self.STATE_READY or state == self.STATE_COMPLETE:
             self._ready_container.show()
             self._processing_container.hide()
             self._analyze_button.setEnabled(True)
-        
+
         elif state == self.STATE_PROCESSING:
             self._ready_container.hide()
             self._processing_container.show()
             self._status_label.setText("⏸️ Processing...")
             self._progress_bar.setValue(0)
-    
+
     def set_progress(self, value: int, status_text: str | None = None):
         """
         Update the progress bar.
-        
+
         Args:
             value: Progress value 0-100.
             status_text: Optional status text to display.
@@ -181,11 +190,11 @@ class ActionPanel(QFrame):
             self._status_label.setText(status_text)
         else:
             self._status_label.setText(f"⏸️ Processing... {value}%")
-    
+
     def set_enabled(self, enabled: bool):
         """Enable or disable the analyze button."""
         self._analyze_button.setEnabled(enabled)
-    
+
     def set_button_text(self, text: str):
         """Set custom text for the analyze button."""
         self._analyze_button.setText(text)

--- a/src/menipy/gui/panels/calibration_panel.py
+++ b/src/menipy/gui/panels/calibration_panel.py
@@ -4,9 +4,15 @@ Calibration Panel
 Panel for managing image calibration (scale factor in px/mm).
 Shows calibration status and provides access to the calibration wizard.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame, QPushButton
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
 )
 
 from menipy.gui import theme
@@ -15,23 +21,23 @@ from menipy.gui import theme
 class CalibrationPanel(QFrame):
     """
     Panel displaying calibration status and controls.
-    
+
     Shows:
         - Calibration status (calibrated/not calibrated)
     - Scale factor (px/mm)
     - Reference file info
     - Calibration date
-    
+
     Signals:
         calibration_requested: User wants to start calibration wizard.
         recalibration_requested: User wants to recalibrate.
         details_requested: User wants to view calibration details.
     """
-    
+
     calibration_requested = Signal()
     recalibration_requested = Signal()
     details_requested = Signal()
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -42,15 +48,15 @@ class CalibrationPanel(QFrame):
         """
         super().__init__(parent)
         self.setObjectName("calibrationPanel")
-        
+
         self._is_calibrated = False
         self._scale_factor = 0.0
         self._reference_file: str | None = None
         self._calibration_date: str | None = None
-        
+
         self._setup_ui()
         self._update_display()
-    
+
     def _setup_ui(self):
         """Set up the panel UI."""
         self.setStyleSheet(f"""
@@ -60,11 +66,11 @@ class CalibrationPanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
-        
+
         # Header
         header = QLabel("Calibration")
         header.setStyleSheet(f"""
@@ -73,104 +79,110 @@ class CalibrationPanel(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Status indicator
         self._status_label = QLabel()
         layout.addWidget(self._status_label)
-        
+
         # Scale factor
         self._scale_label = QLabel()
         self._scale_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(self._scale_label)
-        
+
         # Reference file
         self._reference_label = QLabel()
         self._reference_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         self._reference_label.setWordWrap(True)
         layout.addWidget(self._reference_label)
-        
+
         # Date
         self._date_label = QLabel()
         self._date_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(self._date_label)
-        
+
         # Buttons container (changes based on calibration state)
         self._buttons_container = QWidget()
         buttons_layout = QHBoxLayout(self._buttons_container)
         buttons_layout.setContentsMargins(0, 8, 0, 0)
         buttons_layout.setSpacing(8)
-        
+
         # Calibration button (shown when not calibrated)
         self._calibrate_button = QPushButton("🎯 Start Calibration Wizard")
         self._calibrate_button.clicked.connect(self.calibration_requested.emit)
         buttons_layout.addWidget(self._calibrate_button)
-        
+
         # Recalibrate button (shown when calibrated)
         self._recalibrate_button = QPushButton("🎯 Recalibrate…")
         self._recalibrate_button.setProperty("secondary", True)
         self._recalibrate_button.clicked.connect(self.recalibration_requested.emit)
         buttons_layout.addWidget(self._recalibrate_button)
-        
+
         # Details button (shown when calibrated)
         self._details_button = QPushButton("ℹ️ Details")
         self._details_button.setProperty("secondary", True)
         self._details_button.clicked.connect(self.details_requested.emit)
         buttons_layout.addWidget(self._details_button)
-        
+
         layout.addWidget(self._buttons_container)
-    
+
     def _update_display(self):
         """Update the display based on current calibration state."""
         if self._is_calibrated:
             self._status_label.setText("Status: ✓ Calibrated")
-            self._status_label.setStyleSheet(f"color: {theme.SUCCESS_GREEN}; font-weight: bold;")
-            
+            self._status_label.setStyleSheet(
+                f"color: {theme.SUCCESS_GREEN}; font-weight: bold;"
+            )
+
             self._scale_label.setText(f"Scale Factor: {self._scale_factor:.1f} px/mm")
             self._scale_label.show()
-            
+
             if self._reference_file:
                 self._reference_label.setText(f"Reference: {self._reference_file}")
                 self._reference_label.show()
             else:
                 self._reference_label.hide()
-            
+
             if self._calibration_date:
                 self._date_label.setText(f"Date: {self._calibration_date}")
                 self._date_label.show()
             else:
                 self._date_label.hide()
-            
+
             self._calibrate_button.hide()
             self._recalibrate_button.show()
             self._details_button.show()
-        
+
         else:
             self._status_label.setText("Status: ⚠️ Not Calibrated")
-            self._status_label.setStyleSheet(f"color: {theme.WARNING_ORANGE}; font-weight: bold;")
-            
-            self._scale_label.setText("Calibration is required before\naccurate measurements can be made.")
+            self._status_label.setStyleSheet(
+                f"color: {theme.WARNING_ORANGE}; font-weight: bold;"
+            )
+
+            self._scale_label.setText(
+                "Calibration is required before\naccurate measurements can be made."
+            )
             self._scale_label.show()
-            
+
             self._reference_label.hide()
             self._date_label.hide()
-            
+
             self._calibrate_button.show()
             self._recalibrate_button.hide()
             self._details_button.hide()
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_calibration(
         self,
         scale_factor: float,
         reference_file: str | None = None,
-        date: str | None = None
+        date: str | None = None,
     ):
         """
         Set the calibration data.
-        
+
         Args:
             scale_factor: Scale factor in pixels per millimeter.
             reference_file: Name of the reference file used for calibration.
@@ -181,7 +193,7 @@ class CalibrationPanel(QFrame):
         self._reference_file = reference_file
         self._calibration_date = date
         self._update_display()
-    
+
     def clear_calibration(self):
         """Clear the current calibration."""
         self._is_calibrated = False
@@ -189,11 +201,11 @@ class CalibrationPanel(QFrame):
         self._reference_file = None
         self._calibration_date = None
         self._update_display()
-    
+
     def is_calibrated(self) -> bool:
         """Check if calibration is set."""
         return self._is_calibrated
-    
+
     def get_scale_factor(self) -> float:
         """Get the current scale factor (px/mm)."""
         return self._scale_factor

--- a/src/menipy/gui/panels/image_source_panel.py
+++ b/src/menipy/gui/panels/image_source_panel.py
@@ -4,12 +4,21 @@ Image Source Panel
 Panel for selecting image source (single file, batch folder, or camera)
 and managing the currently loaded image(s).
 """
+
 from pathlib import Path
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPixmap, QDragEnterEvent, QDropEvent
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QRadioButton, QButtonGroup, QPushButton, QSlider, QFileDialog
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QRadioButton,
+    QButtonGroup,
+    QPushButton,
+    QSlider,
+    QFileDialog,
 )
 
 from menipy.gui import theme
@@ -18,26 +27,26 @@ from menipy.gui import theme
 class ImageSourcePanel(QFrame):
     """
     Panel for selecting and managing image sources.
-    
+
     Supports three modes:
         - Single File: Load individual images
     - Batch Folder: Load all images from a folder
     - Live Camera: Stream from connected camera
-    
+
     Signals:
         image_loaded: Emitted when an image is loaded (path, pixmap).
         source_mode_changed: Emitted when the source mode changes.
         frame_changed: Emitted when the current frame changes (for batch/video).
     """
-    
+
     image_loaded = Signal(str, object)  # path, QPixmap or None
     source_mode_changed = Signal(str)  # "single", "batch", "camera"
     frame_changed = Signal(int)  # frame index
-    
+
     MODE_SINGLE = "single"
     MODE_BATCH = "batch"
     MODE_CAMERA = "camera"
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -48,16 +57,16 @@ class ImageSourcePanel(QFrame):
         """
         super().__init__(parent)
         self.setObjectName("imageSourcePanel")
-        
+
         self._current_mode = self.MODE_SINGLE
         self._current_path: str | None = None
         self._batch_files: list[str] = []
         self._current_frame = 0
         self._total_frames = 1
-        
+
         self._setup_ui()
         self.setAcceptDrops(True)
-    
+
     def _setup_ui(self):
         """Set up the panel UI."""
         self.setStyleSheet(f"""
@@ -67,11 +76,11 @@ class ImageSourcePanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel("Image Source")
         header.setStyleSheet(f"""
@@ -80,31 +89,31 @@ class ImageSourcePanel(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Mode selection
         self._mode_group = QButtonGroup(self)
-        
+
         self._single_radio = QRadioButton("Single File")
         self._single_radio.setChecked(True)
         self._mode_group.addButton(self._single_radio)
         layout.addWidget(self._single_radio)
-        
+
         self._batch_radio = QRadioButton("Batch Folder")
         self._mode_group.addButton(self._batch_radio)
         layout.addWidget(self._batch_radio)
-        
+
         self._camera_radio = QRadioButton("Live Camera")
         self._mode_group.addButton(self._camera_radio)
         layout.addWidget(self._camera_radio)
-        
+
         self._mode_group.buttonClicked.connect(self._on_mode_changed)
-        
+
         # File info display
         self._file_label = QLabel("No file loaded")
         self._file_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         self._file_label.setWordWrap(True)
         layout.addWidget(self._file_label)
-        
+
         # Thumbnail preview
         self._thumbnail_frame = QFrame()
         self._thumbnail_frame.setFixedSize(96, 96)
@@ -115,39 +124,39 @@ class ImageSourcePanel(QFrame):
         """)
         thumb_layout = QVBoxLayout(self._thumbnail_frame)
         thumb_layout.setContentsMargins(2, 2, 2, 2)
-        
+
         self._thumbnail_label = QLabel()
         self._thumbnail_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._thumbnail_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         self._thumbnail_label.setText("No Image")
         thumb_layout.addWidget(self._thumbnail_label)
-        
+
         layout.addWidget(self._thumbnail_frame, alignment=Qt.AlignmentFlag.AlignCenter)
-        
+
         # Load button
         self._load_button = QPushButton("📁 Load Image…")
         self._load_button.clicked.connect(self._on_load_clicked)
         layout.addWidget(self._load_button)
-        
+
         # Frame slider (hidden by default)
         self._frame_container = QWidget()
         frame_layout = QVBoxLayout(self._frame_container)
         frame_layout.setContentsMargins(0, 0, 0, 0)
         frame_layout.setSpacing(4)
-        
+
         self._frame_label = QLabel("Frame: 1/1")
         self._frame_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         frame_layout.addWidget(self._frame_label)
-        
+
         self._frame_slider = QSlider(Qt.Orientation.Horizontal)
         self._frame_slider.setMinimum(0)
         self._frame_slider.setMaximum(0)
         self._frame_slider.valueChanged.connect(self._on_frame_changed)
         frame_layout.addWidget(self._frame_slider)
-        
+
         self._frame_container.hide()
         layout.addWidget(self._frame_container)
-        
+
         # Drop zone hint
         self._drop_hint = QLabel("Drop image here")
         self._drop_hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -157,9 +166,9 @@ class ImageSourcePanel(QFrame):
             padding: 8px;
         """)
         layout.addWidget(self._drop_hint)
-        
+
         layout.addStretch()
-    
+
     def _on_mode_changed(self, button: QRadioButton):
         """Handle mode selection change."""
         if button == self._single_radio:
@@ -173,9 +182,9 @@ class ImageSourcePanel(QFrame):
             self._current_mode = self.MODE_CAMERA
             self._load_button.setText("📷 Connect Camera…")
             self._frame_container.hide()
-        
+
         self.source_mode_changed.emit(self._current_mode)
-    
+
     def _on_load_clicked(self):
         """Handle load button click."""
         if self._current_mode == self.MODE_SINGLE:
@@ -183,75 +192,79 @@ class ImageSourcePanel(QFrame):
                 self,
                 "Open Image",
                 "",
-                "Images (*.png *.jpg *.jpeg *.tiff *.tif *.bmp);;All Files (*)"
+                "Images (*.png *.jpg *.jpeg *.tiff *.tif *.bmp);;All Files (*)",
             )
             if path:
                 self.load_image(path)
-        
+
         elif self._current_mode == self.MODE_BATCH:
             path = QFileDialog.getExistingDirectory(self, "Select Folder")
             if path:
                 self.load_batch_folder(path)
-        
+
         elif self._current_mode == self.MODE_CAMERA:
             # TODO: Open camera selection dialog
             pass
-    
+
     def _on_frame_changed(self, value: int):
         """Handle frame slider change."""
         self._current_frame = value
         self._frame_label.setText(f"Frame: {value + 1}/{self._total_frames}")
-        
+
         if self._batch_files and 0 <= value < len(self._batch_files):
             self.load_image(self._batch_files[value], update_slider=False)
-        
+
         self.frame_changed.emit(value)
-    
+
     def load_image(self, path: str, update_slider: bool = True):
         """
         Load an image from the given path.
-        
+
         Args:
             path: Path to the image file.
             update_slider: Whether to update batch slider position.
         """
         self._current_path = path
-        
+
         # Update file label
         filename = Path(path).name
         self._file_label.setText(f"📁 {filename}")
-        
+
         # Load and display thumbnail
         pixmap = QPixmap(path)
         if not pixmap.isNull():
             scaled = pixmap.scaled(
-                92, 92,
+                92,
+                92,
                 Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation
+                Qt.TransformationMode.SmoothTransformation,
             )
             self._thumbnail_label.setPixmap(scaled)
             self.image_loaded.emit(path, pixmap)
         else:
             self._thumbnail_label.setText("Load Error")
             self.image_loaded.emit(path, None)
-    
+
     def load_batch_folder(self, folder_path: str):
         """
         Load all images from a folder.
-        
+
         Args:
             folder_path: Path to the folder containing images.
         """
         folder = Path(folder_path)
         extensions = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp"}
-        
-        self._batch_files = sorted([
-            str(f) for f in folder.iterdir()
-            if f.is_file() and f.suffix.lower() in extensions
-        ])
-        
+
+        self._batch_files = sorted(
+            [
+                str(f)
+                for f in folder.iterdir()
+                if f.is_file() and f.suffix.lower() in extensions
+            ]
+        )
+
         self._total_frames = len(self._batch_files)
-        
+
         if self._total_frames > 0:
             self._frame_slider.setMaximum(self._total_frames - 1)
             self._frame_slider.setValue(0)
@@ -261,27 +274,27 @@ class ImageSourcePanel(QFrame):
         else:
             self._file_label.setText("No images found in folder")
             self._frame_container.hide()
-    
+
     def get_current_path(self) -> str | None:
         """Get the path to the currently loaded image."""
         return self._current_path
-    
+
     def get_current_mode(self) -> str:
         """Get the current source mode."""
         return self._current_mode
-    
+
     def get_current_frame(self) -> int:
         """Get the current frame index."""
         return self._current_frame
-    
+
     def get_total_frames(self) -> int:
         """Get the total number of frames."""
         return self._total_frames
-    
+
     # -------------------------------------------------------------------------
     # Drag and Drop
     # -------------------------------------------------------------------------
-    
+
     def dragEnterEvent(self, event: QDragEnterEvent):
         """Handle drag enter event."""
         if event.mimeData().hasUrls():
@@ -293,7 +306,7 @@ class ImageSourcePanel(QFrame):
                     border-radius: 8px;
                 }}
             """)
-    
+
     def dragLeaveEvent(self, event):
         """Handle drag leave event."""
         self.setStyleSheet(f"""
@@ -303,7 +316,7 @@ class ImageSourcePanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-    
+
     def dropEvent(self, event: QDropEvent):
         """Handle drop event."""
         self.setStyleSheet(f"""
@@ -313,7 +326,7 @@ class ImageSourcePanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         urls = event.mimeData().urls()
         if urls:
             path = urls[0].toLocalFile()

--- a/src/menipy/gui/panels/needle_calibration_panel.py
+++ b/src/menipy/gui/panels/needle_calibration_panel.py
@@ -3,10 +3,17 @@ Needle Calibration Panel
 
 Panel for calibrating needle diameter for pendant drop experiments.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QPushButton, QDoubleSpinBox, QComboBox
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QDoubleSpinBox,
+    QComboBox,
 )
 
 from menipy.gui import theme
@@ -15,21 +22,21 @@ from menipy.gui import theme
 class NeedleCalibrationPanel(QFrame):
     """
     Panel for needle calibration in pendant drop experiments.
-    
+
     Shows:
         - Needle diameter input (with common presets)
     - Detection status
     - Calibration method selection
-    
+
     Signals:
         needle_diameter_changed: Emitted when needle diameter changes.
         auto_detect_requested: User wants to auto-detect needle.
     """
-    
+
     needle_diameter_changed = Signal(float)
     auto_detect_requested = Signal()
     database_requested = Signal()
-    
+
     # Common needle outer diameters (mm)
     NEEDLE_PRESETS = [
         ("Custom", 0.0),
@@ -43,7 +50,7 @@ class NeedleCalibrationPanel(QFrame):
         ("27G (0.41mm)", 0.41),
         ("30G (0.31mm)", 0.31),
     ]
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -54,10 +61,10 @@ class NeedleCalibrationPanel(QFrame):
         """
         super().__init__(parent)
         self.setObjectName("needleCalibrationPanel")
-        
+
         self._is_detected = False
         self._setup_ui()
-    
+
     def _setup_ui(self):
         """Set up the panel UI."""
         self.setStyleSheet(f"""
@@ -67,11 +74,11 @@ class NeedleCalibrationPanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(10)
-        
+
         # Header
         header = QLabel("Needle Calibration")
         header.setStyleSheet(f"""
@@ -80,50 +87,52 @@ class NeedleCalibrationPanel(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Status indicator
         self._status_label = QLabel("Status: ⚠️ Not Calibrated")
-        self._status_label.setStyleSheet(f"color: {theme.WARNING_ORANGE}; font-weight: bold;")
+        self._status_label.setStyleSheet(
+            f"color: {theme.WARNING_ORANGE}; font-weight: bold;"
+        )
         layout.addWidget(self._status_label)
-        
+
         # Needle preset dropdown
         preset_container = QWidget()
         preset_layout = QVBoxLayout(preset_container)
         preset_layout.setContentsMargins(0, 0, 0, 0)
         preset_layout.setSpacing(4)
-        
+
         preset_header = QHBoxLayout()
         preset_label = QLabel("Needle Gauge")
         preset_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         preset_header.addWidget(preset_label)
-        
+
         db_btn = QPushButton("📚 DB")
         db_btn.setProperty("secondary", True)
         db_btn.setFixedSize(50, 24)
         db_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         db_btn.clicked.connect(self.database_requested.emit)
         preset_header.addWidget(db_btn)
-        
+
         preset_layout.addLayout(preset_header)
-        
+
         self._preset_combo = QComboBox()
         for name, _ in self.NEEDLE_PRESETS:
             self._preset_combo.addItem(name)
         self._preset_combo.currentIndexChanged.connect(self._on_preset_changed)
         preset_layout.addWidget(self._preset_combo)
-        
+
         layout.addWidget(preset_container)
-        
+
         # Diameter input
         diameter_container = QWidget()
         diameter_layout = QVBoxLayout(diameter_container)
         diameter_layout.setContentsMargins(0, 0, 0, 0)
         diameter_layout.setSpacing(4)
-        
+
         diameter_label = QLabel("Outer Diameter (mm)")
         diameter_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         diameter_layout.addWidget(diameter_label)
-        
+
         self._diameter_spin = QDoubleSpinBox()
         self._diameter_spin.setRange(0.1, 5.0)
         self._diameter_spin.setDecimals(3)
@@ -131,9 +140,9 @@ class NeedleCalibrationPanel(QFrame):
         self._diameter_spin.setSuffix(" mm")
         self._diameter_spin.valueChanged.connect(self._on_diameter_changed)
         diameter_layout.addWidget(self._diameter_spin)
-        
+
         layout.addWidget(diameter_container)
-        
+
         # Detection info (shown when auto-detected)
         self._detection_info = QFrame()
         self._detection_info.setStyleSheet(f"""
@@ -144,34 +153,34 @@ class NeedleCalibrationPanel(QFrame):
         detection_layout = QVBoxLayout(self._detection_info)
         detection_layout.setContentsMargins(8, 8, 8, 8)
         detection_layout.setSpacing(4)
-        
+
         self._detected_width_label = QLabel("Detected Width: -- px")
         self._detected_width_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         detection_layout.addWidget(self._detected_width_label)
-        
+
         self._scale_factor_label = QLabel("Scale Factor: -- px/mm")
         self._scale_factor_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         detection_layout.addWidget(self._scale_factor_label)
-        
+
         self._detection_info.hide()
         layout.addWidget(self._detection_info)
-        
+
         # Auto-detect button
         self._detect_button = QPushButton("🔍 Auto-Detect Needle")
         self._detect_button.clicked.connect(self.auto_detect_requested.emit)
         layout.addWidget(self._detect_button)
-        
+
         # Apply button
         self._apply_button = QPushButton("✓ Apply Calibration")
         self._apply_button.clicked.connect(self._on_apply)
         layout.addWidget(self._apply_button)
-    
+
     def _on_preset_changed(self, index: int):
         """Handle needle preset selection."""
         if index > 0:  # Skip "Custom"
             _, diameter = self.NEEDLE_PRESETS[index]
             self._diameter_spin.setValue(diameter)
-    
+
     def _on_diameter_changed(self, value: float):
         """Handle diameter value change."""
         # Check if it matches a preset
@@ -183,47 +192,51 @@ class NeedleCalibrationPanel(QFrame):
                 break
         self._preset_combo.setCurrentIndex(matching_preset)
         self._preset_combo.blockSignals(False)
-    
+
     def _on_database_requested(self):
         """Handle database button click."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
-        
+
         dialog = MaterialDialog(self, selection_mode=True, table_type="needles")
         dialog.item_selected.connect(self._on_needle_selected)
         dialog.exec()
-        
+
     def _on_needle_selected(self, data: dict):
         """Handle needle selection from database."""
         if diameter := data.get("outer_diameter"):
-             self._diameter_spin.setValue(float(diameter))
-             # Keep detection status valid if only diameter changed? 
-             # No, if diameter changes, scale factor changes, so it remains "detected" but result updates.
-             self._update_status(self._is_detected, float(diameter))
+            self._diameter_spin.setValue(float(diameter))
+            # Keep detection status valid if only diameter changed?
+            # No, if diameter changes, scale factor changes, so it remains "detected" but result updates.
+            self._update_status(self._is_detected, float(diameter))
 
     def _on_apply(self):
         """Handle apply button click."""
         diameter = self._diameter_spin.value()
         self.needle_diameter_changed.emit(diameter)
         self._update_status(True, diameter)
-    
+
     def _update_status(self, calibrated: bool, diameter: float = 0.0):
         """Update the calibration status display."""
         self._is_detected = calibrated
         if calibrated:
             self._status_label.setText(f"Status: ✓ Calibrated ({diameter:.2f}mm)")
-            self._status_label.setStyleSheet(f"color: {theme.SUCCESS_GREEN}; font-weight: bold;")
+            self._status_label.setStyleSheet(
+                f"color: {theme.SUCCESS_GREEN}; font-weight: bold;"
+            )
         else:
             self._status_label.setText("Status: ⚠️ Not Calibrated")
-            self._status_label.setStyleSheet(f"color: {theme.WARNING_ORANGE}; font-weight: bold;")
-    
+            self._status_label.setStyleSheet(
+                f"color: {theme.WARNING_ORANGE}; font-weight: bold;"
+            )
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_detected_needle(self, width_px: float, scale_factor: float):
         """
         Set the auto-detected needle information.
-        
+
         Args:
             width_px: Detected needle width in pixels.
             scale_factor: Calculated scale factor (px/mm).
@@ -232,15 +245,15 @@ class NeedleCalibrationPanel(QFrame):
         self._scale_factor_label.setText(f"Scale Factor: {scale_factor:.1f} px/mm")
         self._detection_info.show()
         self._update_status(True, self._diameter_spin.value())
-    
+
     def get_diameter(self) -> float:
         """Get the current needle diameter value."""
         return self._diameter_spin.value()
-    
+
     def set_diameter(self, value: float):
         """Set the needle diameter value."""
         self._diameter_spin.setValue(value)
-    
+
     def is_calibrated(self) -> bool:
         """Check if needle is calibrated."""
         return self._is_detected

--- a/src/menipy/gui/panels/parameters_panel.py
+++ b/src/menipy/gui/panels/parameters_panel.py
@@ -4,11 +4,20 @@ Parameters Panel
 Panel for configuring measurement parameters for drop analysis.
 Includes density inputs, advanced options, and material database integration.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QPushButton, QDoubleSpinBox, QComboBox, QCheckBox,
-    QSlider, QGroupBox
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QDoubleSpinBox,
+    QComboBox,
+    QCheckBox,
+    QSlider,
+    QGroupBox,
 )
 
 from menipy.gui import theme
@@ -17,7 +26,7 @@ from menipy.gui import theme
 class ParametersPanel(QFrame):
     """
     Panel for configuring measurement parameters.
-    
+
     For sessile drop analysis:
         - Liquid density
     - Surrounding fluid density
@@ -25,15 +34,15 @@ class ParametersPanel(QFrame):
     - Contact angle method
     - Baseline detection method
     - Edge detection sensitivity
-    
+
     Signals:
         parameters_changed: Emitted when any parameter changes.
         material_database_requested: User wants to open material database.
     """
-    
+
     parameters_changed = Signal(dict)
     material_database_requested = Signal(str)  # field name
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -45,7 +54,7 @@ class ParametersPanel(QFrame):
         super().__init__(parent)
         self.setObjectName("parametersPanel")
         self._setup_ui()
-    
+
     def _setup_ui(self):
         """Set up the panel UI."""
         self.setStyleSheet(f"""
@@ -55,11 +64,11 @@ class ParametersPanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel("Measurement Parameters")
         header.setStyleSheet(f"""
@@ -68,27 +77,27 @@ class ParametersPanel(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Liquid Density
-        layout.addWidget(self._create_density_input(
-            "Liquid Density (kg/m³)",
-            "liquid_density",
-            default=1000.0
-        ))
-        
+        layout.addWidget(
+            self._create_density_input(
+                "Liquid Density (kg/m³)", "liquid_density", default=1000.0
+            )
+        )
+
         # Surrounding Density
-        layout.addWidget(self._create_density_input(
-            "Surrounding Density (kg/m³)",
-            "surrounding_density",
-            default=1.2
-        ))
-        
+        layout.addWidget(
+            self._create_density_input(
+                "Surrounding Density (kg/m³)", "surrounding_density", default=1.2
+            )
+        )
+
         # Surface Tension (optional)
         st_container = QWidget()
         st_layout = QVBoxLayout(st_container)
         st_layout.setContentsMargins(0, 0, 0, 0)
         st_layout.setSpacing(4)
-        
+
         st_label_row = QHBoxLayout()
         st_label = QLabel("Surface Tension (mN/m)")
         st_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
@@ -96,7 +105,7 @@ class ParametersPanel(QFrame):
         st_label_row.addWidget(QLabel("(optional)"))
         st_label_row.addStretch()
         st_layout.addLayout(st_label_row)
-        
+
         self._surface_tension_spin = QDoubleSpinBox()
         self._surface_tension_spin.setRange(0, 1000)
         self._surface_tension_spin.setDecimals(1)
@@ -104,9 +113,9 @@ class ParametersPanel(QFrame):
         self._surface_tension_spin.setSpecialValueText("Auto")
         self._surface_tension_spin.valueChanged.connect(self._on_parameter_changed)
         st_layout.addWidget(self._surface_tension_spin)
-        
+
         layout.addWidget(st_container)
-        
+
         # Advanced Options (collapsible)
         self._advanced_checkbox = QCheckBox("▼ Advanced Options")
         self._advanced_checkbox.setStyleSheet(f"""
@@ -117,114 +126,105 @@ class ParametersPanel(QFrame):
         """)
         self._advanced_checkbox.toggled.connect(self._toggle_advanced)
         layout.addWidget(self._advanced_checkbox)
-        
+
         # Advanced options container
         self._advanced_container = QWidget()
         self._advanced_container.hide()
         advanced_layout = QVBoxLayout(self._advanced_container)
         advanced_layout.setContentsMargins(8, 8, 8, 8)
         advanced_layout.setSpacing(12)
-        
+
         # Contact Angle Method
         method_container = QWidget()
         method_layout = QVBoxLayout(method_container)
         method_layout.setContentsMargins(0, 0, 0, 0)
         method_layout.setSpacing(4)
-        
+
         method_label = QLabel("Contact Angle Method")
         method_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         method_layout.addWidget(method_label)
-        
+
         self._method_combo = QComboBox()
-        self._method_combo.addItems([
-            "Tangent Method",
-            "Polynomial Fit",
-            "Young-Laplace Fit"
-        ])
+        self._method_combo.addItems(
+            ["Tangent Method", "Polynomial Fit", "Young-Laplace Fit"]
+        )
         self._method_combo.currentTextChanged.connect(self._on_parameter_changed)
         method_layout.addWidget(self._method_combo)
-        
+
         advanced_layout.addWidget(method_container)
-        
+
         # Baseline Detection
         baseline_container = QWidget()
         baseline_layout = QVBoxLayout(baseline_container)
         baseline_layout.setContentsMargins(0, 0, 0, 0)
         baseline_layout.setSpacing(4)
-        
+
         baseline_label = QLabel("Baseline Detection")
         baseline_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         baseline_layout.addWidget(baseline_label)
-        
+
         self._baseline_combo = QComboBox()
-        self._baseline_combo.addItems([
-            "Automatic",
-            "Manual",
-            "Three-point"
-        ])
+        self._baseline_combo.addItems(["Automatic", "Manual", "Three-point"])
         self._baseline_combo.currentTextChanged.connect(self._on_parameter_changed)
         baseline_layout.addWidget(self._baseline_combo)
-        
+
         advanced_layout.addWidget(baseline_container)
-        
+
         # Edge Detection Sensitivity
         edge_container = QWidget()
         edge_layout = QVBoxLayout(edge_container)
         edge_layout.setContentsMargins(0, 0, 0, 0)
         edge_layout.setSpacing(4)
-        
+
         edge_label = QLabel("Edge Detection Sensitivity")
         edge_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         edge_layout.addWidget(edge_label)
-        
+
         slider_layout = QHBoxLayout()
         slider_layout.addWidget(QLabel("Low"))
-        
+
         self._edge_sensitivity_slider = QSlider(Qt.Orientation.Horizontal)
         self._edge_sensitivity_slider.setRange(1, 100)
         self._edge_sensitivity_slider.setValue(50)
         self._edge_sensitivity_slider.valueChanged.connect(self._on_parameter_changed)
         slider_layout.addWidget(self._edge_sensitivity_slider)
-        
+
         slider_layout.addWidget(QLabel("High"))
         edge_layout.addLayout(slider_layout)
-        
+
         advanced_layout.addWidget(edge_container)
-        
+
         # Correction options
         self._gravity_correction = QCheckBox("Apply gravity correction")
         self._gravity_correction.setChecked(True)
         self._gravity_correction.stateChanged.connect(self._on_parameter_changed)
         advanced_layout.addWidget(self._gravity_correction)
-        
+
         self._symmetrize_profile = QCheckBox("Symmetrize drop profile")
         self._symmetrize_profile.setChecked(True)
         self._symmetrize_profile.stateChanged.connect(self._on_parameter_changed)
         advanced_layout.addWidget(self._symmetrize_profile)
-        
+
         layout.addWidget(self._advanced_container)
-        
+
         layout.addStretch()
-    
+
     def _create_density_input(
-        self,
-        label_text: str,
-        field_name: str,
-        default: float = 1000.0
+        self, label_text: str, field_name: str, default: float = 1000.0
     ) -> QWidget:
         """Create a density input with material database button."""
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
-        
+
         label = QLabel(label_text)
         label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(label)
-        
+
         row = QHBoxLayout()
         row.setSpacing(8)
-        
+
         spinbox = QDoubleSpinBox()
         spinbox.setRange(0, 50000)
         spinbox.setDecimals(1)
@@ -232,37 +232,41 @@ class ParametersPanel(QFrame):
         spinbox.setSuffix("")
         spinbox.valueChanged.connect(self._on_parameter_changed)
         row.addWidget(spinbox, stretch=1)
-        
+
         # Store reference
         setattr(self, f"_{field_name}_spin", spinbox)
-        
+
         db_button = QPushButton("📚 Database")
         db_button.setProperty("secondary", True)
         db_button.setMaximumWidth(100)
-        db_button.clicked.connect(lambda: self.material_database_requested.emit(field_name))
+        db_button.clicked.connect(
+            lambda: self.material_database_requested.emit(field_name)
+        )
         row.addWidget(db_button)
-        
+
         layout.addLayout(row)
         return container
-    
+
     def _toggle_advanced(self, checked: bool):
         """Toggle advanced options visibility."""
         self._advanced_container.setVisible(checked)
-        self._advanced_checkbox.setText("▲ Advanced Options" if checked else "▼ Advanced Options")
-    
+        self._advanced_checkbox.setText(
+            "▲ Advanced Options" if checked else "▼ Advanced Options"
+        )
+
     def _on_parameter_changed(self):
         """Emit parameters changed signal."""
         params = self.get_parameters()
         self.parameters_changed.emit(params)
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def get_parameters(self) -> dict:
         """
         Get all current parameter values.
-        
+
         Returns:
             Dictionary with all parameter values.
         """
@@ -276,11 +280,11 @@ class ParametersPanel(QFrame):
             "gravity_correction": self._gravity_correction.isChecked(),
             "symmetrize_profile": self._symmetrize_profile.isChecked(),
         }
-    
+
     def set_parameters(self, params: dict):
         """
         Set parameter values from a dictionary.
-        
+
         Args:
             params: Dictionary with parameter values.
         """
@@ -300,11 +304,11 @@ class ParametersPanel(QFrame):
             self._gravity_correction.setChecked(params["gravity_correction"])
         if "symmetrize_profile" in params:
             self._symmetrize_profile.setChecked(params["symmetrize_profile"])
-    
+
     def set_density(self, field_name: str, value: float):
         """
         Set a density value (from material database).
-        
+
         Args:
             field_name: "liquid_density" or "surrounding_density"
             value: Density value in kg/m³

--- a/src/menipy/gui/panels/preview_panel.py
+++ b/src/menipy/gui/panels/preview_panel.py
@@ -20,7 +20,6 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QColor, QAction
 
-
 LAYER_DEFAULTS = {
     "contour": True,
     "fit": True,
@@ -198,10 +197,16 @@ class PreviewPanel:
             self.image_view.clear_overlays()
 
     def apply_overlay_config(self, config: dict[str, Any] | None = None) -> None:
-        cfg = config if config is not None else getattr(self.settings, "overlay_config", None)
+        cfg = (
+            config
+            if config is not None
+            else getattr(self.settings, "overlay_config", None)
+        )
         cfg = dict(cfg or {})
         self._layer_state = self._load_layer_state(cfg)
-        if self.image_view and hasattr(self.image_view, "set_overlay_stroke_scale_mode"):
+        if self.image_view and hasattr(
+            self.image_view, "set_overlay_stroke_scale_mode"
+        ):
             self.image_view.set_overlay_stroke_scale_mode(
                 str(cfg.get("stroke_scale_mode", "screen"))
             )
@@ -343,6 +348,7 @@ class PreviewPanel:
 
     def _wire_buttons(self) -> None:
         """_wire_buttons."""
+
         def _find_button(name: str) -> Optional[QToolButton | QPushButton]:
             button = self.panel.findChild(QToolButton, name)
             if button:
@@ -387,6 +393,7 @@ class PreviewPanel:
 
     def _install_guided_menus(self) -> None:
         """Replace exposed overlay controls with compact guided menus."""
+
         def _find_button(name: str) -> Optional[QToolButton | QPushButton]:
             button = self.panel.findChild(QToolButton, name)
             if button:
@@ -475,8 +482,14 @@ class PreviewPanel:
             self.image_view.set_overlay_layer_visible(layer, bool(visible))
         self._save_layer_state()
 
-    def _load_layer_state(self, config: dict[str, Any] | None = None) -> dict[str, bool]:
-        cfg = config if config is not None else getattr(self.settings, "overlay_config", None)
+    def _load_layer_state(
+        self, config: dict[str, Any] | None = None
+    ) -> dict[str, bool]:
+        cfg = (
+            config
+            if config is not None
+            else getattr(self.settings, "overlay_config", None)
+        )
         cfg = dict(cfg or {})
         return {
             layer: bool(cfg.get(LAYER_SETTINGS_KEYS[layer], default))
@@ -496,7 +509,9 @@ class PreviewPanel:
             pass
 
     def _apply_all_layer_visibility(self) -> None:
-        if not self.image_view or not hasattr(self.image_view, "set_overlay_layer_visible"):
+        if not self.image_view or not hasattr(
+            self.image_view, "set_overlay_layer_visible"
+        ):
             return
         for layer, visible in self._layer_state.items():
             self.image_view.set_overlay_layer_visible(layer, visible)

--- a/src/menipy/gui/panels/results_panel.py
+++ b/src/menipy/gui/panels/results_panel.py
@@ -69,6 +69,7 @@ def get_label_with_unit(key: str, system: str) -> str:
 
     return key.replace("_", " ").title()
 
+
 VALID_PIPELINES = {
     "sessile",
     "pendant",
@@ -714,7 +715,9 @@ class ResultsPanel:
             self.history.add_measurement(measurement)
             self.update_history()
 
-    def update_history_table(self, history=None, unit_system: str | None = None) -> None:
+    def update_history_table(
+        self, history=None, unit_system: str | None = None
+    ) -> None:
         """Refresh the history table using the current global unit setting."""
         if unit_system in ("SI", "CGS"):
             self.unit_system = unit_system

--- a/src/menipy/gui/panels/setup_panel.py
+++ b/src/menipy/gui/panels/setup_panel.py
@@ -129,7 +129,9 @@ class SetupPanelController(QObject):
         self.previewBtn: Optional[QToolButton] = panel.findChild(
             QToolButton, "previewBtn"
         )
-        self.autoCalibrateBtn: Optional[QPushButton] = panel.findChild(QPushButton, "autoCalibrateBtn")
+        self.autoCalibrateBtn: Optional[QPushButton] = panel.findChild(
+            QPushButton, "autoCalibrateBtn"
+        )
 
         # Calibration input widgets
         self.needleLengthSpin: Optional[QDoubleSpinBox] = panel.findChild(

--- a/src/menipy/gui/panels/tilt_stage_panel.py
+++ b/src/menipy/gui/panels/tilt_stage_panel.py
@@ -3,10 +3,18 @@ Tilt Stage Panel
 
 Panel for controlling tilting platform angle in tilted sessile experiments.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QPushButton, QDoubleSpinBox, QSlider, QProgressBar
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QDoubleSpinBox,
+    QSlider,
+    QProgressBar,
 )
 
 from menipy.gui import theme
@@ -15,22 +23,22 @@ from menipy.gui import theme
 class TiltStagePanel(QFrame):
     """
     Panel for controlling the tilting stage angle.
-    
+
     Shows:
         - Current tilt angle
     - Target angle input
     - Tilt sequence controls
-    
+
     Signals:
         angle_changed: Emitted when tilt angle changes.
         sequence_started: User started a tilt sequence.
         sequence_stopped: User stopped the sequence.
     """
-    
+
     angle_changed = Signal(float)
     sequence_started = Signal(float, float, float)  # start, end, step
     sequence_stopped = Signal()
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -41,12 +49,12 @@ class TiltStagePanel(QFrame):
         """
         super().__init__(parent)
         self.setObjectName("tiltStagePanel")
-        
+
         self._current_angle = 0.0
         self._is_sequence_running = False
-        
+
         self._setup_ui()
-    
+
     def _setup_ui(self):
         """Set up the panel UI."""
         self.setStyleSheet(f"""
@@ -56,11 +64,11 @@ class TiltStagePanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(10)
-        
+
         # Header
         header = QLabel("Tilt Stage Control")
         header.setStyleSheet(f"""
@@ -69,7 +77,7 @@ class TiltStagePanel(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Current angle display
         angle_display = QFrame()
         angle_display.setStyleSheet(f"""
@@ -80,11 +88,11 @@ class TiltStagePanel(QFrame):
         angle_layout = QVBoxLayout(angle_display)
         angle_layout.setContentsMargins(12, 12, 12, 12)
         angle_layout.setSpacing(4)
-        
+
         angle_title = QLabel("Current Angle")
         angle_title.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         angle_layout.addWidget(angle_title)
-        
+
         self._angle_label = QLabel("0.0°")
         self._angle_label.setStyleSheet(f"""
             color: {theme.TEXT_PRIMARY};
@@ -93,37 +101,37 @@ class TiltStagePanel(QFrame):
         """)
         self._angle_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         angle_layout.addWidget(self._angle_label)
-        
+
         layout.addWidget(angle_display)
-        
+
         # Angle slider
         slider_container = QWidget()
         slider_layout = QHBoxLayout(slider_container)
         slider_layout.setContentsMargins(0, 0, 0, 0)
         slider_layout.setSpacing(8)
-        
+
         slider_layout.addWidget(QLabel("0°"))
-        
+
         self._angle_slider = QSlider(Qt.Orientation.Horizontal)
         self._angle_slider.setRange(0, 900)  # 0-90 degrees * 10
         self._angle_slider.setValue(0)
         self._angle_slider.valueChanged.connect(self._on_slider_changed)
         slider_layout.addWidget(self._angle_slider, stretch=1)
-        
+
         slider_layout.addWidget(QLabel("90°"))
-        
+
         layout.addWidget(slider_container)
-        
+
         # Manual angle input
         manual_container = QWidget()
         manual_layout = QHBoxLayout(manual_container)
         manual_layout.setContentsMargins(0, 0, 0, 0)
         manual_layout.setSpacing(8)
-        
+
         manual_label = QLabel("Set Angle:")
         manual_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         manual_layout.addWidget(manual_label)
-        
+
         self._angle_spin = QDoubleSpinBox()
         self._angle_spin.setRange(0, 90)
         self._angle_spin.setDecimals(1)
@@ -131,14 +139,14 @@ class TiltStagePanel(QFrame):
         self._angle_spin.setSuffix("°")
         self._angle_spin.valueChanged.connect(self._on_spin_changed)
         manual_layout.addWidget(self._angle_spin)
-        
+
         go_button = QPushButton("Go")
         go_button.setMaximumWidth(60)
         go_button.clicked.connect(self._on_go_clicked)
         manual_layout.addWidget(go_button)
-        
+
         layout.addWidget(manual_container)
-        
+
         # Tilt sequence section
         sequence_header = QLabel("▼ Tilt Sequence")
         sequence_header.setStyleSheet(f"""
@@ -147,13 +155,13 @@ class TiltStagePanel(QFrame):
             padding-top: 8px;
         """)
         layout.addWidget(sequence_header)
-        
+
         # Sequence parameters
         seq_grid = QWidget()
         seq_layout = QVBoxLayout(seq_grid)
         seq_layout.setContentsMargins(0, 0, 0, 0)
         seq_layout.setSpacing(8)
-        
+
         # Start angle
         start_row = QHBoxLayout()
         start_row.addWidget(QLabel("Start:"))
@@ -163,7 +171,7 @@ class TiltStagePanel(QFrame):
         self._start_spin.setSuffix("°")
         start_row.addWidget(self._start_spin)
         seq_layout.addLayout(start_row)
-        
+
         # End angle
         end_row = QHBoxLayout()
         end_row.addWidget(QLabel("End:"))
@@ -173,7 +181,7 @@ class TiltStagePanel(QFrame):
         self._end_spin.setSuffix("°")
         end_row.addWidget(self._end_spin)
         seq_layout.addLayout(end_row)
-        
+
         # Step
         step_row = QHBoxLayout()
         step_row.addWidget(QLabel("Step:"))
@@ -183,31 +191,31 @@ class TiltStagePanel(QFrame):
         self._step_spin.setSuffix("°")
         step_row.addWidget(self._step_spin)
         seq_layout.addLayout(step_row)
-        
+
         layout.addWidget(seq_grid)
-        
+
         # Sequence progress
         self._sequence_progress = QProgressBar()
         self._sequence_progress.setRange(0, 100)
         self._sequence_progress.setValue(0)
         self._sequence_progress.hide()
         layout.addWidget(self._sequence_progress)
-        
+
         # Sequence controls
         seq_buttons = QHBoxLayout()
-        
+
         self._start_sequence_btn = QPushButton("▶ Start Sequence")
         self._start_sequence_btn.clicked.connect(self._on_start_sequence)
         seq_buttons.addWidget(self._start_sequence_btn)
-        
+
         self._stop_sequence_btn = QPushButton("⏹ Stop")
         self._stop_sequence_btn.setProperty("secondary", True)
         self._stop_sequence_btn.clicked.connect(self._on_stop_sequence)
         self._stop_sequence_btn.hide()
         seq_buttons.addWidget(self._stop_sequence_btn)
-        
+
         layout.addLayout(seq_buttons)
-    
+
     def _on_slider_changed(self, value: int):
         """Handle slider change."""
         angle = value / 10.0
@@ -215,25 +223,25 @@ class TiltStagePanel(QFrame):
         self._angle_spin.blockSignals(True)
         self._angle_spin.setValue(angle)
         self._angle_spin.blockSignals(False)
-    
+
     def _on_spin_changed(self, value: float):
         """Handle spin box change."""
         self._angle_slider.blockSignals(True)
         self._angle_slider.setValue(int(value * 10))
         self._angle_slider.blockSignals(False)
-    
+
     def _on_go_clicked(self):
         """Handle go button click."""
         angle = self._angle_spin.value()
         self._current_angle = angle
         self._update_angle_display(angle)
         self.angle_changed.emit(angle)
-    
+
     def _update_angle_display(self, angle: float):
         """Update the angle display."""
         self._current_angle = angle
         self._angle_label.setText(f"{angle:.1f}°")
-    
+
     def _on_start_sequence(self):
         """Handle start sequence button."""
         self._is_sequence_running = True
@@ -241,26 +249,26 @@ class TiltStagePanel(QFrame):
         self._stop_sequence_btn.show()
         self._sequence_progress.show()
         self._sequence_progress.setValue(0)
-        
+
         start = self._start_spin.value()
         end = self._end_spin.value()
         step = self._step_spin.value()
-        
+
         self.sequence_started.emit(start, end, step)
-    
+
     def _on_stop_sequence(self):
         """Handle stop sequence button."""
         self._is_sequence_running = False
         self._start_sequence_btn.show()
         self._stop_sequence_btn.hide()
         self._sequence_progress.hide()
-        
+
         self.sequence_stopped.emit()
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_angle(self, angle: float):
         """Set the current angle."""
         self._current_angle = angle
@@ -271,17 +279,17 @@ class TiltStagePanel(QFrame):
         self._angle_spin.blockSignals(True)
         self._angle_spin.setValue(angle)
         self._angle_spin.blockSignals(False)
-    
+
     def get_angle(self) -> float:
         """Get the current angle."""
         return self._current_angle
-    
+
     def set_sequence_progress(self, progress: int):
         """Set the sequence progress (0-100)."""
         self._sequence_progress.setValue(progress)
         if progress >= 100:
             self._on_stop_sequence()
-    
+
     def is_sequence_running(self) -> bool:
         """Check if a sequence is currently running."""
         return self._is_sequence_running

--- a/src/menipy/gui/resources/menipy_icons_rc.py
+++ b/src/menipy/gui/resources/menipy_icons_rc.py
@@ -181,16 +181,14 @@ qt_resource_struct = b"\
 
 
 def qInitResources():
-    """Initialize qInitResources.
-    """
+    """Initialize qInitResources."""
     QtCore.qRegisterResourceData(
         0x03, qt_resource_struct, qt_resource_name, qt_resource_data
     )
 
 
 def qCleanupResources():
-    """qCleanupResources.
-    """
+    """qCleanupResources."""
     QtCore.qUnregisterResourceData(
         0x03, qt_resource_struct, qt_resource_name, qt_resource_data
     )

--- a/src/menipy/gui/services/camera_service.py
+++ b/src/menipy/gui/services/camera_service.py
@@ -133,8 +133,7 @@ class CameraController(QObject):
         self._stop_requested.emit()
 
     def shutdown(self) -> None:
-        """shutdown.
-        """
+        """shutdown."""
         self.stop()
         self._thread.quit()
         self._thread.wait(1000)

--- a/src/menipy/gui/services/pipeline_runner.py
+++ b/src/menipy/gui/services/pipeline_runner.py
@@ -62,17 +62,17 @@ class _Job(QRunnable):
 
             # patch acquisition - DISABLED to allow pipeline class method to run (and use logging)
             # if self.image:
-                #     p.do_acquisition = (lambda ctx: setattr(ctx, "frames", acq.from_file([self.image])) or ctx)  # type: ignore
+            #     p.do_acquisition = (lambda ctx: setattr(ctx, "frames", acq.from_file([self.image])) or ctx)  # type: ignore
             # else:
-                #     p.do_acquisition = (lambda ctx: setattr(ctx, "frames", acq.from_camera(device=self.camera or 0, n_frames=self.frames)) or ctx)  # type: ignore
+            #     p.do_acquisition = (lambda ctx: setattr(ctx, "frames", acq.from_camera(device=self.camera or 0, n_frames=self.frames)) or ctx)  # type: ignore
             run_kwargs = {
                 "roi": self.roi,
                 "needle_rect": self.needle_rect,
                 "contact_line": self.contact_line,
                 "preprocessing_markers": self.preprocessing_markers,
-                'calibration_params': self.calibration_params,
-                'scale': self.scale,
-                'physics': self.physics,
+                "calibration_params": self.calibration_params,
+                "scale": self.scale,
+                "physics": self.physics,
                 "image": self.image,
                 "camera": self.camera,
                 "frames": self.frames,

--- a/src/menipy/gui/services/settings_service.py
+++ b/src/menipy/gui/services/settings_service.py
@@ -67,8 +67,7 @@ class AppSettings:
             return cls(path=p)
 
     def save(self) -> None:
-        """Save.
-        """
+        """Save."""
         self.path.parent.mkdir(parents=True, exist_ok=True)
         tmp = asdict(self).copy()
         tmp.pop("path", None)

--- a/src/menipy/gui/theme.py
+++ b/src/menipy/gui/theme.py
@@ -8,43 +8,43 @@ for the ADSA application UI based on the design mockup.
 # =============================================================================
 # Background Colors
 # =============================================================================
-BG_PRIMARY = "#2B2B2B"      # Main window background
-BG_SECONDARY = "#353535"    # Panel backgrounds
-BG_TERTIARY = "#1A1A1A"     # Image viewer, darker areas
-BG_HOVER = "#404040"        # Hover state for interactive elements
+BG_PRIMARY = "#2B2B2B"  # Main window background
+BG_SECONDARY = "#353535"  # Panel backgrounds
+BG_TERTIARY = "#1A1A1A"  # Image viewer, darker areas
+BG_HOVER = "#404040"  # Hover state for interactive elements
 
 # =============================================================================
 # Accent Colors
 # =============================================================================
-ACCENT_BLUE = "#4A90E2"         # Primary actions, highlights, focus
-ACCENT_BLUE_HOVER = "#5BA3F5"   # Hover state for accent
-SUCCESS_GREEN = "#5CB85C"       # Calibrated, valid, success states
-WARNING_ORANGE = "#F0AD4E"      # Needs attention, warnings
-ERROR_RED = "#D9534F"           # Invalid, errors
+ACCENT_BLUE = "#4A90E2"  # Primary actions, highlights, focus
+ACCENT_BLUE_HOVER = "#5BA3F5"  # Hover state for accent
+SUCCESS_GREEN = "#5CB85C"  # Calibrated, valid, success states
+WARNING_ORANGE = "#F0AD4E"  # Needs attention, warnings
+ERROR_RED = "#D9534F"  # Invalid, errors
 
 # =============================================================================
 # Text Colors
 # =============================================================================
-TEXT_PRIMARY = "#E8E8E8"    # Main text
+TEXT_PRIMARY = "#E8E8E8"  # Main text
 TEXT_SECONDARY = "#A0A0A0"  # Labels, hints, disabled text
-TEXT_DISABLED = "#666666"   # Disabled state
+TEXT_DISABLED = "#666666"  # Disabled state
 
 # =============================================================================
 # Border Colors
 # =============================================================================
 BORDER_DEFAULT = "#4A4A4A"  # Default borders
-BORDER_FOCUS = "#4A90E2"    # Focused element borders
+BORDER_FOCUS = "#4A90E2"  # Focused element borders
 
 # =============================================================================
 # Overlay Colors (for image annotations)
 # =============================================================================
-OVERLAY_CONTOUR = "#FFFFFF"         # Drop contour - white
-OVERLAY_BASELINE = "#FF00FF"        # Detected baseline - magenta
-OVERLAY_CONTACT_POINT = "#FF0000"   # Contact points - red
-OVERLAY_ANGLE_LINE = "#00FFFF"      # Tangent lines - cyan
-OVERLAY_BOUNDING_BOX = "#FFFF00"    # Bounding box - yellow
-OVERLAY_ADVANCING = "#00FF00"       # Advancing angle (tilted) - green
-OVERLAY_RECEDING = "#FF8800"        # Receding angle (tilted) - orange
+OVERLAY_CONTOUR = "#FFFFFF"  # Drop contour - white
+OVERLAY_BASELINE = "#FF00FF"  # Detected baseline - magenta
+OVERLAY_CONTACT_POINT = "#FF0000"  # Contact points - red
+OVERLAY_ANGLE_LINE = "#00FFFF"  # Tangent lines - cyan
+OVERLAY_BOUNDING_BOX = "#FFFF00"  # Bounding box - yellow
+OVERLAY_ADVANCING = "#00FF00"  # Advancing angle (tilted) - green
+OVERLAY_RECEDING = "#FF8800"  # Receding angle (tilted) - orange
 
 # =============================================================================
 # Experiment Types
@@ -59,23 +59,23 @@ EXPERIMENT_DYNAMIC_CA = "dynamic_ca"
 # =============================================================================
 # Layout Constants
 # =============================================================================
-LEFT_PANEL_WIDTH = 300      # Setup panel width in pixels
-RIGHT_PANEL_WIDTH = 350     # Results panel width in pixels
-MIN_WINDOW_WIDTH = 1280     # Minimum window width
-MIN_WINDOW_HEIGHT = 720     # Minimum window height
-CARD_SPACING = 16           # Spacing between cards
-PANEL_MARGIN = 12           # Panel internal margins
+LEFT_PANEL_WIDTH = 300  # Setup panel width in pixels
+RIGHT_PANEL_WIDTH = 350  # Results panel width in pixels
+MIN_WINDOW_WIDTH = 1280  # Minimum window width
+MIN_WINDOW_HEIGHT = 720  # Minimum window height
+CARD_SPACING = 16  # Spacing between cards
+PANEL_MARGIN = 12  # Panel internal margins
 
 # =============================================================================
 # Animation Constants
 # =============================================================================
-TRANSITION_DURATION_MS = 200    # Default transition time
+TRANSITION_DURATION_MS = 200  # Default transition time
 NOTIFICATION_DISMISS_MS = 3000  # Auto-dismiss notification time
 
 # =============================================================================
 # Font Settings
 # =============================================================================
-FONT_FAMILY = "Segoe UI"    # Primary font (Windows)
+FONT_FAMILY = "Segoe UI"  # Primary font (Windows)
 FONT_SIZE_SMALL = 10
 FONT_SIZE_NORMAL = 12
 FONT_SIZE_LARGE = 14

--- a/src/menipy/gui/viewmodels/plugins_vm.py
+++ b/src/menipy/gui/viewmodels/plugins_vm.py
@@ -17,9 +17,9 @@ class PluginsViewModel(QObject):
 
     def refresh(self):
         """Placeholder docstring for refresh.
-    
+
         TODO: Complete docstring with full description.
-    
+
         Returns
         -------
         type
@@ -29,9 +29,9 @@ class PluginsViewModel(QObject):
 
     def discover(self, dirs):
         """Placeholder docstring for discover.
-    
+
         TODO: Complete docstring with full description.
-    
+
         Returns
         -------
         type
@@ -42,14 +42,14 @@ class PluginsViewModel(QObject):
 
     def toggle(self, name: str, kind: str, active: bool):
         """Placeholder docstring for toggle.
-    
+
         TODO: Complete docstring with full description.
-    
+
         Parameters
         ----------
         dirs : type
         Description of dirs.
-    
+
         Returns
         -------
         type
@@ -61,14 +61,14 @@ class PluginsViewModel(QObject):
 
     def rows(self):
         """Placeholder docstring for rows.
-    
+
         TODO: Complete docstring with full description.
-    
+
         Parameters
         ----------
         dirs : type
         Description of dirs.
-    
+
         Returns
         -------
         type

--- a/src/menipy/gui/viewmodels/run_vm.py
+++ b/src/menipy/gui/viewmodels/run_vm.py
@@ -67,7 +67,10 @@ class RunViewModel(QObject):
             self.error_occurred.emit(payload["err"] or "Unknown error")
             return
         ctx = payload["ctx"]
-        if getattr(ctx, "overlay_commands", None) or getattr(ctx, "image", None) is not None:
+        if (
+            getattr(ctx, "overlay_commands", None)
+            or getattr(ctx, "image", None) is not None
+        ):
             self.context_ready.emit(ctx)
         elif getattr(ctx, "preview", None) is not None:
             self.preview_ready.emit(to_pixmap(ctx.preview))

--- a/src/menipy/gui/views/__init__.py
+++ b/src/menipy/gui/views/__init__.py
@@ -3,6 +3,7 @@ GUI views package.
 
 Contains all view components for the ADSA application.
 """
+
 from menipy.gui.views.experiment_selector import ExperimentSelectorView
 from menipy.gui.views.base_experiment_window import BaseExperimentWindow
 from menipy.gui.views.adsa_main_window import ADSAMainWindow

--- a/src/menipy/gui/views/adsa_main_window.py
+++ b/src/menipy/gui/views/adsa_main_window.py
@@ -4,11 +4,18 @@ ADSA Main Window
 The primary application window for the ADSA (Automated Drop Shape Analysis) software.
 Uses a stacked widget to switch between the experiment selector and experiment-specific windows.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QAction, QKeySequence, QCloseEvent
 from PySide6.QtWidgets import (
-    QMainWindow, QStackedWidget, QMenuBar, QMenu, QStatusBar,
-    QMessageBox, QFileDialog, QWidget
+    QMainWindow,
+    QStackedWidget,
+    QMenuBar,
+    QMenu,
+    QStatusBar,
+    QMessageBox,
+    QFileDialog,
+    QWidget,
 )
 
 from menipy.gui import theme
@@ -20,193 +27,192 @@ import json
 class ADSAMainWindow(QMainWindow):
     """
     Main application window for ADSA.
-    
+
     Uses a QStackedWidget to switch between:
         - Experiment Selector screen (index 0)
     - Experiment-specific windows (indices 1+)
-    
+
     Signals:
         experiment_changed: Emitted when the user switches experiment types.
     """
-    
+
     experiment_changed = Signal(str)
-    
+
     # Stack indices
     INDEX_SELECTOR = 0
     INDEX_EXPERIMENT = 1
-    
+
     def __init__(self):
-        """Initialize.
-        """
+        """Initialize."""
         super().__init__()
         self.setWindowTitle("ADSA - Automated Drop Shape Analysis")
         self.setMinimumSize(theme.MIN_WINDOW_WIDTH, theme.MIN_WINDOW_HEIGHT)
-        
+
         # Apply theme
         self.setStyleSheet(theme.get_stylesheet())
-        
+
         # Track current experiment type and window
         self._current_experiment_type: str | None = None
         self._experiment_windows: dict[str, QWidget] = {}
         self._settings_store = QSettings("Menipy", "ADSA")
-        
+
         self._setup_ui()
         self._setup_menus()
         self._setup_status_bar()
-        
+
         # Connect signals
         self._connect_signals()
-        
+
         # Notification Manager
         from menipy.gui.widgets.notification import NotificationManager
+
         self._notification_manager = NotificationManager(self)
-        
+
         # Load recent projects (placeholder)
         self._load_recent_projects()
-        
-    
+
     def _setup_ui(self):
         """Set up the main UI structure."""
         # Central stacked widget
         self._stack = QStackedWidget()
         self.setCentralWidget(self._stack)
-        
+
         # Experiment selector (always at index 0)
         self._selector = ExperimentSelectorView()
         self._stack.addWidget(self._selector)
-        
+
         # Start showing the selector
         self._stack.setCurrentIndex(self.INDEX_SELECTOR)
-    
+
     def _setup_menus(self):
         """Set up the menu bar."""
         menubar = self.menuBar()
-        
+
         # === File Menu ===
         file_menu = menubar.addMenu("&File")
-        
+
         switch_action = QAction("🏠 Switch Experiment Type", self)
         switch_action.setShortcut(QKeySequence("Ctrl+E"))
         switch_action.triggered.connect(self.show_experiment_selector)
         file_menu.addAction(switch_action)
-        
+
         file_menu.addSeparator()
-        
+
         open_image_action = QAction("📂 Open Image...", self)
         open_image_action.setShortcut(QKeySequence.Open)
         open_image_action.triggered.connect(self._on_open_image)
         file_menu.addAction(open_image_action)
-        
+
         open_folder_action = QAction("📁 Open Folder...", self)
         open_folder_action.setShortcut(QKeySequence("Ctrl+Shift+O"))
         open_folder_action.triggered.connect(self._on_open_folder)
         file_menu.addAction(open_folder_action)
-        
+
         connect_camera_action = QAction("📷 Connect Camera...", self)
         connect_camera_action.triggered.connect(self._on_connect_camera)
         file_menu.addAction(connect_camera_action)
-        
+
         file_menu.addSeparator()
-        
+
         save_action = QAction("💾 Save Project", self)
         save_action.setShortcut(QKeySequence.Save)
         save_action.triggered.connect(self._on_save_project)
         file_menu.addAction(save_action)
-        
+
         save_as_action = QAction("💾 Save Project As...", self)
         save_as_action.setShortcut(QKeySequence("Ctrl+Shift+S"))
         save_as_action.triggered.connect(self._on_save_project_as)
         file_menu.addAction(save_as_action)
-        
+
         file_menu.addSeparator()
-        
+
         export_menu = file_menu.addMenu("📤 Export")
-        
+
         export_csv_action = QAction("Export CSV...", self)
         export_csv_action.triggered.connect(self._on_export_csv)
         export_menu.addAction(export_csv_action)
-        
+
         export_excel_action = QAction("Export Excel...", self)
         export_excel_action.triggered.connect(self._on_export_excel)
         export_menu.addAction(export_excel_action)
-        
+
         export_image_action = QAction("🖼️ Export Image...", self)
         export_image_action.triggered.connect(self._on_export_image)
         export_menu.addAction(export_image_action)
-        
+
         export_report_action = QAction("📄 Generate Report...", self)
         export_report_action.triggered.connect(self._on_generate_report)
         export_menu.addAction(export_report_action)
-        
+
         file_menu.addSeparator()
-        
+
         recent_menu = file_menu.addMenu("Recent Projects")
         self._recent_menu = recent_menu
-        
+
         file_menu.addSeparator()
-        
+
         exit_action = QAction("🚪 Exit", self)
         exit_action.setShortcut(QKeySequence("Alt+F4"))
         exit_action.triggered.connect(self.close)
         file_menu.addAction(exit_action)
-        
+
         # === Edit Menu ===
         edit_menu = menubar.addMenu("&Edit")
-        
+
         undo_action = QAction("Undo", self)
         undo_action.setShortcut(QKeySequence.Undo)
         undo_action.setEnabled(False)  # Placeholder
         edit_menu.addAction(undo_action)
-        
+
         redo_action = QAction("Redo", self)
         redo_action.setShortcut(QKeySequence.Redo)
         redo_action.setEnabled(False)  # Placeholder
         edit_menu.addAction(redo_action)
-        
+
         edit_menu.addSeparator()
-        
+
         preferences_action = QAction("⚙️ Preferences...", self)
         preferences_action.triggered.connect(self._on_preferences)
         edit_menu.addAction(preferences_action)
-        
+
         # === View Menu ===
         view_menu = menubar.addMenu("&View")
-        
+
         zoom_in_action = QAction("🔍+ Zoom In", self)
         zoom_in_action.setShortcut(QKeySequence.ZoomIn)
         zoom_in_action.triggered.connect(self._on_zoom_in)
         view_menu.addAction(zoom_in_action)
-        
+
         zoom_out_action = QAction("🔍- Zoom Out", self)
         zoom_out_action.setShortcut(QKeySequence.ZoomOut)
         zoom_out_action.triggered.connect(self._on_zoom_out)
         view_menu.addAction(zoom_out_action)
-        
+
         fit_action = QAction("↔️ Fit to Window", self)
         fit_action.setShortcut(QKeySequence("Ctrl+0"))
         fit_action.triggered.connect(self._on_fit_view)
         view_menu.addAction(fit_action)
-        
+
         actual_size_action = QAction("Actual Size", self)
         actual_size_action.setShortcut(QKeySequence("Ctrl+1"))
         actual_size_action.triggered.connect(self._on_actual_size)
         view_menu.addAction(actual_size_action)
-        
+
         view_menu.addSeparator()
-        
+
         fullscreen_action = QAction("Toggle Fullscreen", self)
         fullscreen_action.setShortcut(QKeySequence("F11"))
         fullscreen_action.triggered.connect(self._on_toggle_fullscreen)
         view_menu.addAction(fullscreen_action)
-        
+
         # === Tools Menu ===
         tools_menu = menubar.addMenu("&Tools")
-        
+
         calibrate_action = QAction("🎯 Calibrate...", self)
         calibrate_action.setShortcut(QKeySequence("Ctrl+K"))
         calibrate_action.triggered.connect(self._on_calibrate)
         tools_menu.addAction(calibrate_action)
-        
+
         material_db_action = QAction("📚 Material Database...", self)
         material_db_action.triggered.connect(self._on_material_database)
         tools_menu.addAction(material_db_action)
@@ -218,68 +224,68 @@ class ADSAMainWindow(QMainWindow):
         syringe_db_action = QAction("💊 Syringe Database...", self)
         syringe_db_action.triggered.connect(self._on_syringe_database)
         tools_menu.addAction(syringe_db_action)
-        
+
         tools_menu.addSeparator()
 
         plugins_action = QAction("🧩 Plugins...", self)
         plugins_action.triggered.connect(self._on_plugin_manager)
         tools_menu.addAction(plugins_action)
-        
+
         # === Analysis Menu ===
         analysis_menu = menubar.addMenu("&Analysis")
-        
+
         run_action = QAction("▶ Run Analysis", self)
         run_action.setShortcut(QKeySequence("Ctrl+R"))
         run_action.triggered.connect(self._on_run_analysis)
         analysis_menu.addAction(run_action)
-        
+
         pause_action = QAction("⏸️ Pause", self)
         pause_action.setShortcut(QKeySequence("Space"))
         pause_action.triggered.connect(self._on_pause_analysis)
         analysis_menu.addAction(pause_action)
-        
+
         stop_action = QAction("⏹️ Stop", self)
         stop_action.setShortcut(QKeySequence("Escape"))
         stop_action.triggered.connect(self._on_stop_analysis)
         analysis_menu.addAction(stop_action)
-        
+
         analysis_menu.addSeparator()
-        
+
         settings_action = QAction("⚙️ Analysis Settings...", self)
         settings_action.triggered.connect(self._on_analysis_settings)
         analysis_menu.addAction(settings_action)
-        
+
         analysis_menu.addSeparator()
-        
+
         batch_action = QAction("🔄 Batch Process Folder...", self)
         batch_action.triggered.connect(self._on_batch_process)
         analysis_menu.addAction(batch_action)
-        
+
         video_action = QAction("⏯️ Process Video...", self)
         video_action.triggered.connect(self._on_process_video)
         analysis_menu.addAction(video_action)
-        
+
         analysis_menu.addSeparator()
-        
+
         clear_action = QAction("🧹 Clear All Results", self)
         clear_action.setShortcut(QKeySequence("Ctrl+Shift+Delete"))
         clear_action.triggered.connect(self._on_clear_results)
         analysis_menu.addAction(clear_action)
-        
+
         # === Utilities Menu ===
         utilities_menu = menubar.addMenu("&Utilities")
-        
+
         utilities_action = QAction("🔧 Image Utilities...", self)
         utilities_action.setShortcut(QKeySequence("Ctrl+U"))
         utilities_action.triggered.connect(self._on_utilities)
         utilities_menu.addAction(utilities_action)
-        
+
         utilities_menu.addSeparator()
-        
+
         image_quality_action = QAction("📊 Image Quality Analysis", self)
         image_quality_action.triggered.connect(self._on_image_quality_analysis)
         utilities_menu.addAction(image_quality_action)
-        
+
         edge_comparison_action = QAction("🔍 Edge Detection Comparison", self)
         edge_comparison_action.triggered.connect(self._on_edge_comparison)
         utilities_menu.addAction(edge_comparison_action)
@@ -288,31 +294,30 @@ class ADSAMainWindow(QMainWindow):
         test_detectors_action.triggered.connect(self._on_test_detectors)
         utilities_menu.addAction(test_detectors_action)
 
-        
         # === Help Menu ===
         help_menu = menubar.addMenu("&Help")
-        
+
         help_action = QAction("📖 Help", self)
         help_action.setShortcut(QKeySequence.HelpContents)
         help_action.triggered.connect(self._on_help)
         help_menu.addAction(help_action)
-        
+
         help_menu.addSeparator()
-        
+
         about_action = QAction("About ADSA", self)
         about_action.triggered.connect(self._on_about)
         help_menu.addAction(about_action)
-    
+
     def _setup_status_bar(self):
         """Set up the status bar."""
         status = self.statusBar()
         status.showMessage("Ready")
-    
+
     def _connect_signals(self):
         """Connect internal signals."""
         self._selector.experiment_selected.connect(self._on_experiment_selected)
         self._selector.project_opened.connect(self._on_project_opened)
-    
+
     def _load_recent_projects(self):
         """Load and display recent projects from settings."""
         import datetime
@@ -337,11 +342,11 @@ class ADSAMainWindow(QMainWindow):
             projects = json.loads(raw)
         except Exception:
             projects = []
-        
+
         # Ensure it's a list
         if not isinstance(projects, list):
             projects = []
-            
+
         entry = {
             "filename": title,
             "experiment_type": experiment_type,
@@ -352,25 +357,27 @@ class ADSAMainWindow(QMainWindow):
         filtered = []
         for p in projects:
             same_path = (path is not None) and (p.get("path") == path)
-            same_name = (p.get("filename") == title) and (p.get("experiment_type") == experiment_type)
+            same_name = (p.get("filename") == title) and (
+                p.get("experiment_type") == experiment_type
+            )
             if not same_path and not same_name:
                 filtered.append(p)
-                
+
         projects = filtered
         projects.insert(0, entry)
         projects = projects[:10]
-        
+
         self._settings_store.setValue("recent_projects", json.dumps(projects))
         self._selector.set_recent_projects(projects)
         self._update_recent_menu()
-    
+
     def _update_recent_menu(self):
         """Populate the recent projects menu."""
         if not hasattr(self, "_recent_menu"):
             return
-            
+
         self._recent_menu.clear()
-        
+
         raw = self._settings_store.value("recent_projects")
         projects = []
         if raw:
@@ -378,44 +385,46 @@ class ADSAMainWindow(QMainWindow):
                 projects = json.loads(raw)
             except Exception:
                 projects = []
-                
+
         if not projects:
             dummy = QAction("(No recent projects)", self)
             dummy.setEnabled(False)
             self._recent_menu.addAction(dummy)
             return
-            
+
         for proj in projects:
             name = proj.get("filename", "Untitled")
             date = proj.get("date_str", "")
             path = proj.get("path", "")
-            
+
             label = f"{name} ({date})"
             action = QAction(label, self)
             if path:
                 action.setToolTip(path)
                 # Use default argument capture for lambda closure
-                action.triggered.connect(lambda checked=False, p=path: self._on_project_opened(p))
+                action.triggered.connect(
+                    lambda checked=False, p=path: self._on_project_opened(p)
+                )
             else:
-                action.setEnabled(False) # Disable seed items with no path
-                
+                action.setEnabled(False)  # Disable seed items with no path
+
             self._recent_menu.addAction(action)
-            
+
         self._recent_menu.addSeparator()
         clear_action = QAction("Clear Recent Projects", self)
         clear_action.triggered.connect(self._clear_recent_projects)
         self._recent_menu.addAction(clear_action)
-        
+
     def _clear_recent_projects(self):
         """Clear the recent projects list."""
         self._settings_store.setValue("recent_projects", "[]")
         self._selector.set_recent_projects([])
         self._update_recent_menu()
-        
+
     def _open_project_file(self, path: str):
         """
         Open a project file and restore state.
-        
+
         Args:
             path: Absolute path to .adsa.json file.
         """
@@ -425,22 +434,22 @@ class ADSAMainWindow(QMainWindow):
         if not os.path.exists(path):
             self.statusBar().showMessage(f"Project file not found: {path}", 4000)
             return
-            
+
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                
+
             exp_type = data.get("experiment_type")
             image_path = data.get("image_path")
             analysis_data = data.get("analysis_settings") or {}
-            
+
             if not exp_type:
                 raise ValueError("Missing experiment_type in project file")
-                
+
             # 1. Switch to experiment
             self.show_experiment_window(exp_type)
             window = self.get_current_experiment_window()
-            
+
             if window:
                 # 2. Load image
                 if image_path and os.path.exists(image_path):
@@ -448,40 +457,42 @@ class ADSAMainWindow(QMainWindow):
                         window.load_image(image_path)
                     elif hasattr(window, "_image_source_panel"):
                         window._image_source_panel.load_image(image_path)
-                
+
                 # 3. Apply settings
                 # If analysis_settings are in the project file, use them overrides stored defaults
                 if analysis_data:
                     pre = PreprocessingSettings(**analysis_data.get("preproc", {}))
                     edge = EdgeDetectionSettings(**analysis_data.get("edge", {}))
                     pipe = analysis_data.get("pipeline", {})
-                    
+
                     if hasattr(window, "apply_analysis_settings"):
                         window.apply_analysis_settings(pre, edge, pipe)
-            
+
             self.statusBar().showMessage(f"Opened project: {path}", 3000)
-            
+
             # Update recents list (move to top)
-            title = data.get("filename") or os.path.basename(path).replace(".adsa.json", "").replace(".json", "")
+            title = data.get("filename") or os.path.basename(path).replace(
+                ".adsa.json", ""
+            ).replace(".json", "")
             self._record_recent(exp_type, title, path)
-            
+
         except Exception as e:
             self.statusBar().showMessage(f"Error opening project: {str(e)}", 4000)
             print(f"Project open error: {e}")
-    
+
     # =========================================================================
     # Public Methods
     # =========================================================================
-    
+
     def show_experiment_selector(self):
         """Show the experiment selector screen."""
         self._stack.setCurrentIndex(self.INDEX_SELECTOR)
         self.setWindowTitle("ADSA - Automated Drop Shape Analysis")
-    
+
     def show_experiment_window(self, experiment_type: str):
         """
         Show the window for a specific experiment type.
-        
+
         Args:
             experiment_type: One of the EXPERIMENT_* constants from theme.
         """
@@ -491,24 +502,24 @@ class ADSAMainWindow(QMainWindow):
             if window:
                 self._experiment_windows[experiment_type] = window
                 self._stack.addWidget(window)
-        
+
         window = self._experiment_windows.get(experiment_type)
         if window:
             self._current_experiment_type = experiment_type
             index = self._stack.indexOf(window)
             self._stack.setCurrentIndex(index)
-            
+
             # Update window title
             title = self._get_experiment_title(experiment_type)
             self.setWindowTitle(f"ADSA - {title}")
-            
+
             self.experiment_changed.emit(experiment_type)
             self._record_recent(experiment_type, title, path=None)
-    
+
     def get_current_experiment_type(self) -> str | None:
         """Get the currently active experiment type."""
         return self._current_experiment_type
-    
+
     def get_current_experiment_window(self) -> QWidget | None:
         """Get the currently active experiment window."""
         if self._current_experiment_type:
@@ -556,45 +567,48 @@ class ADSAMainWindow(QMainWindow):
         }
         key = f"analysis/{experiment_type.lower()}"
         self._settings_store.setValue(key, json.dumps(payload))
-    
+
     # =========================================================================
     # Private Methods
     # =========================================================================
-    
+
     def _create_experiment_window(self, experiment_type: str) -> QWidget | None:
         """
         Create an experiment window for the given type.
-        
+
         Args:
             experiment_type: Experiment type constant.
-            
+
         Returns:
             The created experiment window, or None if type not supported.
         """
         window = None
-        
+
         # Import here to avoid circular imports
         if experiment_type == theme.EXPERIMENT_SESSILE:
             try:
                 from menipy.gui.views.sessile_drop_window import SessileDropWindow
+
                 window = SessileDropWindow()
             except ImportError as e:
                 print(f"Error importing SessileDropWindow: {e}")
-        
+
         elif experiment_type == theme.EXPERIMENT_PENDANT:
             try:
                 from menipy.gui.views.pendant_drop_window import PendantDropWindow
+
                 window = PendantDropWindow()
             except ImportError:
                 pass
-        
+
         elif experiment_type == theme.EXPERIMENT_TILTED_SESSILE:
             try:
                 from menipy.gui.views.tilted_sessile_window import TiltedSessileWindow
+
                 window = TiltedSessileWindow()
             except ImportError:
                 pass
-        
+
         if window:
             window.switch_experiment_requested.connect(self.show_experiment_selector)
             window.notification_requested.connect(self._on_notification_requested)
@@ -602,15 +616,15 @@ class ADSAMainWindow(QMainWindow):
             return window
         else:
             return self._create_placeholder_window(experiment_type)
-    
+
     def _create_placeholder_window(self, experiment_type: str) -> QWidget:
         """Create a placeholder window for not-yet-implemented experiment types."""
         from PySide6.QtWidgets import QLabel, QVBoxLayout, QPushButton
-        
+
         widget = QWidget()
         layout = QVBoxLayout(widget)
         layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
+
         title = self._get_experiment_title(experiment_type)
         label = QLabel(f"{title}\n\n(Coming Soon)")
         label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -619,153 +633,157 @@ class ADSAMainWindow(QMainWindow):
             color: {theme.TEXT_SECONDARY};
         """)
         layout.addWidget(label)
-        
+
         back_btn = QPushButton("🏠 Back to Experiment Selector")
         back_btn.clicked.connect(self.show_experiment_selector)
         layout.addWidget(back_btn, alignment=Qt.AlignmentFlag.AlignCenter)
-        
+
         return widget
-    
+
     def _get_experiment_title(self, experiment_type: str) -> str:
         """Get human-readable title for experiment type."""
         from menipy.gui.widgets.experiment_card import EXPERIMENT_DEFINITIONS
+
         for defn in EXPERIMENT_DEFINITIONS:
             if defn["type"] == experiment_type:
                 return defn["title"]
         return experiment_type.replace("_", " ").title()
-    
+
     # =========================================================================
     # Signal Handlers
     # =========================================================================
-    
+
     def _on_experiment_selected(self, experiment_type: str):
         """Handle experiment type selection."""
         self.show_experiment_window(experiment_type)
-    
+
     def _on_project_opened(self, path: str):
         """Handle project file opening."""
         if not path:
             # User clicked "Open Project..." button
             path, _ = QFileDialog.getOpenFileName(
-                self,
-                "Open ADSA Project",
-                "",
-                "ADSA Projects (*.adsa);;All Files (*)"
+                self, "Open ADSA Project", "", "ADSA Projects (*.adsa);;All Files (*)"
             )
-        
+
         if path:
             self._open_project_file(path)
-    
+
     # -------------------------------------------------------------------------
     # Menu Action Handlers (Placeholders)
     # -------------------------------------------------------------------------
-    
+
     def _on_open_image(self):
         path, _ = QFileDialog.getOpenFileName(
             self,
             "Open Image",
             "",
-            "Images (*.png *.jpg *.jpeg *.tiff *.bmp);;All Files (*)"
+            "Images (*.png *.jpg *.jpeg *.tiff *.bmp);;All Files (*)",
         )
         if path:
             self.statusBar().showMessage(f"Opened: {path}", 3000)
             # TODO: Pass to current experiment window
-    
+
     def _on_open_folder(self):
         path = QFileDialog.getExistingDirectory(self, "Open Folder")
         if path:
             self.statusBar().showMessage(f"Opened folder: {path}", 3000)
-    
+
     def _on_connect_camera(self):
         self.statusBar().showMessage("Camera connection not implemented yet", 3000)
-    
+
     def _on_save_project(self):
         self._save_project_dialog()
-    
+
     def _on_save_project_as(self):
         self._save_project_dialog()
-    
+
     def _on_export_csv(self):
         self.statusBar().showMessage("Export CSV not implemented yet", 3000)
-    
+
     def _on_export_excel(self):
         self.statusBar().showMessage("Export Excel not implemented yet", 3000)
-    
+
     def _on_export_image(self):
         self.statusBar().showMessage("Export Image not implemented yet", 3000)
-    
+
     def _on_generate_report(self):
         self.statusBar().showMessage("Report generation not implemented yet", 3000)
-    
+
     def _on_preferences(self):
         """Open settings dialog."""
         from menipy.gui.dialogs.settings_dialog import SettingsDialog
+
         dialog = SettingsDialog(self)
         if dialog.exec():
             # Apply settings (placeholder for now)
             settings = dialog.get_settings()
             self._notification_manager.show("Settings saved (Simulated)", "success")
-    
+
     def _on_zoom_in(self):
         window = self.get_current_experiment_window()
         if hasattr(window, "_on_zoom_in"):
             window._on_zoom_in()
-    
+
     def _on_zoom_out(self):
         """_on_zoom_out."""
         window = self.get_current_experiment_window()
         if hasattr(window, "_on_zoom_out"):
             window._on_zoom_out()
-    
+
     def _on_fit_view(self):
         """_on_fit_view."""
         window = self.get_current_experiment_window()
         if hasattr(window, "_on_fit_view"):
             window._on_fit_view()
-    
+
     def _on_actual_size(self):
         """_on_actual_size."""
         self.statusBar().showMessage("Actual size view", 1500)
-    
+
     def _on_toggle_fullscreen(self):
         """_on_toggle_fullscreen."""
         if self.isFullScreen():
             self.showNormal()
         else:
             self.showFullScreen()
-    
+
     def _on_notification_requested(self, message: str, type_: str):
         """Handle notification request from view."""
         self._notification_manager.show(message, type_)
 
     def _on_calibrate(self):
         """Open calibration wizard."""
-        # Forward to current window if it supports it, 
+        # Forward to current window if it supports it,
         # otherwise act global (not supported yet globally)
         window = self.get_current_experiment_window()
         if hasattr(window, "_on_calibration_requested"):
             window._on_calibration_requested()
         else:
-            self._notification_manager.show("Calibration wizard not supported in this view.", "warning")
-    
+            self._notification_manager.show(
+                "Calibration wizard not supported in this view.", "warning"
+            )
+
     def _on_material_database(self):
         """Open material database manager."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
+
         dialog = MaterialDialog(self, selection_mode=False)
         dialog.exec()
 
     def _on_needle_database(self):
         """Open needle database manager."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
+
         dialog = MaterialDialog(self, selection_mode=False, table_type="needles")
         dialog.exec()
 
     def _on_syringe_database(self):
         """Open syringe database manager."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
+
         dialog = MaterialDialog(self, selection_mode=False, table_type="syringes")
         dialog.exec()
-    
+
     def _on_plugin_manager(self):
         """Open plugin manager dialog."""
         from menipy.common.plugin_db import PluginDB
@@ -776,22 +794,22 @@ class ADSAMainWindow(QMainWindow):
         db = PluginDB()
         vm = PluginsViewModel(db)
         settings = AppSettings.load()
-        
+
         dlg = PluginManagerDialog(vm, settings, self)
         dlg.exec()
-    
+
     def _on_run_analysis(self):
         """_on_run_analysis."""
         self.statusBar().showMessage("Running analysis...", 1500)
-    
+
     def _on_pause_analysis(self):
         """_on_pause_analysis."""
         self.statusBar().showMessage("Analysis paused", 1500)
-    
+
     def _on_stop_analysis(self):
         """_on_stop_analysis."""
         self.statusBar().showMessage("Analysis stopped", 1500)
-    
+
     def _on_analysis_settings(self):
         """_on_analysis_settings."""
         from menipy.gui.dialogs.analysis_settings_dialog import AnalysisSettingsDialog
@@ -805,7 +823,9 @@ class ADSAMainWindow(QMainWindow):
 
         dlg = AnalysisSettingsDialog(
             pipeline_name,
-            preprocessing=getattr(window, "_preprocessing_settings", PreprocessingSettings()),
+            preprocessing=getattr(
+                window, "_preprocessing_settings", PreprocessingSettings()
+            ),
             edge=getattr(window, "_edge_settings", EdgeDetectionSettings()),
             pipeline_settings=getattr(window, "_pipeline_settings", {}),
             parent=self,
@@ -824,94 +844,108 @@ class ADSAMainWindow(QMainWindow):
                 window._pipeline_settings = pipe or {}
             self._save_analysis_settings(pipeline_name, pre, edge, pipe)
             self.statusBar().showMessage("Analysis settings saved", 2000)
-    
+
     def _on_batch_process(self):
         """_on_batch_process."""
         self.statusBar().showMessage("Batch processing not implemented yet", 3000)
-    
+
     def _on_process_video(self):
         """_on_process_video."""
         self.statusBar().showMessage("Video processing not implemented yet", 3000)
-    
+
     def _on_clear_results(self):
         """_on_clear_results."""
         reply = QMessageBox.question(
             self,
             "Clear All Results",
             "Are you sure you want to clear all results?",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
         if reply == QMessageBox.StandardButton.Yes:
             self.statusBar().showMessage("Results cleared", 1500)
-    
+
     # ------------------------------------------------------------------
     # Utilities
     # ------------------------------------------------------------------
     def _on_utilities(self):
         """Open the utilities dialog."""
         from menipy.gui.dialogs.utilities_dialog import UtilitiesDialog
-        
+
         # Get current image from experiment window if available
         image = None
         window = self.get_current_experiment_window()
         if window and hasattr(window, "_current_image_path"):
             import cv2
+
             path = window._current_image_path
             if path:
                 image = cv2.imread(path)
-        
+
         dialog = UtilitiesDialog(image=image, parent=self)
         dialog.exec()
-    
+
     def _on_image_quality_analysis(self):
         """Run image quality analysis on current image."""
         window = self.get_current_experiment_window()
-        if not window or not hasattr(window, "_current_image_path") or not window._current_image_path:
+        if (
+            not window
+            or not hasattr(window, "_current_image_path")
+            or not window._current_image_path
+        ):
             self._notification_manager.show("Load an image first", "warning")
             return
-        
+
         import cv2
         from menipy.common.registry import UTILITIES
-        
+
         image = cv2.imread(window._current_image_path)
         if image is None:
             self._notification_manager.show("Could not load image", "error")
             return
-        
+
         # Run image quality utility if registered
         if "image_quality" in UTILITIES:
             result = UTILITIES["image_quality"](image)
             msg = f"Quality: {result.get('overall_quality', 'N/A')}"
             self._notification_manager.show(msg, "success")
         else:
-            self._notification_manager.show("Image quality utility not registered", "warning")
-    
+            self._notification_manager.show(
+                "Image quality utility not registered", "warning"
+            )
+
     def _on_edge_comparison(self):
         """Open edge detection comparison tool."""
         window = self.get_current_experiment_window()
-        if not window or not hasattr(window, "_current_image_path") or not window._current_image_path:
+        if (
+            not window
+            or not hasattr(window, "_current_image_path")
+            or not window._current_image_path
+        ):
             self._notification_manager.show("Load an image first", "warning")
             return
-        
+
         import cv2
         from menipy.common.registry import UTILITIES
-        
+
         image = cv2.imread(window._current_image_path)
         if image is None:
             self._notification_manager.show("Could not load image", "error")
             return
-        
+
         # Run edge comparison utility if registered
         if "edge_comparison" in UTILITIES:
             result = UTILITIES["edge_comparison"](image)
             msg = f"Best method: {result.get('recommended_method', 'N/A')}"
             self._notification_manager.show(msg, "success")
         else:
-            self._notification_manager.show("Edge comparison utility not registered", "warning")
+            self._notification_manager.show(
+                "Edge comparison utility not registered", "warning"
+            )
 
     def _on_test_detectors(self):
         """Open detector test dialog."""
         from menipy.gui.dialogs.detector_test_dialog import DetectorTestDialog
+
         dlg = DetectorTestDialog(self)
         dlg.exec()
 
@@ -921,6 +955,7 @@ class ADSAMainWindow(QMainWindow):
     def _save_project_dialog(self):
         """Prompt for file path and save current project as JSON (.adsa.json)."""
         from pathlib import Path
+
         exp_type = self.get_current_experiment_type()
         if not exp_type:
             self.statusBar().showMessage("No experiment to save.", 2000)
@@ -967,6 +1002,7 @@ class ADSAMainWindow(QMainWindow):
             "analysis_settings": analysis,
         }
         Path(path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
     def _on_help(self):
         """_on_help."""
         from pathlib import Path
@@ -975,7 +1011,7 @@ class ADSAMainWindow(QMainWindow):
         docs_root = Path("docs")
         dlg = HelpDialog(self, docs_dir=docs_root)
         dlg.exec()
-    
+
     def _on_about(self):
         """_on_about."""
         QMessageBox.about(
@@ -984,9 +1020,9 @@ class ADSAMainWindow(QMainWindow):
             "<h2>ADSA</h2>"
             "<p>Automated Drop Shape Analysis</p>"
             "<p>Version 1.0.0</p>"
-            "<p>A comprehensive tool for surface tension and contact angle measurements.</p>"
+            "<p>A comprehensive tool for surface tension and contact angle measurements.</p>",
         )
-    
+
     def closeEvent(self, event: QCloseEvent):
         """Handle window close."""
         # TODO: Check for unsaved changes

--- a/src/menipy/gui/views/base_experiment_window.py
+++ b/src/menipy/gui/views/base_experiment_window.py
@@ -4,11 +4,18 @@ Base Experiment Window
 Abstract base class for experiment-specific analysis windows.
 Provides the three-panel layout template and common functionality.
 """
+
 from abc import abstractmethod
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QHBoxLayout, QVBoxLayout, QFrame, QSplitter,
-    QToolBar, QPushButton, QLabel
+    QWidget,
+    QHBoxLayout,
+    QVBoxLayout,
+    QFrame,
+    QSplitter,
+    QToolBar,
+    QPushButton,
+    QLabel,
 )
 from PySide6.QtGui import QAction
 
@@ -18,30 +25,30 @@ from menipy.gui import theme
 class BaseExperimentWindow(QWidget):
     """
     Abstract base class for experiment analysis windows.
-    
+
     Provides a consistent three-panel layout:
         - Left panel (300px): Setup and control
     - Center panel (flexible): Visualization
     - Right panel (350px): Results
-    
+
     Subclasses must implement:
         - _create_left_panel_content()
     - _create_center_panel_content()
     - _create_right_panel_content()
     - get_experiment_type()
-    
+
     Signals:
         switch_experiment_requested: User wants to switch to a different experiment type.
         analysis_started: Analysis has begun.
         analysis_completed: Analysis has finished.
         notification_requested: Request to show a notification.
     """
-    
+
     switch_experiment_requested = Signal()
     analysis_started = Signal()
     analysis_completed = Signal(dict)  # results dict
     notification_requested = Signal(str, str)  # message, type
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -53,17 +60,17 @@ class BaseExperimentWindow(QWidget):
         super().__init__(parent)
         self.setObjectName("experimentWindow")
         self._setup_ui()
-    
+
     def _setup_ui(self):
         """Set up the three-panel layout."""
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
-        
+
         # Toolbar
         self._toolbar = self._create_toolbar()
         main_layout.addWidget(self._toolbar)
-        
+
         # Main content area with splitter
         self._splitter = QSplitter(Qt.Orientation.Horizontal)
         self._splitter.setHandleWidth(2)
@@ -75,37 +82,39 @@ class BaseExperimentWindow(QWidget):
                 background-color: {theme.ACCENT_BLUE};
             }}
         """)
-        
+
         # Left panel
         self._left_panel = self._create_left_panel()
         self._splitter.addWidget(self._left_panel)
-        
+
         # Center panel
         self._center_panel = self._create_center_panel()
         self._splitter.addWidget(self._center_panel)
-        
+
         # Right panel
         self._right_panel = self._create_right_panel()
         self._splitter.addWidget(self._right_panel)
-        
+
         # Set initial sizes
-        self._splitter.setSizes([
-            theme.LEFT_PANEL_WIDTH,
-            800,  # Center panel - flexible
-            theme.RIGHT_PANEL_WIDTH
-        ])
-        
+        self._splitter.setSizes(
+            [
+                theme.LEFT_PANEL_WIDTH,
+                800,  # Center panel - flexible
+                theme.RIGHT_PANEL_WIDTH,
+            ]
+        )
+
         # Prevent left and right panels from being too small
         self._splitter.setStretchFactor(0, 0)  # Left - don't stretch
         self._splitter.setStretchFactor(1, 1)  # Center - stretch
         self._splitter.setStretchFactor(2, 0)  # Right - don't stretch
-        
+
         main_layout.addWidget(self._splitter, stretch=1)
-        
+
         # Status bar placeholder (actual status bar is in main window)
         self._status_frame = self._create_status_bar()
         main_layout.addWidget(self._status_frame)
-    
+
     def _create_toolbar(self) -> QToolBar:
         """Create the visualization toolbar."""
         toolbar = QToolBar()
@@ -132,49 +141,51 @@ class BaseExperimentWindow(QWidget):
                 background-color: {theme.ACCENT_BLUE};
             }}
         """)
-        
+
         # Zoom controls
         zoom_in_action = QAction("🔍+ Zoom In", self)
         zoom_in_action.setShortcut("Ctrl++")
         zoom_in_action.triggered.connect(self._on_zoom_in)
         toolbar.addAction(zoom_in_action)
-        
+
         zoom_out_action = QAction("🔍- Zoom Out", self)
         zoom_out_action.setShortcut("Ctrl+-")
         zoom_out_action.triggered.connect(self._on_zoom_out)
         toolbar.addAction(zoom_out_action)
-        
+
         fit_action = QAction("↔️ Fit", self)
         fit_action.setShortcut("Ctrl+0")
         fit_action.triggered.connect(self._on_fit_view)
         toolbar.addAction(fit_action)
-        
+
         reset_action = QAction("⟲ Reset View", self)
         reset_action.triggered.connect(self._on_reset_view)
         toolbar.addAction(reset_action)
-        
+
         toolbar.addSeparator()
-        
+
         # Add experiment-specific toolbar items (can be overridden)
         self._add_toolbar_items(toolbar)
-        
+
         # Spacer
         spacer = QWidget()
-        spacer.setSizePolicy(spacer.sizePolicy().horizontalPolicy(),
-                             spacer.sizePolicy().verticalPolicy())
+        spacer.setSizePolicy(
+            spacer.sizePolicy().horizontalPolicy(), spacer.sizePolicy().verticalPolicy()
+        )
         spacer.setMinimumWidth(1)
         from PySide6.QtWidgets import QSizePolicy
+
         spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         toolbar.addWidget(spacer)
-        
+
         # Switch experiment button
         switch_btn = QPushButton("🏠 Switch Experiment")
         switch_btn.setProperty("secondary", True)
         switch_btn.clicked.connect(self.switch_experiment_requested.emit)
         toolbar.addWidget(switch_btn)
-        
+
         return toolbar
-    
+
     def _create_left_panel(self) -> QFrame:
         """Create the left setup/control panel."""
         panel = QFrame()
@@ -185,12 +196,16 @@ class BaseExperimentWindow(QWidget):
                 border-right: 1px solid {theme.BORDER_DEFAULT};
             }}
         """)
-        
+
         layout = QVBoxLayout(panel)
-        layout.setContentsMargins(theme.PANEL_MARGIN, theme.PANEL_MARGIN,
-                                  theme.PANEL_MARGIN, theme.PANEL_MARGIN)
+        layout.setContentsMargins(
+            theme.PANEL_MARGIN,
+            theme.PANEL_MARGIN,
+            theme.PANEL_MARGIN,
+            theme.PANEL_MARGIN,
+        )
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel(f"{self.get_experiment_title()} Setup")
         header.setProperty("header", True)
@@ -201,14 +216,14 @@ class BaseExperimentWindow(QWidget):
             padding: 8px 0;
         """)
         layout.addWidget(header)
-        
+
         # Content (implemented by subclass)
         content = self._create_left_panel_content()
         if content:
             layout.addWidget(content, stretch=1)
-        
+
         return panel
-    
+
     def _create_center_panel(self) -> QFrame:
         """Create the center visualization panel."""
         panel = QFrame()
@@ -217,18 +232,18 @@ class BaseExperimentWindow(QWidget):
                 background-color: {theme.BG_TERTIARY};
             }}
         """)
-        
+
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        
+
         # Content (implemented by subclass)
         content = self._create_center_panel_content()
         if content:
             layout.addWidget(content, stretch=1)
-        
+
         return panel
-    
+
     def _create_right_panel(self) -> QFrame:
         """Create the right results panel."""
         panel = QFrame()
@@ -239,12 +254,16 @@ class BaseExperimentWindow(QWidget):
                 border-left: 1px solid {theme.BORDER_DEFAULT};
             }}
         """)
-        
+
         layout = QVBoxLayout(panel)
-        layout.setContentsMargins(theme.PANEL_MARGIN, theme.PANEL_MARGIN,
-                                  theme.PANEL_MARGIN, theme.PANEL_MARGIN)
+        layout.setContentsMargins(
+            theme.PANEL_MARGIN,
+            theme.PANEL_MARGIN,
+            theme.PANEL_MARGIN,
+            theme.PANEL_MARGIN,
+        )
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel("Results")
         header.setProperty("header", True)
@@ -255,14 +274,14 @@ class BaseExperimentWindow(QWidget):
             padding: 8px 0;
         """)
         layout.addWidget(header)
-        
+
         # Content (implemented by subclass)
         content = self._create_right_panel_content()
         if content:
             layout.addWidget(content, stretch=1)
-        
+
         return panel
-    
+
     def _create_status_bar(self) -> QFrame:
         """Create the status bar at the bottom."""
         status = QFrame()
@@ -277,153 +296,153 @@ class BaseExperimentWindow(QWidget):
                 padding: 0 8px;
             }}
         """)
-        
+
         layout = QHBoxLayout(status)
         layout.setContentsMargins(8, 0, 8, 0)
         layout.setSpacing(16)
-        
+
         self._status_label = QLabel("Ready")
         layout.addWidget(self._status_label)
-        
+
         layout.addStretch()
-        
+
         self._frame_label = QLabel("Frame: 1/1")
         layout.addWidget(self._frame_label)
-        
+
         self._memory_label = QLabel("Memory: -- MB")
         layout.addWidget(self._memory_label)
-        
+
         return status
-    
+
     # -------------------------------------------------------------------------
     # Abstract Methods - Must be implemented by subclasses
     # -------------------------------------------------------------------------
-    
+
     @abstractmethod
     def _create_left_panel_content(self) -> QWidget:
         """
         Create the content for the left panel.
-        
+
         Returns:
             Widget containing setup/control elements.
         """
         pass
-    
+
     @abstractmethod
     def _create_center_panel_content(self) -> QWidget:
         """
         Create the content for the center panel.
-        
+
         Returns:
             Widget containing visualization elements.
         """
         pass
-    
+
     @abstractmethod
     def _create_right_panel_content(self) -> QWidget:
         """
         Create the content for the right panel.
-        
+
         Returns:
             Widget containing results elements.
         """
         pass
-    
+
     @abstractmethod
     def get_experiment_type(self) -> str:
         """
         Get the experiment type constant.
-        
+
         Returns:
             One of the EXPERIMENT_* constants from theme.
         """
         pass
-    
+
     @abstractmethod
     def get_experiment_title(self) -> str:
         """
         Get the human-readable experiment title.
-        
+
         Returns:
             Title string for display.
         """
         pass
-        
+
     def load_image(self, path: str):
         """
         Load an image into the experiment window.
-        
+
         Args:
             path: Absolute path to the image file.
         """
         pass
-        
+
     def apply_analysis_settings(self, pre, edge, pipeline_settings=None):
         """
         Apply analysis settings to the window.
-        
+
         Args:
             pre: PreprocessingSettings
             edge: EdgeDetectionSettings
             pipeline_settings: Dict of pipeline settings
         """
         pass
-    
+
     # -------------------------------------------------------------------------
     # Virtual Methods - Can be overridden by subclasses
     # -------------------------------------------------------------------------
-    
+
     def _add_toolbar_items(self, toolbar: QToolBar):
         """
         Add experiment-specific toolbar items.
-        
+
         Override in subclasses to add custom toolbar buttons.
-        
+
         Args:
             toolbar: The toolbar to add items to.
         """
         pass
-    
+
     # -------------------------------------------------------------------------
     # Toolbar Actions
     # -------------------------------------------------------------------------
-    
+
     def _on_zoom_in(self):
         """Handle zoom in action."""
         # Override in subclass to implement actual zoom
         pass
-    
+
     def _on_zoom_out(self):
         """Handle zoom out action."""
         # Override in subclass to implement actual zoom
         pass
-    
+
     def _on_fit_view(self):
         """Handle fit to view action."""
         # Override in subclass to implement
         pass
-    
+
     def _on_reset_view(self):
         """Handle reset view action."""
         # Override in subclass to implement
         pass
-    
+
     # -------------------------------------------------------------------------
     # Status Updates
     # -------------------------------------------------------------------------
-    
+
     def set_status(self, message: str):
         """Update the status bar message."""
         self._status_label.setText(message)
-    
+
     def set_frame_info(self, current: int, total: int):
         """Update the frame counter."""
         self._frame_label.setText(f"Frame: {current}/{total}")
-    
+
     def set_memory_usage(self, mb: float):
         """Update the memory usage display."""
         self._memory_label.setText(f"Memory: {mb:.0f} MB")
-        
+
     def show_notification(self, message: str, type_: str = "info"):
         """Show a notification toast."""
         self.notification_requested.emit(message, type_)

--- a/src/menipy/gui/views/experiment_selector.py
+++ b/src/menipy/gui/views/experiment_selector.py
@@ -4,23 +4,34 @@ Experiment Selector View
 The initial screen where users select their experiment type.
 Displays experiment type cards and recent projects.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont, QKeyEvent
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QScrollArea, QGridLayout, QPushButton, QListWidget,
-    QListWidgetItem, QMenu
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QScrollArea,
+    QGridLayout,
+    QPushButton,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
 )
 
 from menipy.gui import theme
 from menipy.gui.widgets.experiment_card import (
-    ExperimentCard, EXPERIMENT_DEFINITIONS, create_experiment_card
+    ExperimentCard,
+    EXPERIMENT_DEFINITIONS,
+    create_experiment_card,
 )
 
 
 class RecentProjectItem(QListWidgetItem):
     """List item representing a recent project."""
-    
+
     def __init__(self, filename: str, experiment_type: str, date_str: str):
         """Initialize.
 
@@ -37,27 +48,27 @@ class RecentProjectItem(QListWidgetItem):
         self.filename = filename
         self.experiment_type = experiment_type
         self.date_str = date_str
-        
+
         # Get icon for experiment type
         icon = "💧"  # default
         for defn in EXPERIMENT_DEFINITIONS:
             if defn["type"] == experiment_type:
                 icon = defn["icon"]
                 break
-        
+
         self.setText(f"{icon}  {filename}    {date_str}")
 
 
 class RecentProjectsPanel(QFrame):
     """Panel displaying recent projects with quick access."""
-    
+
     project_selected = Signal(str)  # Emits file path
     open_dialog_requested = Signal()
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._setup_ui()
-    
+
     def _setup_ui(self):
         """Set up the recent projects panel UI."""
         self.setStyleSheet(f"""
@@ -68,29 +79,29 @@ class RecentProjectsPanel(QFrame):
                 padding: 12px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(12)
-        
+
         # Header row
         header_layout = QHBoxLayout()
-        
+
         header_label = QLabel("📂 Recent Projects")
         header_font = QFont(theme.FONT_FAMILY, theme.FONT_SIZE_LARGE)
         header_font.setBold(True)
         header_label.setFont(header_font)
         header_layout.addWidget(header_label)
-        
+
         header_layout.addStretch()
-        
+
         open_button = QPushButton("Open Project…")
         open_button.setProperty("secondary", True)
         open_button.clicked.connect(self.open_dialog_requested.emit)
         header_layout.addWidget(open_button)
-        
+
         layout.addLayout(header_layout)
-        
+
         # Projects list
         self.projects_list = QListWidget()
         self.projects_list.setStyleSheet(f"""
@@ -115,11 +126,11 @@ class RecentProjectsPanel(QFrame):
         self.projects_list.customContextMenuRequested.connect(self._show_context_menu)
         self.projects_list.itemDoubleClicked.connect(self._on_project_double_clicked)
         layout.addWidget(self.projects_list)
-    
+
     def set_recent_projects(self, projects: list[dict]):
         """
         Set the list of recent projects.
-        
+
         Args:
             projects: List of dicts with keys: filename, experiment_type, date_str, path
         """
@@ -128,23 +139,23 @@ class RecentProjectsPanel(QFrame):
             item = RecentProjectItem(
                 filename=proj.get("filename", "Unknown"),
                 experiment_type=proj.get("experiment_type", theme.EXPERIMENT_SESSILE),
-                date_str=proj.get("date_str", "")
+                date_str=proj.get("date_str", ""),
             )
             item.setData(Qt.ItemDataRole.UserRole, proj.get("path", ""))
             self.projects_list.addItem(item)
-    
+
     def _on_project_double_clicked(self, item: QListWidgetItem):
         """Handle double-click on a project."""
         path = item.data(Qt.ItemDataRole.UserRole)
         if path:
             self.project_selected.emit(path)
-    
+
     def _show_context_menu(self, position):
         """Show context menu for project item."""
         item = self.projects_list.itemAt(position)
         if not item:
             return
-        
+
         menu = QMenu(self)
         menu.setStyleSheet(f"""
             QMenu {{
@@ -159,14 +170,14 @@ class RecentProjectsPanel(QFrame):
                 background-color: {theme.ACCENT_BLUE};
             }}
         """)
-        
+
         open_action = menu.addAction("Open")
         menu.addSeparator()
         delete_action = menu.addAction("Remove from List")
         show_folder_action = menu.addAction("Show in Folder")
-        
+
         action = menu.exec_(self.projects_list.mapToGlobal(position))
-        
+
         if action == open_action:
             path = item.data(Qt.ItemDataRole.UserRole)
             if path:
@@ -182,18 +193,18 @@ class RecentProjectsPanel(QFrame):
 class ExperimentSelectorView(QWidget):
     """
     Main experiment selector screen.
-    
+
     Displays a grid of experiment type cards and recent projects.
     Users select their experiment type before proceeding to the main analysis window.
-    
+
     Signals:
         experiment_selected: Emitted when user selects an experiment type.
         project_opened: Emitted when user opens a recent project.
     """
-    
+
     experiment_selected = Signal(str)
     project_opened = Signal(str)
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("experimentSelector")
@@ -201,13 +212,13 @@ class ExperimentSelectorView(QWidget):
         self._current_focus_index = 0
         self._setup_ui()
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-    
+
     def _setup_ui(self):
         """Set up the experiment selector UI."""
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(40, 40, 40, 40)
         main_layout.setSpacing(24)
-        
+
         # Header
         header_label = QLabel("Select Your Experiment Type")
         header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -217,56 +228,56 @@ class ExperimentSelectorView(QWidget):
         header_label.setFont(header_font)
         header_label.setStyleSheet(f"color: {theme.TEXT_PRIMARY};")
         main_layout.addWidget(header_label)
-        
+
         # Scroll area for cards
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_area.setFrameShape(QFrame.Shape.NoFrame)
         scroll_area.setStyleSheet("background: transparent;")
-        
+
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
         scroll_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Cards grid
         cards_container = QWidget()
         cards_layout = QGridLayout(cards_container)
         cards_layout.setSpacing(theme.CARD_SPACING)
         cards_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
+
         # Create cards for each experiment type
         row = 0
         col = 0
         max_cols = 3
-        
+
         for defn in EXPERIMENT_DEFINITIONS:
             card = ExperimentCard(
                 experiment_type=defn["type"],
                 title=defn["title"],
                 description=defn["description"],
                 icon=defn["icon"],
-                parent=self
+                parent=self,
             )
             card.selected.connect(self._on_experiment_selected)
             cards_layout.addWidget(card, row, col)
             self._cards.append(card)
-            
+
             col += 1
             if col >= max_cols:
                 col = 0
                 row += 1
-        
+
         scroll_layout.addWidget(cards_container, alignment=Qt.AlignmentFlag.AlignCenter)
         scroll_area.setWidget(scroll_content)
         main_layout.addWidget(scroll_area, stretch=1)
-        
+
         # Separator
         separator = QFrame()
         separator.setFrameShape(QFrame.Shape.HLine)
         separator.setStyleSheet(f"background-color: {theme.BORDER_DEFAULT};")
         separator.setFixedHeight(1)
         main_layout.addWidget(separator)
-        
+
         # Recent projects panel
         self.recent_projects_panel = RecentProjectsPanel()
         self.recent_projects_panel.project_selected.connect(self._on_project_selected)
@@ -274,51 +285,55 @@ class ExperimentSelectorView(QWidget):
             lambda: self.project_opened.emit("")
         )
         main_layout.addWidget(self.recent_projects_panel)
-    
+
     def _on_experiment_selected(self, experiment_type: str):
         """Handle experiment type selection."""
         self.experiment_selected.emit(experiment_type)
-    
+
     def _on_project_selected(self, path: str):
         """Handle recent project selection."""
         self.project_opened.emit(path)
-    
+
     def set_recent_projects(self, projects: list[dict]):
         """
         Set the list of recent projects to display.
-        
+
         Args:
             projects: List of project dicts with filename, experiment_type, date_str, path
         """
         self.recent_projects_panel.set_recent_projects(projects)
-    
+
     def keyPressEvent(self, event: QKeyEvent):
         """Handle keyboard navigation."""
         key = event.key()
-        
+
         if key == Qt.Key.Key_Tab:
             # Navigate between cards
             if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
-                self._current_focus_index = (self._current_focus_index - 1) % len(self._cards)
+                self._current_focus_index = (self._current_focus_index - 1) % len(
+                    self._cards
+                )
             else:
-                self._current_focus_index = (self._current_focus_index + 1) % len(self._cards)
+                self._current_focus_index = (self._current_focus_index + 1) % len(
+                    self._cards
+                )
             self._cards[self._current_focus_index].setFocus()
             event.accept()
-        
+
         elif key == Qt.Key.Key_Return or key == Qt.Key.Key_Enter:
             # Select current card
             if 0 <= self._current_focus_index < len(self._cards):
                 card = self._cards[self._current_focus_index]
                 card.selected.emit(card.experiment_type)
             event.accept()
-        
+
         elif key == Qt.Key.Key_Escape:
             # Could emit close signal or show confirmation
             event.accept()
-        
+
         else:
             super().keyPressEvent(event)
-    
+
     def showEvent(self, event):
         """Handle show event - set initial focus."""
         super().showEvent(event)

--- a/src/menipy/gui/views/image_view.py
+++ b/src/menipy/gui/views/image_view.py
@@ -307,7 +307,7 @@ class ImageView(QGraphicsView):
         tag: str | None = None,
     ) -> None:
         """Add a rectangle overlay.
-        
+
         Args:
             rect: Rectangle in scene coordinates (can be QRectF or tuple of x,y,w,h)
             color: Outline color
@@ -324,7 +324,7 @@ class ImageView(QGraphicsView):
             return
         if "color" in marker_style:
             color = QColor(str(marker_style["color"]))
-        
+
         item = QGraphicsRectItem(rect)
         pen = QPen(color)
         pen.setWidthF(float(width))
@@ -410,7 +410,11 @@ class ImageView(QGraphicsView):
             return
         if marker_style:
             color = QColor(
-                str(marker_style.get("label_color", marker_style.get("color", color.name())))
+                str(
+                    marker_style.get(
+                        "label_color", marker_style.get("color", color.name())
+                    )
+                )
             )
         item = QGraphicsSimpleTextItem(str(text))
         item.setPos(point)
@@ -422,7 +426,9 @@ class ImageView(QGraphicsView):
             if marker_style.get("font_size"):
                 font.setPointSizeF(float(marker_style["font_size"]))
             item.setFont(font)
-            item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations, True)
+            item.setFlag(
+                QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations, True
+            )
         except Exception:
             pass
         try:
@@ -443,7 +449,11 @@ class ImageView(QGraphicsView):
     def _marker_style_for_tag(self, tag: str | None) -> dict[str, object]:
         config = self._marker_config or {}
         marker_type = self._marker_type_for_tag(tag)
-        style = dict(config.get("default", {})) if isinstance(config.get("default"), dict) else {}
+        style = (
+            dict(config.get("default", {}))
+            if isinstance(config.get("default"), dict)
+            else {}
+        )
         specific = config.get(marker_type)
         if isinstance(specific, dict):
             style.update(specific)
@@ -477,7 +487,9 @@ class ImageView(QGraphicsView):
             return
         item = QGraphicsSimpleTextItem(label)
         item.setPos(point + QPointF(6, -18))
-        item.setBrush(QColor(str(style.get("label_color", style.get("color", "white")))))
+        item.setBrush(
+            QColor(str(style.get("label_color", style.get("color", "white"))))
+        )
         try:
             font = item.font()
             if style.get("font_family"):
@@ -485,7 +497,9 @@ class ImageView(QGraphicsView):
             if style.get("font_size"):
                 font.setPointSizeF(float(style["font_size"]))
             item.setFont(font)
-            item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations, True)
+            item.setFlag(
+                QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations, True
+            )
         except Exception:
             pass
         item.setZValue(13_000)
@@ -579,6 +593,7 @@ class ImageView(QGraphicsView):
         self._mode = "fit"
 
         # --------------------- events & helpers ---------------------
+
     def wheelEvent(self, event):
         """wheel event."""
         # Require Ctrl only if configured

--- a/src/menipy/gui/views/pendant_drop_window.py
+++ b/src/menipy/gui/views/pendant_drop_window.py
@@ -3,12 +3,22 @@ Pendant Drop Window
 
 Specialized window for pendant drop surface tension measurements.
 """
+
 from PySide6.QtCore import Qt, Signal, QPoint
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QScrollArea, QTabWidget, QToolBar, QPushButton,
-    QTableWidget, QTableWidgetItem, QHeaderView
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QScrollArea,
+    QTabWidget,
+    QToolBar,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
 )
 from PySide6.QtGui import QAction
 
@@ -18,7 +28,7 @@ from menipy.gui.panels import (
     ImageSourcePanel,
     CalibrationPanel,
     ParametersPanel,
-    ActionPanel
+    ActionPanel,
 )
 from menipy.gui.dialogs.calibration_wizard_dialog import CalibrationWizardDialog
 from menipy.gui.widgets.pendant_results_widget import PendantResultsWidget
@@ -30,25 +40,25 @@ import numpy as np
 
 class PendantHistoryTableWidget(QWidget):
     """Table showing measurement history."""
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._count = 0
         self._setup_ui()
-    
+
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         self.table = QTableWidget()
         self.table.setColumnCount(6)
-        self.table.setHorizontalHeaderLabels([
-            "ID", "γ (mN/m)", "Vol (μL)", "Beta", "R0 (mm)", "Conf (%)"
-        ])
-        
+        self.table.setHorizontalHeaderLabels(
+            ["ID", "γ (mN/m)", "Vol (μL)", "Beta", "R0 (mm)", "Conf (%)"]
+        )
+
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
-        
+
         # Basic styling
         self.table.setStyleSheet(f"""
             QTableWidget {{
@@ -72,36 +82,36 @@ class PendantHistoryTableWidget(QWidget):
         """)
         self.table.verticalHeader().setVisible(False)
         self.table.setAlternatingRowColors(True)
-        
+
         layout.addWidget(self.table)
-        
+
     def add_result(self, results: dict):
         """Add a result row to the table."""
         self._count += 1
         row = self.table.rowCount()
         self.table.insertRow(row)
-        
+
         def item(text):
             it = QTableWidgetItem(text)
             it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             return it
-            
+
         def fmt(key, fstr="{:.1f}"):
             val = results.get(key)
             if val is None:
                 return "-"
             return fstr.format(val)
-            
+
         self.table.setItem(row, 0, item(str(self._count)))
         self.table.setItem(row, 1, item(fmt("surface_tension", "{:.2f}")))
         self.table.setItem(row, 2, item(fmt("volume", "{:.3f}")))
         self.table.setItem(row, 3, item(fmt("bond_number", "{:.3f}")))
-        self.table.setItem(row, 4, item(fmt("r0_mm", "{:.3f}"))) # Pipeline uses r0_mm
-        
+        self.table.setItem(row, 4, item(fmt("r0_mm", "{:.3f}")))  # Pipeline uses r0_mm
+
         # Confidence
         conf = results.get("confidence")
         self.table.setItem(row, 5, item(f"{conf:.0f}" if conf is not None else "-"))
-        
+
         self.table.scrollToBottom()
 
 
@@ -110,7 +120,7 @@ class PendantImageViewer(QWidget):
     Central image viewer for pendant drop with zoom and pan.
     Displays the loaded image with analysis overlays.
     """
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._base_pixmap: QPixmap | None = None
@@ -124,13 +134,13 @@ class PendantImageViewer(QWidget):
         self._overlay_alpha = 0.6
 
         self._zoom = 1.0
-        
+
         self._setup_ui()
-    
+
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Scroll area for zoom/pan
         self._scroll_area = QScrollArea()
         self._scroll_area.setWidgetResizable(True)
@@ -141,16 +151,18 @@ class PendantImageViewer(QWidget):
                 border: none;
             }}
         """)
-        
+
         # Image label
         self._image_label = QLabel()
         self._image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._image_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
-        self._image_label.setText("Load an image to begin analysis\n\n💧\n\nPendant drop should hang from\na needle visible in the image")
-        
+        self._image_label.setText(
+            "Load an image to begin analysis\n\n💧\n\nPendant drop should hang from\na needle visible in the image"
+        )
+
         self._scroll_area.setWidget(self._image_label)
         layout.addWidget(self._scroll_area)
-    
+
     def set_image(self, pixmap: QPixmap | None):
         """Set the base image (no overlay)."""
         self._base_pixmap = pixmap
@@ -161,8 +173,14 @@ class PendantImageViewer(QWidget):
         self._overlay_commands = commands or []
         self._repaint_with_overlays()
 
-    def set_overlay_visibility(self, *, overlay: bool | None = None, contour: bool | None = None,
-                                axis: bool | None = None, fit: bool | None = None):
+    def set_overlay_visibility(
+        self,
+        *,
+        overlay: bool | None = None,
+        contour: bool | None = None,
+        axis: bool | None = None,
+        fit: bool | None = None,
+    ):
         if overlay is not None:
             self._overlay_visible = overlay
         if contour is not None:
@@ -176,17 +194,17 @@ class PendantImageViewer(QWidget):
     def set_overlay_alpha(self, alpha: float):
         self._overlay_alpha = max(0.0, min(1.0, alpha))
         self._repaint_with_overlays()
-    
+
     def set_zoom(self, zoom: float):
         self._zoom = max(0.1, min(10.0, zoom))
         self._repaint_with_overlays()
-    
+
     def zoom_in(self):
         self.set_zoom(self._zoom * 1.25)
-    
+
     def zoom_out(self):
         self.set_zoom(self._zoom / 1.25)
-    
+
     def fit_to_view(self):
         if self._base_pixmap and not self._base_pixmap.isNull():
             vp_size = self._scroll_area.viewport().size()
@@ -195,7 +213,7 @@ class PendantImageViewer(QWidget):
             scale_y = vp_size.height() / img_size.height()
             self._zoom = min(scale_x, scale_y) * 0.95
             self._repaint_with_overlays()
-    
+
     def reset_view(self):
         self.set_zoom(1.0)
 
@@ -218,12 +236,13 @@ class PendantImageViewer(QWidget):
         target = composed.scaled(
             composed.size() * self._zoom,
             Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation
+            Qt.TransformationMode.SmoothTransformation,
         )
         self._image_label.setPixmap(target)
 
     def _color_from(self, c):
         from PySide6.QtGui import QColor
+
         if isinstance(c, str):
             return QColor(c)
         if isinstance(c, (tuple, list)) and len(c) == 3:
@@ -232,6 +251,7 @@ class PendantImageViewer(QWidget):
 
     def _draw_overlay(self, pix: QPixmap):
         from PySide6.QtGui import QPainter, QPen
+
         painter = QPainter(pix)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         painter.setOpacity(self._overlay_alpha)
@@ -249,7 +269,10 @@ class PendantImageViewer(QWidget):
             if typ == "line":
                 p1 = cmd.get("p1", (0, 0))
                 p2 = cmd.get("p2", (0, 0))
-                pen = QPen(self._color_from(cmd.get("color", "cyan")), int(cmd.get("thickness", 2)))
+                pen = QPen(
+                    self._color_from(cmd.get("color", "cyan")),
+                    int(cmd.get("thickness", 2)),
+                )
                 painter.setPen(pen)
                 painter.drawLine(int(p1[0]), int(p1[1]), int(p2[0]), int(p2[1]))
             elif typ == "polyline":
@@ -257,14 +280,21 @@ class PendantImageViewer(QWidget):
                 if not pts:
                     continue
                 from PySide6.QtGui import QPolygon
+
                 poly = QPolygon([QPoint(int(x), int(y)) for x, y in pts])
-                pen = QPen(self._color_from(cmd.get("color", "yellow")), int(cmd.get("thickness", 2)))
+                pen = QPen(
+                    self._color_from(cmd.get("color", "yellow")),
+                    int(cmd.get("thickness", 2)),
+                )
                 painter.setPen(pen)
                 painter.drawPolygon(poly)
             elif typ == "cross":
                 cx, cy = cmd.get("p", (0, 0))
                 size = int(cmd.get("size", 6))
-                pen = QPen(self._color_from(cmd.get("color", "red")), int(cmd.get("thickness", 2)))
+                pen = QPen(
+                    self._color_from(cmd.get("color", "red")),
+                    int(cmd.get("thickness", 2)),
+                )
                 painter.setPen(pen)
                 painter.drawLine(int(cx - size), int(cy), int(cx + size), int(cy))
                 painter.drawLine(int(cx), int(cy - size), int(cx), int(cy + size))
@@ -277,14 +307,19 @@ class PendantImageViewer(QWidget):
             elif typ == "circle":
                 c = cmd.get("center", (0, 0))
                 r = int(cmd.get("radius", 10))
-                pen = QPen(self._color_from(cmd.get("color", "magenta")), int(cmd.get("thickness", 2)))
+                pen = QPen(
+                    self._color_from(cmd.get("color", "magenta")),
+                    int(cmd.get("thickness", 2)),
+                )
                 painter.setPen(pen)
                 painter.drawEllipse(QPoint(int(c[0]), int(c[1])), r, r)
             elif typ == "scatter":
                 pts = cmd.get("points", [])
                 r = int(cmd.get("radius", 2))
                 th = int(cmd.get("thickness", -1))
-                pen = QPen(self._color_from(cmd.get("color", "white")), th if th > 0 else 1)
+                pen = QPen(
+                    self._color_from(cmd.get("color", "white")), th if th > 0 else 1
+                )
                 painter.setPen(pen)
                 for x, y in pts:
                     painter.drawEllipse(QPoint(int(x), int(y)), r, r)
@@ -293,15 +328,15 @@ class PendantImageViewer(QWidget):
 
 class PendantParametersPanel(QFrame):
     """Simplified parameters panel for pendant drop."""
-    
+
     parameters_changed = Signal(dict)
     material_db_requested = Signal(str)  # field name
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("pendantParametersPanel")
         self._setup_ui()
-    
+
     def _setup_ui(self):
         self.setStyleSheet(f"""
             QFrame#pendantParametersPanel {{
@@ -310,11 +345,11 @@ class PendantParametersPanel(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(10)
-        
+
         header = QLabel("Physical Properties")
         header.setStyleSheet(f"""
             font-size: {theme.FONT_SIZE_LARGE}px;
@@ -322,74 +357,75 @@ class PendantParametersPanel(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Liquid density
         from PySide6.QtWidgets import QDoubleSpinBox
-        
+
         # Helper for input rows with DB button
         def add_density_input(label_text, field_name, default):
             container = QWidget()
             h_layout = QVBoxLayout(container)
             h_layout.setContentsMargins(0, 0, 0, 0)
             h_layout.setSpacing(4)
-            
+
             label = QLabel(label_text)
             label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
             h_layout.addWidget(label)
-            
+
             row = QHBoxLayout()
             row.setSpacing(8)
-            
+
             spin = QDoubleSpinBox()
             spin.setRange(0, 50000)
             spin.setValue(default)
             spin.setDecimals(1)
             row.addWidget(spin, stretch=1)
-            
+
             setattr(self, f"_{field_name}", spin)
-            
+
             db_btn = QPushButton("📚")
             db_btn.setProperty("secondary", True)
             db_btn.setFixedSize(32, 24)
             db_btn.setToolTip("Select from Material Database")
             db_btn.clicked.connect(lambda: self.material_db_requested.emit(field_name))
             row.addWidget(db_btn)
-            
+
             h_layout.addLayout(row)
             layout.addWidget(container)
 
         add_density_input("Liquid Density (kg/m³)", "liquid_density", 1000.0)
         add_density_input("Surrounding Density (kg/m³)", "surrounding_density", 1.2)
-        
+
         # Gravity
         g_label = QLabel("Gravitational Acceleration (m/s²)")
         g_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(g_label)
-        
+
         self._gravity = QDoubleSpinBox()
         self._gravity.setRange(0, 20)
         self._gravity.setValue(9.81)
         self._gravity.setDecimals(4)
         layout.addWidget(self._gravity)
-        
+
         layout.addStretch()
-    
+
     def get_parameters(self) -> dict:
         return {
             "liquid_density": self._liquid_density.value(),
             "surrounding_density": self._surrounding_density.value(),
             "gravity": self._gravity.value(),
         }
-        
+
     def set_density(self, field_name: str, value: float):
         """Set density value from database selection."""
         spin = getattr(self, f"_{field_name}", None)
         if spin:
             spin.setValue(value)
 
+
 class PendantDropWindow(BaseExperimentWindow):
     """Window for pendant drop surface tension analysis."""
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._current_image = None
@@ -402,7 +438,7 @@ class PendantDropWindow(BaseExperimentWindow):
     def load_image(self, path: str):
         """Load image via source panel."""
         self._image_source_panel.load_image(path)
-        
+
     def apply_analysis_settings(
         self,
         pre: PreprocessingSettings,
@@ -425,79 +461,81 @@ class PendantDropWindow(BaseExperimentWindow):
         self._pipeline_settings = pipeline_settings or {}
         # Apply visibility settings if present
         if "overlay_visible" in self._pipeline_settings:
-            self._image_viewer.set_overlay_visibility(overlay=self._pipeline_settings["overlay_visible"])
-    
+            self._image_viewer.set_overlay_visibility(
+                overlay=self._pipeline_settings["overlay_visible"]
+            )
+
     def get_experiment_type(self) -> str:
         """Get_experiment_type."""
         return theme.EXPERIMENT_PENDANT
-    
+
     def get_experiment_title(self) -> str:
         """Get_experiment_title."""
         return "Pendant Drop"
-    
+
     def _create_left_panel_content(self) -> QWidget:
         """Create the left panel content with setup controls."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         scroll.setStyleSheet("background: transparent;")
-        
+
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
         scroll_layout.setContentsMargins(0, 0, 0, 0)
         scroll_layout.setSpacing(12)
-        
+
         # Image Source panel
         self._image_source_panel = ImageSourcePanel()
         scroll_layout.addWidget(self._image_source_panel)
-        
+
         # Calibration panel
         self._calibration_panel = CalibrationPanel()
         scroll_layout.addWidget(self._calibration_panel)
-        
+
         # Parameters panel
         self._parameters_panel = PendantParametersPanel()
         scroll_layout.addWidget(self._parameters_panel)
-        
+
         # Action panel
         self._action_panel = ActionPanel()
         self._action_panel.set_button_text("▶ Analyze Drop Shape")
         scroll_layout.addWidget(self._action_panel)
-        
+
         scroll_layout.addStretch()
         scroll.setWidget(scroll_content)
         layout.addWidget(scroll)
-        
+
         return content
-    
+
     def _create_center_panel_content(self) -> QWidget:
         """Create the center panel content with image viewer."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        
+
         self._image_viewer = PendantImageViewer()
         layout.addWidget(self._image_viewer)
-        
+
         return content
-    
+
     def _create_right_panel_content(self) -> QWidget:
         """Create the right panel content with results."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         # Pendant results widget
         self._results_widget = PendantResultsWidget()
         layout.addWidget(self._results_widget)
-        
+
         # Tabs for profile and history
         tabs = QTabWidget()
         tabs.setStyleSheet(f"""
@@ -517,22 +555,24 @@ class PendantDropWindow(BaseExperimentWindow):
                 color: {theme.TEXT_PRIMARY};
             }}
         """)
-        
+
         # Profile tab
         profile_placeholder = QWidget()
         profile_layout = QVBoxLayout(profile_placeholder)
-        profile_label = QLabel("📈 Drop profile comparison\nwill appear here after analysis")
+        profile_label = QLabel(
+            "📈 Drop profile comparison\nwill appear here after analysis"
+        )
         profile_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         profile_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         profile_layout.addWidget(profile_label)
         tabs.addTab(profile_placeholder, "Profile")
-        
+
         # History tab
         self._history_widget = PendantHistoryTableWidget()
         tabs.addTab(self._history_widget, "History")
-        
+
         layout.addWidget(tabs, stretch=1)
-        
+
         # Export buttons
         export_frame = QFrame()
         export_frame.setStyleSheet(f"""
@@ -545,19 +585,19 @@ class PendantDropWindow(BaseExperimentWindow):
         export_layout = QHBoxLayout(export_frame)
         export_layout.setContentsMargins(8, 8, 8, 8)
         export_layout.setSpacing(8)
-        
+
         csv_btn = QPushButton("📊 Export CSV")
         csv_btn.setProperty("secondary", True)
         export_layout.addWidget(csv_btn)
-        
+
         report_btn = QPushButton("📄 Report")
         report_btn.setProperty("secondary", True)
         export_layout.addWidget(report_btn)
-        
+
         layout.addWidget(export_frame)
-        
+
         return content
-    
+
     def _add_toolbar_items(self, toolbar: QToolBar):
         """Add pendant-drop specific toolbar items."""
         # Overlay toggle
@@ -566,39 +606,43 @@ class PendantDropWindow(BaseExperimentWindow):
         self._overlay_action.setChecked(True)
         self._overlay_action.toggled.connect(self._on_overlay_toggled)
         toolbar.addAction(self._overlay_action)
-        
+
         # Needle detection
         self._needle_action = QAction("📍 Needle", self)
         self._needle_action.setCheckable(True)
         self._needle_action.setChecked(True)
         self._needle_action.toggled.connect(self._on_needle_toggled)
         toolbar.addAction(self._needle_action)
-        
+
         # Drop contour
         self._contour_action = QAction("〰️ Contour", self)
         self._contour_action.setCheckable(True)
         self._contour_action.setChecked(True)
         self._contour_action.toggled.connect(self._on_contour_toggled)
         toolbar.addAction(self._contour_action)
-        
+
         # Fitted profile
         self._fit_action = QAction("📐 Fitted Profile", self)
         self._fit_action.setCheckable(True)
         self._fit_action.setChecked(True)
         self._fit_action.toggled.connect(self._on_fit_toggled)
         toolbar.addAction(self._fit_action)
-    
+
     def _connect_signals(self):
         """Connect internal signals."""
         self._image_source_panel.image_loaded.connect(self._on_image_loaded)
         self._action_panel.analyze_requested.connect(self._on_analyze_requested)
         self._action_panel.cancel_requested.connect(self._on_cancel_requested)
-        
+
         # Calibration signals
-        self._calibration_panel.calibration_requested.connect(self._on_calibration_requested)
-        
-        self._parameters_panel.material_db_requested.connect(self._on_material_db_requested)
-    
+        self._calibration_panel.calibration_requested.connect(
+            self._on_calibration_requested
+        )
+
+        self._parameters_panel.material_db_requested.connect(
+            self._on_material_db_requested
+        )
+
     def _on_image_loaded(self, path: str, pixmap: QPixmap | None):
         """Handle image loaded."""
         self._current_path = path or None
@@ -613,16 +657,13 @@ class PendantDropWindow(BaseExperimentWindow):
             self._image_viewer.set_overlay_commands([])
             self._image_viewer.fit_to_view()
             self.set_status(f"Loaded: {path}")
-    
 
-    
-    
     def _on_calibration_requested(self):
         """Handle calibration request."""
         if self._current_image is None:
             self.set_status("Please load an image first")
             return
-            
+
         wizard = CalibrationWizardDialog(self._current_image, "pendant", self)
         if wizard.exec():
             result = wizard.get_result()
@@ -631,43 +672,51 @@ class PendantDropWindow(BaseExperimentWindow):
     def _on_calibration_result(self, result):
         """Handle calibration result."""
         self._last_calibration_result = result
-        
+
         # Calculate scale
         px_per_mm = 1.0
         needle_width_px = 0
-        
+
         # Try to get needle width from result
         if result.needle_rect:
-             _, _, w, _ = result.needle_rect
-             needle_width_px = w
-             
+            _, _, w, _ = result.needle_rect
+            needle_width_px = w
+
         # Ask user for needle diameter if we have pixel width
         if needle_width_px > 0:
             from PySide6.QtWidgets import QInputDialog
+
             diameter, ok = QInputDialog.getDouble(
-                self, "Needle Diameter", 
-                "Enter needle outer diameter (mm):", 
-                0.71, 0.01, 100.0, 3
+                self,
+                "Needle Diameter",
+                "Enter needle outer diameter (mm):",
+                0.71,
+                0.01,
+                100.0,
+                3,
             )
             known_diameter_mm = diameter if ok else 0.71
         else:
-             known_diameter_mm = 0.71
+            known_diameter_mm = 0.71
 
         if needle_width_px > 0 and known_diameter_mm > 0:
             px_per_mm = needle_width_px / known_diameter_mm
-            self.set_status(f"Calibrated: {px_per_mm:.1f} px/mm (Needle: {needle_width_px}px, {known_diameter_mm}mm)")
+            self.set_status(
+                f"Calibrated: {px_per_mm:.1f} px/mm (Needle: {needle_width_px}px, {known_diameter_mm}mm)"
+            )
         else:
             self.set_status("Calibration incomplete: Need needle width and diameter")
 
         # Update panel
         # Use set_calibration instead of set_scale (which doesn't exist)
         import datetime
+
         date_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
         self._calibration_panel.set_calibration(px_per_mm, "Auto-Calibration", date_str)
-        
+
         # Store diameter for analysis
         self._last_known_diameter = known_diameter_mm
-        
+
     def _run_analysis(self):
         """Run the actual pendant drop analysis."""
         if self._current_image is None:
@@ -697,8 +746,12 @@ class PendantDropWindow(BaseExperimentWindow):
             # Physics params
             params = self._parameters_panel.get_parameters()
             pipeline_kwargs["physics"] = {
-                "rho1": self._pipeline_settings.get("rho1", params.get("liquid_density", 1000.0)),
-                "rho2": self._pipeline_settings.get("rho2", params.get("surrounding_density", 1.2)),
+                "rho1": self._pipeline_settings.get(
+                    "rho1", params.get("liquid_density", 1000.0)
+                ),
+                "rho2": self._pipeline_settings.get(
+                    "rho2", params.get("surrounding_density", 1.2)
+                ),
                 "g": self._pipeline_settings.get("g", params.get("gravity", 9.81)),
             }
 
@@ -715,14 +768,14 @@ class PendantDropWindow(BaseExperimentWindow):
                 pipeline.edge_detector_name = self._pipeline_settings["edge_detector"]
             # In a real app, run in background thread. For now, run directly.
             ctx = pipeline.run(**pipeline_kwargs)
-            
+
             # 3. Process Results
             results = ctx.results or {}
-            
+
             # Map pipeline results to UI keys
             # Pipeline: surface_tension_mN_m, beta, r0_mm, volume_uL, height_mm, diameter_mm
             # Widget: surface_tension, bond_number, apex_radius, volume, de, ds...
-            
+
             ui_results = {
                 "surface_tension": results.get("surface_tension_mN_m"),
                 "bond_number": results.get("beta"),
@@ -730,7 +783,8 @@ class PendantDropWindow(BaseExperimentWindow):
                 "volume": results.get("volume_uL"),
                 "de": results.get("diameter_mm"),  # Approx DE = 2*R0 for sphere
                 "ds": results.get("diameter_mm"),  # Placeholder
-                "density_diff": params.get("liquid_density", 0) - params.get("surrounding_density", 0),
+                "density_diff": params.get("liquid_density", 0)
+                - params.get("surrounding_density", 0),
                 "rmse": results.get("residuals", {}).get("optimality", 0.0),
                 "iterations": results.get("residuals", {}).get("nfev")
                 or results.get("residuals", {}).get("nit")
@@ -741,10 +795,10 @@ class PendantDropWindow(BaseExperimentWindow):
             if results.get("diameter_mm"):
                 d = results["diameter_mm"]
                 ui_results["surface_area"] = 4 * 3.14159 * (d / 2) ** 2
-            
+
             # Do not drop keys; widget handles None/invalid gracefully
             self._results_widget.set_results(ui_results)
-            
+
             # Align history row keys with widget expectations
             history_row = dict(results)
             history_row["surface_tension"] = results.get("surface_tension_mN_m")
@@ -754,80 +808,86 @@ class PendantDropWindow(BaseExperimentWindow):
 
             self._action_panel.set_state(ActionPanel.STATE_COMPLETE)
             self.set_status("Analysis complete")
-            
+
             # Update image viewer with overlay if available (ctx.preview)
             base_img = getattr(ctx, "image", None)
             if base_img is not None:
                 import cv2
                 from PySide6.QtGui import QImage
+
                 rgb = cv2.cvtColor(base_img, cv2.COLOR_BGR2RGB)
                 h, w, ch = rgb.shape
                 bytes_per_line = ch * w
-                qimg = QImage(rgb.data, w, h, bytes_per_line, QImage.Format_RGB888).copy()
+                qimg = QImage(
+                    rgb.data, w, h, bytes_per_line, QImage.Format_RGB888
+                ).copy()
                 self._image_viewer.set_image(QPixmap.fromImage(qimg))
                 # Pass overlay drawing commands to Qt painter layer
-                self._image_viewer.set_overlay_commands(getattr(ctx, "overlay_commands", None))
-            
+                self._image_viewer.set_overlay_commands(
+                    getattr(ctx, "overlay_commands", None)
+                )
+
             self.analysis_completed.emit(results)
-            
+
         except Exception as e:
             self.set_status(f"Analysis failed: {e}")
             self._action_panel.set_state(ActionPanel.STATE_READY)
             import traceback
+
             traceback.print_exc()
 
     def _on_analyze_requested(self):
         """Handle analyze button click."""
         self._action_panel.set_state(ActionPanel.STATE_PROCESSING)
         self.set_status("Analyzing pendant drop...")
-        
+
         # Use QTimer to allow UI update before blocking
         from PySide6.QtCore import QTimer
+
         QTimer.singleShot(100, self._run_analysis)
 
     def _on_cancel_requested(self):
         """Handle cancel button click."""
         self._action_panel.set_state(ActionPanel.STATE_READY)
         self.set_status("Analysis cancelled")
-        
+
     def _on_material_db_requested(self, field_name: str):
         """Handle material database request."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
+
         dialog = MaterialDialog(self, selection_mode=True, table_type="materials")
         dialog.item_selected.connect(
             lambda data: self._on_material_selected(data, field_name)
         )
         dialog.exec()
-        
+
     def _on_material_selected(self, data: dict, field_name: str):
         """Handle material selection."""
         if density := data.get("density"):
             self._parameters_panel.set_density(field_name, density)
             self.set_status(f"Selected material: {data['name']} ({density} kg/m³)")
-            
+
     def _on_needle_db_requested(self):
         """_on_needle_db_requested."""
         # CalibrationPanel might not emit this, but if we add it later:
         pass
 
-
-    
     # -------------------------------------------------------------------------
     # Toolbar Actions
     # -------------------------------------------------------------------------
-    
+
     def _on_zoom_in(self):
         """_on_zoom_in."""
         self._image_viewer.zoom_in()
-    
+
     def _on_zoom_out(self):
         """_on_zoom_out."""
         self._image_viewer.zoom_out()
-    
+
     def _on_fit_view(self):
         """_on_fit_view."""
         self._image_viewer.fit_to_view()
-    
+
     def _on_reset_view(self):
         """_on_reset_view."""
         self._image_viewer.reset_view()
@@ -847,22 +907,35 @@ class PendantDropWindow(BaseExperimentWindow):
         if pipeline_settings:
             # Update parameter panel with physics defaults
             if "rho1" in pipeline_settings:
-                self._parameters_panel.set_density("liquid_density", pipeline_settings["rho1"])
+                self._parameters_panel.set_density(
+                    "liquid_density", pipeline_settings["rho1"]
+                )
             if "rho2" in pipeline_settings:
-                self._parameters_panel.set_density("surrounding_density", pipeline_settings["rho2"])
+                self._parameters_panel.set_density(
+                    "surrounding_density", pipeline_settings["rho2"]
+                )
             if "g" in pipeline_settings and hasattr(self._parameters_panel, "_gravity"):
                 self._parameters_panel._gravity.setValue(pipeline_settings["g"])
             # Overlay prefs
             if "overlay_visible" in pipeline_settings:
-                self._image_viewer.set_overlay_visibility(overlay=pipeline_settings["overlay_visible"])
+                self._image_viewer.set_overlay_visibility(
+                    overlay=pipeline_settings["overlay_visible"]
+                )
             if "contour_visible" in pipeline_settings:
-                self._image_viewer.set_overlay_visibility(contour=pipeline_settings["contour_visible"])
+                self._image_viewer.set_overlay_visibility(
+                    contour=pipeline_settings["contour_visible"]
+                )
             if "axis_visible" in pipeline_settings:
-                self._image_viewer.set_overlay_visibility(axis=pipeline_settings["axis_visible"])
+                self._image_viewer.set_overlay_visibility(
+                    axis=pipeline_settings["axis_visible"]
+                )
             if "fit_visible" in pipeline_settings:
-                self._image_viewer.set_overlay_visibility(fit=pipeline_settings["fit_visible"])
+                self._image_viewer.set_overlay_visibility(
+                    fit=pipeline_settings["fit_visible"]
+                )
             if "overlay_alpha" in pipeline_settings:
                 self._image_viewer.set_overlay_alpha(pipeline_settings["overlay_alpha"])
+
     def _on_overlay_toggled(self, checked: bool):
         self._image_viewer.set_overlay_visibility(overlay=checked)
 

--- a/src/menipy/gui/views/sessile_drop_window.py
+++ b/src/menipy/gui/views/sessile_drop_window.py
@@ -4,12 +4,23 @@ Sessile Drop Window
 Specialized window for sessile drop contact angle measurements.
 Provides the full three-panel layout with all necessary controls.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QScrollArea, QSplitter, QTabWidget, QToolBar, QPushButton,
-    QTableWidget, QTableWidgetItem, QHeaderView
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QScrollArea,
+    QSplitter,
+    QTabWidget,
+    QToolBar,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
 )
 from PySide6.QtGui import QAction
 
@@ -19,7 +30,7 @@ from menipy.gui.panels import (
     ImageSourcePanel,
     CalibrationPanel,
     ParametersPanel,
-    ActionPanel
+    ActionPanel,
 )
 from menipy.gui.widgets.quick_stats_widget import QuickStatsWidget
 from menipy.gui.widgets.interactive_image_viewer import InteractiveImageViewer
@@ -31,25 +42,25 @@ from menipy.gui.dialogs.preprocessing_config_dialog import PreprocessingConfigDi
 
 class HistoryTableWidget(QWidget):
     """Table showing measurement history."""
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._count = 0
         self._setup_ui()
-    
+
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         self.table = QTableWidget()
         self.table.setColumnCount(6)
-        self.table.setHorizontalHeaderLabels([
-            "ID", "θ_L (°)", "θ_R (°)", "θ_M (°)", "Vol (μL)", "Area (mm²)"
-        ])
-        
+        self.table.setHorizontalHeaderLabels(
+            ["ID", "θ_L (°)", "θ_R (°)", "θ_M (°)", "Vol (μL)", "Area (mm²)"]
+        )
+
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
-        
+
         # Basic styling to match theme
         self.table.setStyleSheet(f"""
             QTableWidget {{
@@ -73,45 +84,45 @@ class HistoryTableWidget(QWidget):
         """)
         self.table.verticalHeader().setVisible(False)
         self.table.setAlternatingRowColors(True)
-        
+
         layout.addWidget(self.table)
-        
+
     def add_result(self, results: dict):
         """Add a result row to the table."""
         self._count += 1
         row = self.table.rowCount()
         self.table.insertRow(row)
-        
+
         def item(text):
             it = QTableWidgetItem(text)
             it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             return it
-            
+
         def fmt(key, fstr="{:.1f}"):
             val = results.get(key)
             if val is None:
                 return "-"
             return fstr.format(val)
-            
+
         # Use cleaned keys from ui_results
         al = results.get("angle_left")
         ar = results.get("angle_right")
         am = results.get("angle_mean")
-             
+
         self.table.setItem(row, 0, item(str(self._count)))
         self.table.setItem(row, 1, item(f"{al:.1f}" if al is not None else "-"))
         self.table.setItem(row, 2, item(f"{ar:.1f}" if ar is not None else "-"))
         self.table.setItem(row, 3, item(f"{am:.1f}" if am is not None else "-"))
         self.table.setItem(row, 4, item(fmt("volume", "{:.3f}")))
         self.table.setItem(row, 5, item(fmt("area", "{:.2f}")))
-        
+
         self.table.scrollToBottom()
 
 
 class SessileDropWindow(BaseExperimentWindow):
     """
     Window for sessile drop contact angle analysis.
-    
+
     Provides controls for:
         - Image loading (single, batch, camera)
     - Calibration setup
@@ -119,7 +130,7 @@ class SessileDropWindow(BaseExperimentWindow):
     - Analysis execution
     - Results display
     """
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._show_overlay = True
@@ -132,81 +143,81 @@ class SessileDropWindow(BaseExperimentWindow):
         self._edge_settings = EdgeDetectionSettings()
         self._pipeline_settings: dict = {}
         self._connect_signals()
-        
+
     def load_image(self, path: str):
         """Load image via source panel."""
         self._image_source_panel.load_image(path)
-    
+
     def get_experiment_type(self) -> str:
         return theme.EXPERIMENT_SESSILE
-    
+
     def get_experiment_title(self) -> str:
         return "Sessile Drop"
-    
+
     def _create_left_panel_content(self) -> QWidget:
         """Create the left panel content with setup controls."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         # Wrap in scroll area for long content
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         scroll.setStyleSheet("background: transparent;")
-        
+
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
         scroll_layout.setContentsMargins(0, 0, 0, 0)
         scroll_layout.setSpacing(12)
-        
+
         # Image Source panel
         self._image_source_panel = ImageSourcePanel()
         scroll_layout.addWidget(self._image_source_panel)
-        
+
         # Calibration panel
         self._calibration_panel = CalibrationPanel()
         scroll_layout.addWidget(self._calibration_panel)
-        
+
         # Parameters panel
         self._parameters_panel = ParametersPanel()
         scroll_layout.addWidget(self._parameters_panel)
-        
+
         # Action panel (Analyze button)
         self._action_panel = ActionPanel()
         scroll_layout.addWidget(self._action_panel)
-        
+
         scroll_layout.addStretch()
         scroll.setWidget(scroll_content)
         layout.addWidget(scroll)
-        
+
         return content
-    
+
     def _create_center_panel_content(self) -> QWidget:
         """Create the center panel content with image viewer."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        
+
         # Image viewer
         self._image_viewer = ImageViewer()
         layout.addWidget(self._image_viewer)
-        
+
         return content
-    
+
     def _create_right_panel_content(self) -> QWidget:
         """Create the right panel content with results."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         # Quick stats widget
         self._quick_stats = QuickStatsWidget()
         layout.addWidget(self._quick_stats)
-        
+
         # Tabs for history and charts
         tabs = QTabWidget()
         tabs.setStyleSheet(f"""
@@ -226,11 +237,11 @@ class SessileDropWindow(BaseExperimentWindow):
                 color: {theme.TEXT_PRIMARY};
             }}
         """)
-        
+
         # History tab
         self._history_widget = HistoryTableWidget()
         tabs.addTab(self._history_widget, "History")
-        
+
         # Chart tab
         chart_placeholder = QWidget()
         chart_layout = QVBoxLayout(chart_placeholder)
@@ -239,9 +250,9 @@ class SessileDropWindow(BaseExperimentWindow):
         chart_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         chart_layout.addWidget(chart_label)
         tabs.addTab(chart_placeholder, "Charts")
-        
+
         layout.addWidget(tabs, stretch=1)
-        
+
         # Export buttons
         export_frame = QFrame()
         export_frame.setStyleSheet(f"""
@@ -254,42 +265,44 @@ class SessileDropWindow(BaseExperimentWindow):
         export_layout = QHBoxLayout(export_frame)
         export_layout.setContentsMargins(8, 8, 8, 8)
         export_layout.setSpacing(8)
-        
+
         csv_btn = QPushButton("📊 Export CSV")
         csv_btn.setProperty("secondary", True)
         export_layout.addWidget(csv_btn)
-        
+
         report_btn = QPushButton("📄 Report")
         report_btn.setProperty("secondary", True)
         export_layout.addWidget(report_btn)
-        
+
         layout.addWidget(export_frame)
-        
+
         return content
-        
+
     def _create_center_panel_content(self) -> QWidget:
         """Create the center panel content (Image Viewer)."""
         self._image_viewer = InteractiveImageViewer()
         self._image_viewer.overlay_painted.connect(self._on_draw_overlay)
         return self._image_viewer
-    
+
     def _create_right_panel_content(self) -> QWidget:
         """Create the right panel content (Results)."""
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         # Quick Stats
         self._quick_stats = QuickStatsWidget()
         layout.addWidget(self._quick_stats)
-        
+
         # History/Charts placeholder
         from menipy.gui.widgets.measurements_table import MeasurementsTableWidget
+
         self._history_widget = MeasurementsTableWidget()
         layout.addWidget(self._history_widget, stretch=1)
-        
+
         return container
+
     def _add_toolbar_items(self, toolbar: QToolBar):
         """Add sessile-drop specific toolbar items."""
         # Overlay toggle
@@ -298,31 +311,31 @@ class SessileDropWindow(BaseExperimentWindow):
         overlay_action.setChecked(True)
         overlay_action.triggered.connect(self._on_toggle_overlay)
         toolbar.addAction(overlay_action)
-        
+
         # Baseline markers
         baseline_action = QAction("📏 Baseline", self)
         baseline_action.setCheckable(True)
         baseline_action.setChecked(True)
         baseline_action.triggered.connect(self._on_toggle_baseline)
         toolbar.addAction(baseline_action)
-        
+
         # Contact points
         contact_action = QAction("📍 Contact Points", self)
         contact_action.setCheckable(True)
         contact_action.setChecked(True)
         contact_action.triggered.connect(self._on_toggle_contact_points)
         toolbar.addAction(contact_action)
-    
+
     def _connect_signals(self):
         """Connect internal signals."""
         # Image loading
         self._image_source_panel.image_loaded.connect(self._on_image_loaded)
-        
+
         # Analysis
         self._action_panel.analyze_requested.connect(self._on_analyze_requested)
         self._action_panel.settings_requested.connect(self._on_settings_requested)
         self._action_panel.cancel_requested.connect(self._on_cancel_requested)
-        
+
         # Calibration
         # Calibration
         self._calibration_panel.calibration_requested.connect(
@@ -334,33 +347,35 @@ class SessileDropWindow(BaseExperimentWindow):
         self._calibration_panel.details_requested.connect(
             self._on_calibration_details_requested
         )
-        
+
         # Material Database
         self._parameters_panel.material_database_requested.connect(
             self._on_material_database_requested
         )
-    
+
     # -------------------------------------------------------------------------
     # Signal Handlers
     # -------------------------------------------------------------------------
-    
+
     def _on_material_database_requested(self, field_name: str):
         """Handle material database request."""
         from menipy.gui.dialogs.material_dialog import MaterialDialog
-        
+
         dialog = MaterialDialog(self, selection_mode=True)
         # Connect signal before exec
         dialog.material_selected.connect(
             lambda data: self._on_material_selected(data, field_name)
         )
         dialog.exec()
-            
+
     def _on_material_selected(self, material_data: dict, field_name: str):
         """Handle material selection from dialog."""
         if density := material_data.get("density"):
             self._parameters_panel.set_density(field_name, density)
-            self.set_status(f"Selected material: {material_data['name']} ({density} kg/m³)")
-    
+            self.set_status(
+                f"Selected material: {material_data['name']} ({density} kg/m³)"
+            )
+
     def _on_image_loaded(self, path: str, pixmap: QPixmap | None):
         """Handle image loaded."""
         self._current_image_path = path
@@ -368,96 +383,103 @@ class SessileDropWindow(BaseExperimentWindow):
             self._image_viewer.set_image(pixmap)
             self._image_viewer.fit_to_view()
             self.set_status(f"Loaded: {path}")
-    
+
     def _on_analyze_requested(self):
         """Handle analyze button click."""
         self._action_panel.set_state(ActionPanel.STATE_PROCESSING)
         self.set_status("Running analysis...")
-        
+
         # Run actual analysis pipeline
         self._run_analysis()
-    
+
     def _on_cancel_requested(self):
         """Handle cancel button click."""
         self._action_panel.set_state(ActionPanel.STATE_READY)
         self.set_status("Analysis cancelled")
-    
+
     def _on_settings_requested(self):
         """Handle settings button click."""
         # Open preprocessing config dialog
         # Note: We duplicate some logic from DialogCoordinator here because
         # SessileDropWindow is currently acting independently of the main controller
         # in some aspects (like running the pipeline directly).
-        dialog = PreprocessingConfigDialog(
-            self._preprocessing_settings, parent=self
-        )
-        
+        dialog = PreprocessingConfigDialog(self._preprocessing_settings, parent=self)
+
         # We need a controller to handle previews if we want previews in the dialog.
         # Ideally we refactor this to use the DialogCoordinator.
         # For now, we instantiate a temporary controller or just let the dialog run without
         # live preview if too complex, BUT the user wants the auto-detect preview.
-        
-        from menipy.gui.controllers.preprocessing_controller import PreprocessingPipelineController
+
+        from menipy.gui.controllers.preprocessing_controller import (
+            PreprocessingPipelineController,
+        )
+
         controller = PreprocessingPipelineController(parent=self)
         controller.set_settings(self._preprocessing_settings)
-        
+
         # If we have an image currently loaded, pass it to controller
         if self._image_viewer._pixmap and not self._image_viewer._pixmap.isNull():
-             img = self._image_viewer._pixmap.toImage()
-             # Convert QImage to numpy
-             import numpy as np
-             width = img.width()
-             height = img.height()
-             
-             ptr = img.bits()
-             # Assuming Format_RGB888 or similar for simple conversion, check format
-             # If loaded via QPixmap(path), format depends. 
-             # Simpler: read from path if available
-             if self._current_image_path:
-                 import cv2
-                 cv_img = cv2.imread(self._current_image_path)
-                 if cv_img is not None:
-                      controller.set_source(cv_img)
-        
+            img = self._image_viewer._pixmap.toImage()
+            # Convert QImage to numpy
+            import numpy as np
+
+            width = img.width()
+            height = img.height()
+
+            ptr = img.bits()
+            # Assuming Format_RGB888 or similar for simple conversion, check format
+            # If loaded via QPixmap(path), format depends.
+            # Simpler: read from path if available
+            if self._current_image_path:
+                import cv2
+
+                cv_img = cv2.imread(self._current_image_path)
+                if cv_img is not None:
+                    controller.set_source(cv_img)
+
         controller.previewReady.connect(dialog._on_preview_image_ready)
         dialog.previewRequested.connect(lambda s: self._run_preview(controller, s))
-        
+
         if dialog.exec():
             self._preprocessing_settings = dialog.settings()
             self.set_status("Settings updated.")
-            
+
     def _run_preview(self, controller, settings):
         controller.set_settings(settings)
         controller.run()
-    
+
     def _on_calibration_requested(self):
         """Handle calibration wizard request."""
         # Use the main application's CalibrationWizardDialog for full auto-detection
         from menipy.gui.dialogs.calibration_wizard_dialog import CalibrationWizardDialog
-        
+
         # Get raw image data
         image_data = None
         if self._current_image_path:
             import cv2
+
             image_data = cv2.imread(self._current_image_path)
-        
+
         if image_data is None:
             from PySide6.QtWidgets import QMessageBox
+
             QMessageBox.warning(self, "Calibration", "Please load an image first.")
             return
-        
-        wizard = CalibrationWizardDialog(image_data, pipeline_name="sessile", parent=self)
+
+        wizard = CalibrationWizardDialog(
+            image_data, pipeline_name="sessile", parent=self
+        )
         wizard.calibration_complete.connect(self._on_calibration_result)
         wizard.exec()
-        
+
     def _on_calibration_result(self, result):
         """Handle calibration result from CalibrationWizardDialog."""
         if result is None:
             return
-            
+
         # Store detected regions for later use in analysis
         self._last_calibration_result = result
-        
+
         # Update status with what was detected
         conf = result.confidence_scores.get("overall", 0.0)
         parts = []
@@ -467,64 +489,63 @@ class SessileDropWindow(BaseExperimentWindow):
             parts.append("substrate")
         if result.roi_rect:
             parts.append("ROI")
-        
+
         detected_str = ", ".join(parts) if parts else "nothing"
         self.set_status(f"Detected: {detected_str} (confidence: {conf*100:.0f}%)")
-        
+
         # If needle was detected, prompt user for physical dimension to compute scale
         if result.needle_rect:
             _, _, width_px, _ = result.needle_rect
             self._detected_needle_width_px = width_px
-            
+
             # Ask user for physical needle diameter
             from PySide6.QtWidgets import QInputDialog
+
             # getDouble(parent, title, label, value, min, max, decimals)
             diameter_mm, ok = QInputDialog.getDouble(
                 self,
                 "Enter Needle Diameter",
                 f"Detected needle width: {width_px:.1f} px\n\n"
                 "Enter the physical needle outer diameter (mm):",
-                0.72,   # default value (21 gauge)
-                0.1,    # minimum
-                5.0,    # maximum
-                3       # decimals
+                0.72,  # default value (21 gauge)
+                0.1,  # minimum
+                5.0,  # maximum
+                3,  # decimals
             )
-            
+
             if ok and diameter_mm > 0:
                 # Compute scale factor: px_per_mm = width_px / diameter_mm
                 scale_factor = width_px / diameter_mm
                 self._calibration_panel.set_calibration(
-                    scale_factor,
-                    reference_file="needle",
-                    date=None
+                    scale_factor, reference_file="needle", date=None
                 )
                 self.set_status(f"Calibration set: {scale_factor:.2f} px/mm")
-    
+
     def _on_calibration_completed(self, scale_factor: float):
         """Handle successful calibration (legacy signal)."""
         self._calibration_panel.set_calibration(scale_factor)
         self.set_status(f"Calibration updated: {scale_factor:.2f} px/mm")
-    
+
     def _on_calibration_details_requested(self):
         """Handle calibration details request - show current calibration info."""
         from PySide6.QtWidgets import QMessageBox
-        
+
         if not self._calibration_panel.is_calibrated():
             QMessageBox.information(
                 self,
                 "Calibration Details",
                 "No calibration is currently set.\n\n"
-                "Click 'Start Calibration Wizard' to calibrate."
+                "Click 'Start Calibration Wizard' to calibrate.",
             )
             return
-        
+
         # Build details message
         scale = self._calibration_panel.get_scale_factor()
         calib = getattr(self, "_last_calibration_result", None)
-        
+
         details = f"Scale Factor: {scale:.2f} px/mm\n"
         details += f"Resolution: {1.0/scale*1000:.1f} μm/pixel\n\n"
-        
+
         if calib:
             if calib.needle_rect:
                 x, y, w, h = calib.needle_rect
@@ -545,15 +566,15 @@ class SessileDropWindow(BaseExperimentWindow):
             if calib.roi_rect:
                 x, y, w, h = calib.roi_rect
                 details += f"ROI: {w:.0f}×{h:.0f} px at ({x:.0f}, {y:.0f})\n"
-            
+
             # Confidence scores
             if calib.confidence_scores:
                 details += "\nConfidence Scores:\n"
                 for key, value in calib.confidence_scores.items():
                     details += f"  • {key}: {value*100:.0f}%\n"
-        
+
         QMessageBox.information(self, "Calibration Details", details)
-    
+
     def _run_analysis(self):
         """Run the actual analysis pipeline."""
         if not self._current_image_path:
@@ -566,7 +587,7 @@ class SessileDropWindow(BaseExperimentWindow):
             # Get density directly from panel (assuming method exists or we parse it)
             # For now, default or parsing from UI if possible.
             # (ParametersPanel usually manages this, assumes defaults if not set)
-            
+
             # 2. Run Pipeline
             pipeline = SessilePipeline(
                 preprocessing_settings=self._preprocessing_settings,
@@ -578,7 +599,7 @@ class SessileDropWindow(BaseExperimentWindow):
                 pipeline.preprocessor_name = self._pipeline_settings["preprocessor"]
             if "edge_detector" in self._pipeline_settings:
                 pipeline.edge_detector_name = self._pipeline_settings["edge_detector"]
-            
+
             # Build kwargs from calibration result if available
             pipeline_kwargs = {
                 "image_path": self._current_image_path,
@@ -586,7 +607,9 @@ class SessileDropWindow(BaseExperimentWindow):
             }
             # pipeline-stage choices
             if "contact_angle_method" in self._pipeline_settings:
-                pipeline_kwargs["contact_angle_method"] = self._pipeline_settings["contact_angle_method"]
+                pipeline_kwargs["contact_angle_method"] = self._pipeline_settings[
+                    "contact_angle_method"
+                ]
             # physics overrides
             if any(k in self._pipeline_settings for k in ("rho1", "rho2", "g")):
                 pipeline_kwargs["physics"] = {
@@ -594,7 +617,7 @@ class SessileDropWindow(BaseExperimentWindow):
                     "rho2": float(self._pipeline_settings.get("rho2", 1.2)),
                     "g": float(self._pipeline_settings.get("g", 9.80665)),
                 }
-            
+
             # Use calibration result if available (from CalibrationWizardDialog)
             calib = getattr(self, "_last_calibration_result", None)
             if calib:
@@ -618,98 +641,110 @@ class SessileDropWindow(BaseExperimentWindow):
             else:
                 # No calibration - run auto-detection
                 pipeline_kwargs["auto_detect_features"] = True
-            
+
             # Get scale factor from calibration panel (px/mm)
             if self._calibration_panel.is_calibrated():
                 scale_factor = self._calibration_panel.get_scale_factor()
                 if scale_factor > 0:
                     pipeline_kwargs["px_per_mm"] = scale_factor
-            
+
             # Retrieve enabled stages via pipeline settings or fallback to all
             enabled_stages = self._pipeline_settings.get("enabled_stages", None)
-            
+
             # Extract other dynamic settings
             if "physics" in self._pipeline_settings:
                 # Assuming pipeline accepts physics_params directly or we update existing model?
                 # Usually pipeline takes 'physics_params'
                 pipeline_kwargs["physics_params"] = self._pipeline_settings["physics"]
             if "geometry_config" in self._pipeline_settings:
-                pipeline_kwargs["geometry_config"] = self._pipeline_settings["geometry_config"]
-            if "overlay_config" in self._pipeline_settings: 
-                pipeline_kwargs["overlay_config"] = self._pipeline_settings["overlay_config"]
+                pipeline_kwargs["geometry_config"] = self._pipeline_settings[
+                    "geometry_config"
+                ]
+            if "overlay_config" in self._pipeline_settings:
+                pipeline_kwargs["overlay_config"] = self._pipeline_settings[
+                    "overlay_config"
+                ]
 
             ctx = pipeline.run(only=enabled_stages, **pipeline_kwargs)
-            
+
             # 3. Handle Results
             if ctx.error:
                 self.set_status(f"Analysis failed: {ctx.error}")
                 self._action_panel.set_state(ActionPanel.STATE_READY)
                 return
-                
+
             self._last_ctx = ctx
             results = ctx.results or {}
-            
+
             # Map pipeline results to UI widget expected format
             raw_ui_results = {
                 "angle_left": results.get("theta_left_deg"),
                 "angle_right": results.get("theta_right_deg"),
                 "angle_mean": (
-                    (results.get("theta_left_deg", 0) + results.get("theta_right_deg", 0)) / 2 
-                    if results.get("theta_left_deg") is not None else None
+                    (
+                        results.get("theta_left_deg", 0)
+                        + results.get("theta_right_deg", 0)
+                    )
+                    / 2
+                    if results.get("theta_left_deg") is not None
+                    else None
                 ),
                 "angle_uncertainty": max(
                     results.get("uncertainty_deg", {}).get("left", 0.5),
-                    results.get("uncertainty_deg", {}).get("right", 0.5)
+                    results.get("uncertainty_deg", {}).get("right", 0.5),
                 ),
                 "volume": results.get("volume_uL"),
                 "diameter": results.get("diameter_mm"),
                 "height": results.get("height_mm"),
-                "base_width": results.get("diameter_mm"), # Base width ~= diameter for sessile
-                "surface_tension": results.get("surface_tension"), # If computed
+                "base_width": results.get(
+                    "diameter_mm"
+                ),  # Base width ~= diameter for sessile
+                "surface_tension": results.get("surface_tension"),  # If computed
                 "area": results.get("contact_surface_mm2"),
-                "confidence": results.get("baseline_confidence", 1.0) * 100
+                "confidence": results.get("baseline_confidence", 1.0) * 100,
             }
-            
+
             # Filter out None values to avoid formatting errors in widget
             ui_results = {k: v for k, v in raw_ui_results.items() if v is not None}
-            
+
             # 4. update UI
             self._quick_stats.set_results(ui_results)
-            self._history_widget.add_result(ui_results) # Update valid history table
-            
+            self._history_widget.add_result(ui_results)  # Update valid history table
+
             self._action_panel.set_state(ActionPanel.STATE_COMPLETE)
             self.set_status("Analysis complete")
-            
+
             self.analysis_completed.emit(results)
             self._image_viewer.update()
-            
+
         except Exception as e:
             self.set_status(f"Error: {str(e)}")
             self._action_panel.set_state(ActionPanel.STATE_READY)
             import traceback
+
             traceback.print_exc()
 
     def _on_draw_overlay(self, painter, target_rect, zoom):
         """Draw analysis overlay."""
         if not self._show_overlay or not self._last_ctx:
             return
-            
+
         from PySide6.QtGui import QColor, QPen, QPolygonF
         from PySide6.QtCore import QPointF, QRectF
-        
+
         ctx = self._last_ctx
-        
+
         # Map function
         img_w = self._image_viewer._pixmap.width()
         img_h = self._image_viewer._pixmap.height()
-        
+
         def to_view(x, y):
             # x, y are in image pixels
             # map 0..img_w to target_rect.left()..target_rect.right()
             vx = target_rect.left() + (x / img_w) * target_rect.width()
             vy = target_rect.top() + (y / img_h) * target_rect.height()
             return QPointF(vx, vy)
-            
+
         def to_view_rect(rect_obj):
             """To_view_rect."""
             # rect_obj has x, y, width, height
@@ -719,13 +754,15 @@ class SessileDropWindow(BaseExperimentWindow):
 
         # 1. Draw ROI (Yellow)
         if ctx.roi:
-            # ROI is likely a tuple or object with x,y,w,h. 
+            # ROI is likely a tuple or object with x,y,w,h.
             # Context.roi is Tuple[int, int, int, int] (x, y, w, h)
             if isinstance(ctx.roi, (list, tuple)):
                 rx, ry, rw, rh = ctx.roi
-                r_view = to_view_rect(type('R',(),{'x':rx,'y':ry,'width':rw,'height':rh}))
-                
-                pen = QPen(QColor(255, 255, 0, 200)) # Yellow
+                r_view = to_view_rect(
+                    type("R", (), {"x": rx, "y": ry, "width": rw, "height": rh})
+                )
+
+                pen = QPen(QColor(255, 255, 0, 200))  # Yellow
                 pen.setWidth(1)
                 pen.setStyle(Qt.PenStyle.DotLine)
                 painter.setPen(pen)
@@ -735,9 +772,11 @@ class SessileDropWindow(BaseExperimentWindow):
         if ctx.needle_rect:
             if isinstance(ctx.needle_rect, (list, tuple)):
                 nx, ny, nw, nh = ctx.needle_rect
-                n_view = to_view_rect(type('N',(),{'x':nx,'y':ny,'width':nw,'height':nh}))
-                
-                pen = QPen(QColor(0, 255, 255, 180)) # Cyan
+                n_view = to_view_rect(
+                    type("N", (), {"x": nx, "y": ny, "width": nw, "height": nh})
+                )
+
+                pen = QPen(QColor(0, 255, 255, 180))  # Cyan
                 pen.setWidth(1)
                 painter.setPen(pen)
                 painter.drawRect(n_view)
@@ -748,9 +787,9 @@ class SessileDropWindow(BaseExperimentWindow):
             pts = []
             for pt in ctx.contour.xy:
                 pts.append(to_view(pt[0], pt[1]))
-            
+
             if pts:
-                pen = QPen(QColor(0, 255, 0, 200)) # Green
+                pen = QPen(QColor(0, 255, 0, 200))  # Green
                 pen.setWidth(2)
                 painter.setPen(pen)
                 painter.drawPolyline(pts)
@@ -758,44 +797,44 @@ class SessileDropWindow(BaseExperimentWindow):
         # 4. Draw Geometry (Red/Blue)
         if ctx.geometry:
             geom = ctx.geometry
-            
+
             # Baseline (Blue)
             if self._show_baseline and geom.baseline_y is not None:
                 y_base = geom.baseline_y
                 p1 = to_view(0, y_base)
                 p2 = to_view(img_w, y_base)
-                
+
                 pen = QPen(QColor(0, 100, 255, 200))
                 pen.setWidth(1)
                 painter.setPen(pen)
                 painter.drawLine(p1, p2)
-            
+
             # Axis (Red dash)
             if geom.axis_x is not None:
                 x_axis = geom.axis_x
                 p1 = to_view(x_axis, 0)
                 p2 = to_view(x_axis, img_h)
-                
+
                 pen = QPen(QColor(255, 50, 50, 180))
                 pen.setWidth(1)
                 pen.setStyle(Qt.PenStyle.DashLine)
                 painter.setPen(pen)
                 painter.drawLine(p1, p2)
-                
+
             # Apex (Red Point)
             if geom.apex_xy:
                 ap = to_view(geom.apex_xy[0], geom.apex_xy[1])
                 painter.setBrush(QColor(255, 0, 0))
                 painter.setPen(Qt.PenStyle.NoPen)
                 painter.drawEllipse(ap, 4, 4)
-                
+
         # 5. Draw Contact Points (Magenta)
         if self._show_contact_points and ctx.contact_line:
             # contact_line is ((x1, y1), (x2, y2))
             (x1, y1), (x2, y2) = ctx.contact_line
             p1 = to_view(x1, y1)
             p2 = to_view(x2, y2)
-            
+
             pen = QPen(QColor(255, 0, 255, 255))
             pen.setWidth(5)
             pen.setCapStyle(Qt.PenCapStyle.RoundCap)
@@ -803,41 +842,40 @@ class SessileDropWindow(BaseExperimentWindow):
             painter.drawPoint(p1)
             painter.drawPoint(p2)
 
-    
     def _on_toggle_overlay(self, checked: bool):
         """Toggle overlay visibility."""
         self._show_overlay = checked
         self._image_viewer.update()
         self.set_status(f"Overlay: {'on' if checked else 'off'}")
-    
+
     def _on_toggle_baseline(self, checked: bool):
         """Toggle baseline visibility."""
         self._show_baseline = checked
         self._image_viewer.update()
         self.set_status(f"Baseline: {'on' if checked else 'off'}")
-    
+
     def _on_toggle_contact_points(self, checked: bool):
         """Toggle contact points visibility."""
         self._show_contact_points = checked
         self._image_viewer.update()
         self.set_status(f"Contact points: {'on' if checked else 'off'}")
-    
+
     # -------------------------------------------------------------------------
     # Toolbar Actions
     # -------------------------------------------------------------------------
-    
+
     def _on_zoom_in(self):
         """_on_zoom_in."""
         self._image_viewer.zoom_in()
-    
+
     def _on_zoom_out(self):
         """_on_zoom_out."""
         self._image_viewer.zoom_out()
-    
+
     def _on_fit_view(self):
         """_on_fit_view."""
         self._image_viewer.fit_to_view()
-    
+
     def _on_reset_view(self):
         """_on_reset_view."""
         self._image_viewer.reset_view()

--- a/src/menipy/gui/views/step_item_widget.py
+++ b/src/menipy/gui/views/step_item_widget.py
@@ -137,16 +137,13 @@ class StepItemWidget(QWidget):
             self.style().polish(self)
             return
         color = _STATUS_COLORS[status]
-        self.statusLbl.setStyleSheet(
-            f"background-color: {color}; border-radius: 5px;"
-        )
+        self.statusLbl.setStyleSheet(f"background-color: {color}; border-radius: 5px;")
         self.statusLbl.setToolTip(status.title())
         self.style().unpolish(self)
         self.style().polish(self)
 
     def _apply_widget_style(self) -> None:
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QWidget[stepState="pending"] {
                 background: #ffffff;
                 border: 1px solid #d7dde5;
@@ -196,5 +193,4 @@ class StepItemWidget(QWidget):
                 background: #f1f5f9;
                 border-color: #e2e8f0;
             }
-            """
-        )
+            """)

--- a/src/menipy/gui/views/tilted_sessile_window.py
+++ b/src/menipy/gui/views/tilted_sessile_window.py
@@ -4,11 +4,19 @@ Tilted Sessile Window
 Specialized window for tilted sessile drop measurements.
 Measures advancing and receding contact angles during tilting.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame,
-    QScrollArea, QTabWidget, QToolBar, QPushButton
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QScrollArea,
+    QTabWidget,
+    QToolBar,
+    QPushButton,
 )
 from PySide6.QtGui import QAction
 
@@ -21,19 +29,19 @@ from menipy.gui.widgets.tilted_sessile_results_widget import TiltedSessileResult
 
 class TiltedImageViewer(QWidget):
     """Image viewer for tilted sessile with tilt angle indicator."""
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._pixmap: QPixmap | None = None
         self._zoom = 1.0
         self._tilt_angle = 0.0
-        
+
         self._setup_ui()
-    
+
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Tilt indicator at top
         self._tilt_indicator = QLabel("Tilt: 0.0°")
         self._tilt_indicator.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -47,7 +55,7 @@ class TiltedImageViewer(QWidget):
         """)
         self._tilt_indicator.setMaximumHeight(40)
         layout.addWidget(self._tilt_indicator)
-        
+
         # Scroll area
         self._scroll_area = QScrollArea()
         self._scroll_area.setWidgetResizable(True)
@@ -58,15 +66,17 @@ class TiltedImageViewer(QWidget):
                 border: none;
             }}
         """)
-        
+
         self._image_label = QLabel()
         self._image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._image_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
-        self._image_label.setText("Load an image to begin analysis\n\n📐\n\nFor tilted measurements,\nplace drop on tilting platform")
-        
+        self._image_label.setText(
+            "Load an image to begin analysis\n\n📐\n\nFor tilted measurements,\nplace drop on tilting platform"
+        )
+
         self._scroll_area.setWidget(self._image_label)
         layout.addWidget(self._scroll_area)
-    
+
     def set_image(self, pixmap: QPixmap | None):
         """Set the image to display."""
         self._pixmap = pixmap
@@ -74,29 +84,29 @@ class TiltedImageViewer(QWidget):
             scaled = pixmap.scaled(
                 pixmap.size() * self._zoom,
                 Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation
+                Qt.TransformationMode.SmoothTransformation,
             )
             self._image_label.setPixmap(scaled)
         else:
             self._image_label.clear()
             self._image_label.setText("Load an image to begin analysis")
-    
+
     def set_tilt_angle(self, angle: float):
         """Update the tilt angle indicator."""
         self._tilt_angle = angle
         self._tilt_indicator.setText(f"Tilt: {angle:.1f}°")
-    
+
     def set_zoom(self, zoom: float):
         self._zoom = max(0.1, min(10.0, zoom))
         if self._pixmap:
             self.set_image(self._pixmap)
-    
+
     def zoom_in(self):
         self.set_zoom(self._zoom * 1.25)
-    
+
     def zoom_out(self):
         self.set_zoom(self._zoom / 1.25)
-    
+
     def fit_to_view(self):
         if self._pixmap and not self._pixmap.isNull():
             vp_size = self._scroll_area.viewport().size()
@@ -105,7 +115,7 @@ class TiltedImageViewer(QWidget):
             scale_y = vp_size.height() / img_size.height()
             self._zoom = min(scale_x, scale_y) * 0.95
             self.set_image(self._pixmap)
-    
+
     def reset_view(self):
         self.set_zoom(1.0)
 
@@ -113,21 +123,21 @@ class TiltedImageViewer(QWidget):
 class TiltedSessileWindow(BaseExperimentWindow):
     """
     Window for tilted sessile drop contact angle analysis.
-    
+
     Provides controls for:
         - Image loading
     - Tilt stage control
     - Advancing/receding angle measurement
     - Tilt sequence automation
     """
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._connect_signals()
-    
+
     def get_experiment_type(self) -> str:
         return theme.EXPERIMENT_TILTED_SESSILE
-    
+
     def get_experiment_title(self) -> str:
         """Get experiment title.
 
@@ -137,66 +147,66 @@ class TiltedSessileWindow(BaseExperimentWindow):
         Description.
         """
         return "Tilted Sessile"
-    
+
     def _create_left_panel_content(self) -> QWidget:
         """Create the left panel content with setup controls."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         scroll.setStyleSheet("background: transparent;")
-        
+
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
         scroll_layout.setContentsMargins(0, 0, 0, 0)
         scroll_layout.setSpacing(12)
-        
+
         # Image Source panel
         self._image_source_panel = ImageSourcePanel()
         scroll_layout.addWidget(self._image_source_panel)
-        
+
         # Tilt Stage panel
         self._tilt_panel = TiltStagePanel()
         scroll_layout.addWidget(self._tilt_panel)
-        
+
         # Action panel
         self._action_panel = ActionPanel()
         self._action_panel.set_button_text("▶ Measure at Current Tilt")
         scroll_layout.addWidget(self._action_panel)
-        
+
         scroll_layout.addStretch()
         scroll.setWidget(scroll_content)
         layout.addWidget(scroll)
-        
+
         return content
-    
+
     def _create_center_panel_content(self) -> QWidget:
         """Create the center panel content with image viewer."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        
+
         self._image_viewer = TiltedImageViewer()
         layout.addWidget(self._image_viewer)
-        
+
         return content
-    
+
     def _create_right_panel_content(self) -> QWidget:
         """Create the right panel content with results."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(12)
-        
+
         # Tilted results widget
         self._results_widget = TiltedSessileResultsWidget()
         layout.addWidget(self._results_widget)
-        
+
         # Tabs for sequence history and graph
         tabs = QTabWidget()
         tabs.setStyleSheet(f"""
@@ -216,16 +226,18 @@ class TiltedSessileWindow(BaseExperimentWindow):
                 color: {theme.TEXT_PRIMARY};
             }}
         """)
-        
+
         # Graph tab - angle vs tilt
         graph_placeholder = QWidget()
         graph_layout = QVBoxLayout(graph_placeholder)
-        graph_label = QLabel("📈 Contact angle vs tilt\nPlot will appear here after\nmultiple measurements")
+        graph_label = QLabel(
+            "📈 Contact angle vs tilt\nPlot will appear here after\nmultiple measurements"
+        )
         graph_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         graph_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         graph_layout.addWidget(graph_label)
         tabs.addTab(graph_placeholder, "θ vs Tilt")
-        
+
         # History tab
         history_placeholder = QWidget()
         history_layout = QVBoxLayout(history_placeholder)
@@ -234,9 +246,9 @@ class TiltedSessileWindow(BaseExperimentWindow):
         history_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         history_layout.addWidget(history_label)
         tabs.addTab(history_placeholder, "History")
-        
+
         layout.addWidget(tabs, stretch=1)
-        
+
         # Export buttons
         export_frame = QFrame()
         export_frame.setStyleSheet(f"""
@@ -249,19 +261,19 @@ class TiltedSessileWindow(BaseExperimentWindow):
         export_layout = QHBoxLayout(export_frame)
         export_layout.setContentsMargins(8, 8, 8, 8)
         export_layout.setSpacing(8)
-        
+
         csv_btn = QPushButton("📊 Export CSV")
         csv_btn.setProperty("secondary", True)
         export_layout.addWidget(csv_btn)
-        
+
         report_btn = QPushButton("📄 Report")
         report_btn.setProperty("secondary", True)
         export_layout.addWidget(report_btn)
-        
+
         layout.addWidget(export_frame)
-        
+
         return content
-    
+
     def _add_toolbar_items(self, toolbar: QToolBar):
         """Add tilted-sessile specific toolbar items."""
         # Overlay toggle
@@ -269,25 +281,25 @@ class TiltedSessileWindow(BaseExperimentWindow):
         overlay_action.setCheckable(True)
         overlay_action.setChecked(True)
         toolbar.addAction(overlay_action)
-        
+
         # Advancing point
         adv_action = QAction("🟢 Advancing", self)
         adv_action.setCheckable(True)
         adv_action.setChecked(True)
         toolbar.addAction(adv_action)
-        
+
         # Receding point
         rec_action = QAction("🟠 Receding", self)
         rec_action.setCheckable(True)
         rec_action.setChecked(True)
         toolbar.addAction(rec_action)
-        
+
         # Baseline
         baseline_action = QAction("📏 Baseline", self)
         baseline_action.setCheckable(True)
         baseline_action.setChecked(True)
         toolbar.addAction(baseline_action)
-    
+
     def _connect_signals(self):
         """Connect internal signals."""
         self._image_source_panel.image_loaded.connect(self._on_image_loaded)
@@ -296,53 +308,53 @@ class TiltedSessileWindow(BaseExperimentWindow):
         self._tilt_panel.angle_changed.connect(self._on_tilt_changed)
         self._tilt_panel.sequence_started.connect(self._on_sequence_started)
         self._tilt_panel.sequence_stopped.connect(self._on_sequence_stopped)
-    
+
     # -------------------------------------------------------------------------
     # Signal Handlers
     # -------------------------------------------------------------------------
-    
+
     def _on_image_loaded(self, path: str, pixmap: QPixmap | None):
         """Handle image loaded."""
         if pixmap:
             self._image_viewer.set_image(pixmap)
             self._image_viewer.fit_to_view()
             self.set_status(f"Loaded: {path}")
-    
+
     def _on_analyze_requested(self):
         """Handle analyze button click."""
         self._action_panel.set_state(ActionPanel.STATE_PROCESSING)
         self.set_status("Analyzing tilted sessile drop...")
-        
+
         # Simulate analysis
         self._simulate_analysis()
-    
+
     def _on_cancel_requested(self):
         """Handle cancel button click."""
         self._action_panel.set_state(ActionPanel.STATE_READY)
         self.set_status("Analysis cancelled")
-    
+
     def _on_tilt_changed(self, angle: float):
         """Handle tilt angle change."""
         self._image_viewer.set_tilt_angle(angle)
         self._results_widget.set_tilt_angle(angle)
         self.set_status(f"Tilt angle: {angle:.1f}°")
-    
+
     def _on_sequence_started(self, start: float, end: float, step: float):
         """Handle tilt sequence start."""
         self.set_status(f"Starting sequence: {start}° to {end}° by {step}°")
-    
+
     def _on_sequence_stopped(self):
         """Handle tilt sequence stop."""
         self.set_status("Sequence stopped")
-    
+
     def _simulate_analysis(self):
         """Simulate analysis with mock results."""
         import random
-        
+
         self._action_panel.set_progress(50, "Detecting contact points...")
-        
+
         tilt = self._tilt_panel.get_angle()
-        
+
         # Mock results
         results = {
             "tilt_angle": tilt,
@@ -356,25 +368,25 @@ class TiltedSessileWindow(BaseExperimentWindow):
             "base_right": 1.18 + random.uniform(-0.05, 0.05),
             "confidence": 95 + random.uniform(-5, 5),
         }
-        
+
         self._results_widget.set_results(results)
         self._action_panel.set_state(ActionPanel.STATE_COMPLETE)
         self.set_status("Analysis complete")
-        
+
         self.analysis_completed.emit(results)
-    
+
     # -------------------------------------------------------------------------
     # Toolbar Actions
     # -------------------------------------------------------------------------
-    
+
     def _on_zoom_in(self):
         self._image_viewer.zoom_in()
-    
+
     def _on_zoom_out(self):
         self._image_viewer.zoom_out()
-    
+
     def _on_fit_view(self):
         self._image_viewer.fit_to_view()
-    
+
     def _on_reset_view(self):
         self._image_viewer.reset_view()

--- a/src/menipy/gui/views/ui_main_window.py
+++ b/src/menipy/gui/views/ui_main_window.py
@@ -8,84 +8,121 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
-    QMetaObject, QObject, QPoint, QRect,
-    QSize, QTime, QUrl, Qt)
-from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
-    QCursor, QFont, QFontDatabase, QGradient,
-    QIcon, QImage, QKeySequence, QLinearGradient,
-    QPainter, QPalette, QPixmap, QRadialGradient,
-    QTransform)
-from PySide6.QtWidgets import (QApplication, QHBoxLayout, QMainWindow, QMenu,
-    QMenuBar, QSizePolicy, QSpacerItem, QSplitter,
-    QStatusBar, QTabWidget, QToolButton, QVBoxLayout,
-    QWidget)
+from PySide6.QtCore import (
+    QCoreApplication,
+    QDate,
+    QDateTime,
+    QLocale,
+    QMetaObject,
+    QObject,
+    QPoint,
+    QRect,
+    QSize,
+    QTime,
+    QUrl,
+    Qt,
+)
+from PySide6.QtGui import (
+    QAction,
+    QBrush,
+    QColor,
+    QConicalGradient,
+    QCursor,
+    QFont,
+    QFontDatabase,
+    QGradient,
+    QIcon,
+    QImage,
+    QKeySequence,
+    QLinearGradient,
+    QPainter,
+    QPalette,
+    QPixmap,
+    QRadialGradient,
+    QTransform,
+)
+from PySide6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QMainWindow,
+    QMenu,
+    QMenuBar,
+    QSizePolicy,
+    QSpacerItem,
+    QSplitter,
+    QStatusBar,
+    QTabWidget,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
-            MainWindow.setObjectName(u"MainWindow")
+            MainWindow.setObjectName("MainWindow")
         self.actionOpenImage = QAction(MainWindow)
-        self.actionOpenImage.setObjectName(u"actionOpenImage")
+        self.actionOpenImage.setObjectName("actionOpenImage")
         self.actionPreview = QAction(MainWindow)
-        self.actionPreview.setObjectName(u"actionPreview")
+        self.actionPreview.setObjectName("actionPreview")
         self.actionExportCsv = QAction(MainWindow)
-        self.actionExportCsv.setObjectName(u"actionExportCsv")
+        self.actionExportCsv.setObjectName("actionExportCsv")
         self.actionOpenCamera = QAction(MainWindow)
-        self.actionOpenCamera.setObjectName(u"actionOpenCamera")
+        self.actionOpenCamera.setObjectName("actionOpenCamera")
         self.actionRunFull = QAction(MainWindow)
-        self.actionRunFull.setObjectName(u"actionRunFull")
+        self.actionRunFull.setObjectName("actionRunFull")
         self.actionRunSelected = QAction(MainWindow)
-        self.actionRunSelected.setObjectName(u"actionRunSelected")
+        self.actionRunSelected.setObjectName("actionRunSelected")
         self.actionStop = QAction(MainWindow)
-        self.actionStop.setObjectName(u"actionStop")
+        self.actionStop.setObjectName("actionStop")
         self.actionQuit = QAction(MainWindow)
-        self.actionQuit.setObjectName(u"actionQuit")
+        self.actionQuit.setObjectName("actionQuit")
         self.actionAbout = QAction(MainWindow)
-        self.actionAbout.setObjectName(u"actionAbout")
+        self.actionAbout.setObjectName("actionAbout")
         self.actionOverlay = QAction(MainWindow)
-        self.actionOverlay.setObjectName(u"actionOverlay")
+        self.actionOverlay.setObjectName("actionOverlay")
         icon = QIcon()
-        icon.addFile(u":/icons/overlay.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
+        icon.addFile(":/icons/overlay.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.actionOverlay.setIcon(icon)
         self.actionConfigOverlay = QAction(MainWindow)
-        self.actionConfigOverlay.setObjectName(u"actionConfigOverlay")
+        self.actionConfigOverlay.setObjectName("actionConfigOverlay")
         self.actionConfigMarkers = QAction(MainWindow)
-        self.actionConfigMarkers.setObjectName(u"actionConfigMarkers")
+        self.actionConfigMarkers.setObjectName("actionConfigMarkers")
         self.actionConfigPipeline = QAction(MainWindow)
-        self.actionConfigPipeline.setObjectName(u"actionConfigPipeline")
+        self.actionConfigPipeline.setObjectName("actionConfigPipeline")
         self.actionConfigPreprocessing = QAction(MainWindow)
-        self.actionConfigPreprocessing.setObjectName(u"actionConfigPreprocessing")
+        self.actionConfigPreprocessing.setObjectName("actionConfigPreprocessing")
         self.actionConfigEdgeDetection = QAction(MainWindow)
-        self.actionConfigEdgeDetection.setObjectName(u"actionConfigEdgeDetection")
+        self.actionConfigEdgeDetection.setObjectName("actionConfigEdgeDetection")
         self.actionConfigGeometry = QAction(MainWindow)
-        self.actionConfigGeometry.setObjectName(u"actionConfigGeometry")
+        self.actionConfigGeometry.setObjectName("actionConfigGeometry")
         self.actionConfigPhysics = QAction(MainWindow)
-        self.actionConfigPhysics.setObjectName(u"actionConfigPhysics")
+        self.actionConfigPhysics.setObjectName("actionConfigPhysics")
         self.actionConfigAcquisition = QAction(MainWindow)
-        self.actionConfigAcquisition.setObjectName(u"actionConfigAcquisition")
+        self.actionConfigAcquisition.setObjectName("actionConfigAcquisition")
         self.menubar = QMenuBar(MainWindow)
-        self.menubar.setObjectName(u"menubar")
+        self.menubar.setObjectName("menubar")
         self.menubar.setNativeMenuBar(False)
         self.menuFile = QMenu(self.menubar)
-        self.menuFile.setObjectName(u"menuFile")
+        self.menuFile.setObjectName("menuFile")
         self.menuConfig = QMenu(self.menubar)
-        self.menuConfig.setObjectName(u"menuConfig")
+        self.menuConfig.setObjectName("menuConfig")
         self.menuView = QMenu(self.menubar)
-        self.menuView.setObjectName(u"menuView")
+        self.menuView.setObjectName("menuView")
         self.menuRun = QMenu(self.menubar)
-        self.menuRun.setObjectName(u"menuRun")
+        self.menuRun.setObjectName("menuRun")
         self.menuPlugins = QMenu(self.menubar)
-        self.menuPlugins.setObjectName(u"menuPlugins")
+        self.menuPlugins.setObjectName("menuPlugins")
         self.menuHelp = QMenu(self.menubar)
-        self.menuHelp.setObjectName(u"menuHelp")
+        self.menuHelp.setObjectName("menuHelp")
         MainWindow.setMenuBar(self.menubar)
         self.centralwidget = QWidget(MainWindow)
-        self.centralwidget.setObjectName(u"centralwidget")
+        self.centralwidget.setObjectName("centralwidget")
         self.centralLayout = QVBoxLayout(self.centralwidget)
-        self.centralLayout.setObjectName(u"centralLayout")
+        self.centralLayout.setObjectName("centralLayout")
         self.workflowBar = QWidget(self.centralwidget)
-        self.workflowBar.setObjectName(u"workflowBar")
+        self.workflowBar.setObjectName("workflowBar")
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -94,91 +131,92 @@ class Ui_MainWindow(object):
         self.workflowBar.setMaximumSize(QSize(16777215, 44))
         self.workflowBarLayout = QHBoxLayout(self.workflowBar)
         self.workflowBarLayout.setSpacing(8)
-        self.workflowBarLayout.setObjectName(u"workflowBarLayout")
+        self.workflowBarLayout.setObjectName("workflowBarLayout")
         self.workflowBarLayout.setContentsMargins(8, 8, 8, 6)
         self.actionOpenImageBtn = QToolButton(self.workflowBar)
-        self.actionOpenImageBtn.setObjectName(u"actionOpenImageBtn")
+        self.actionOpenImageBtn.setObjectName("actionOpenImageBtn")
         self.actionOpenImageBtn.setAutoRaise(True)
 
         self.workflowBarLayout.addWidget(self.actionOpenImageBtn)
 
         self.workflowAutoCalibrateBtn = QToolButton(self.workflowBar)
-        self.workflowAutoCalibrateBtn.setObjectName(u"workflowAutoCalibrateBtn")
+        self.workflowAutoCalibrateBtn.setObjectName("workflowAutoCalibrateBtn")
         self.workflowAutoCalibrateBtn.setAutoRaise(True)
 
         self.workflowBarLayout.addWidget(self.workflowAutoCalibrateBtn)
 
         self.actionRunBtn = QToolButton(self.workflowBar)
-        self.actionRunBtn.setObjectName(u"actionRunBtn")
+        self.actionRunBtn.setObjectName("actionRunBtn")
         self.actionRunBtn.setAutoRaise(True)
 
         self.workflowBarLayout.addWidget(self.actionRunBtn)
 
         self.actionExportCsvBtn = QToolButton(self.workflowBar)
-        self.actionExportCsvBtn.setObjectName(u"actionExportCsvBtn")
+        self.actionExportCsvBtn.setObjectName("actionExportCsvBtn")
         self.actionExportCsvBtn.setAutoRaise(True)
 
         self.workflowBarLayout.addWidget(self.actionExportCsvBtn)
 
         self.workflowAdvancedBtn = QToolButton(self.workflowBar)
-        self.workflowAdvancedBtn.setObjectName(u"workflowAdvancedBtn")
+        self.workflowAdvancedBtn.setObjectName("workflowAdvancedBtn")
         self.workflowAdvancedBtn.setCheckable(True)
         self.workflowAdvancedBtn.setAutoRaise(True)
 
         self.workflowBarLayout.addWidget(self.workflowAdvancedBtn)
 
-        self.workflowSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.workflowSpacer = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.workflowBarLayout.addItem(self.workflowSpacer)
-
 
         self.centralLayout.addWidget(self.workflowBar)
 
         self.rootSplitter = QSplitter(self.centralwidget)
-        self.rootSplitter.setObjectName(u"rootSplitter")
+        self.rootSplitter.setObjectName("rootSplitter")
         self.rootSplitter.setOrientation(Qt.Horizontal)
         self.setupHost = QWidget(self.rootSplitter)
-        self.setupHost.setObjectName(u"setupHost")
+        self.setupHost.setObjectName("setupHost")
         self.setupHostLayout = QVBoxLayout(self.setupHost)
-        self.setupHostLayout.setObjectName(u"setupHostLayout")
+        self.setupHostLayout.setObjectName("setupHostLayout")
         self.setupHostLayout.setContentsMargins(0, 0, 0, 0)
         self.rootSplitter.addWidget(self.setupHost)
         self.workbenchHost = QWidget(self.rootSplitter)
-        self.workbenchHost.setObjectName(u"workbenchHost")
+        self.workbenchHost.setObjectName("workbenchHost")
         self.workbenchHostLayout = QVBoxLayout(self.workbenchHost)
-        self.workbenchHostLayout.setObjectName(u"workbenchHostLayout")
+        self.workbenchHostLayout.setObjectName("workbenchHostLayout")
         self.workbenchHostLayout.setContentsMargins(0, 0, 0, 0)
         self.workbenchSplitter = QSplitter(self.workbenchHost)
-        self.workbenchSplitter.setObjectName(u"workbenchSplitter")
+        self.workbenchSplitter.setObjectName("workbenchSplitter")
         self.workbenchSplitter.setOrientation(Qt.Vertical)
         self.previewHost = QWidget(self.workbenchSplitter)
-        self.previewHost.setObjectName(u"previewHost")
+        self.previewHost.setObjectName("previewHost")
         self.previewHostLayout = QVBoxLayout(self.previewHost)
-        self.previewHostLayout.setObjectName(u"previewHostLayout")
+        self.previewHostLayout.setObjectName("previewHostLayout")
         self.previewHostLayout.setContentsMargins(0, 0, 0, 0)
         self.workbenchSplitter.addWidget(self.previewHost)
         self.inspectTabs = QTabWidget(self.workbenchSplitter)
-        self.inspectTabs.setObjectName(u"inspectTabs")
+        self.inspectTabs.setObjectName("inspectTabs")
         self.inspectTabs.setTabPosition(QTabWidget.North)
         self.resultsTab = QWidget()
-        self.resultsTab.setObjectName(u"resultsTab")
+        self.resultsTab.setObjectName("resultsTab")
         self.resultsHostLayout = QVBoxLayout(self.resultsTab)
-        self.resultsHostLayout.setObjectName(u"resultsHostLayout")
+        self.resultsHostLayout.setObjectName("resultsHostLayout")
         self.inspectTabs.addTab(self.resultsTab, "")
         self.residualsTab = QWidget()
-        self.residualsTab.setObjectName(u"residualsTab")
+        self.residualsTab.setObjectName("residualsTab")
         self.residualsHostLayout = QVBoxLayout(self.residualsTab)
-        self.residualsHostLayout.setObjectName(u"residualsHostLayout")
+        self.residualsHostLayout.setObjectName("residualsHostLayout")
         self.inspectTabs.addTab(self.residualsTab, "")
         self.timingsTab = QWidget()
-        self.timingsTab.setObjectName(u"timingsTab")
+        self.timingsTab.setObjectName("timingsTab")
         self.timingsHostLayout = QVBoxLayout(self.timingsTab)
-        self.timingsHostLayout.setObjectName(u"timingsHostLayout")
+        self.timingsHostLayout.setObjectName("timingsHostLayout")
         self.inspectTabs.addTab(self.timingsTab, "")
         self.logTab = QWidget()
-        self.logTab.setObjectName(u"logTab")
+        self.logTab.setObjectName("logTab")
         self.logHostLayout = QVBoxLayout(self.logTab)
-        self.logHostLayout.setObjectName(u"logHostLayout")
+        self.logHostLayout.setObjectName("logHostLayout")
         self.inspectTabs.addTab(self.logTab, "")
         self.workbenchSplitter.addWidget(self.inspectTabs)
 
@@ -190,7 +228,7 @@ class Ui_MainWindow(object):
 
         MainWindow.setCentralWidget(self.centralwidget)
         self.statusbar = QStatusBar(MainWindow)
-        self.statusbar.setObjectName(u"statusbar")
+        self.statusbar.setObjectName("statusbar")
         MainWindow.setStatusBar(self.statusbar)
 
         self.menubar.addAction(self.menuFile.menuAction())
@@ -225,69 +263,154 @@ class Ui_MainWindow(object):
         self.retranslateUi(MainWindow)
 
         QMetaObject.connectSlotsByName(MainWindow)
+
     # setupUi
 
     def retranslateUi(self, MainWindow):
-        MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"Menipy ADSA", None))
-        self.actionOpenImage.setText(QCoreApplication.translate("MainWindow", u"Open &Image\u2026", None))
-#if QT_CONFIG(shortcut)
-        self.actionOpenImage.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+O", None))
-#endif // QT_CONFIG(shortcut)
-        self.actionPreview.setText(QCoreApplication.translate("MainWindow", u"&Preview", None))
-#if QT_CONFIG(shortcut)
-        self.actionPreview.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+P", None))
-#endif // QT_CONFIG(shortcut)
-        self.actionExportCsv.setText(QCoreApplication.translate("MainWindow", u"Export &CSV\u2026", None))
-        self.actionOpenCamera.setText(QCoreApplication.translate("MainWindow", u"Open &Camera", None))
-        self.actionRunFull.setText(QCoreApplication.translate("MainWindow", u"Run &Full", None))
-#if QT_CONFIG(shortcut)
-        self.actionRunFull.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+R", None))
-#endif // QT_CONFIG(shortcut)
-        self.actionRunSelected.setText(QCoreApplication.translate("MainWindow", u"Run &Selected", None))
-#if QT_CONFIG(shortcut)
-        self.actionRunSelected.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+Shift+R", None))
-#endif // QT_CONFIG(shortcut)
-        self.actionStop.setText(QCoreApplication.translate("MainWindow", u"&Stop", None))
-        self.actionQuit.setText(QCoreApplication.translate("MainWindow", u"&Quit", None))
-#if QT_CONFIG(shortcut)
-        self.actionQuit.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+Q", None))
-#endif // QT_CONFIG(shortcut)
-        self.actionAbout.setText(QCoreApplication.translate("MainWindow", u"&About", None))
-        self.actionOverlay.setText(QCoreApplication.translate("MainWindow", u"&Overlay\u2026", None))
-#if QT_CONFIG(shortcut)
-        self.actionOverlay.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+Shift+O", None))
-#endif // QT_CONFIG(shortcut)
-#if QT_CONFIG(tooltip)
-        self.actionOverlay.setToolTip(QCoreApplication.translate("MainWindow", u"Open overlay configuration and preview overlay styling", None))
-#endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(statustip)
-        self.actionOverlay.setStatusTip(QCoreApplication.translate("MainWindow", u"Configure overlay appearance", None))
-#endif // QT_CONFIG(statustip)
-        self.actionConfigOverlay.setText(QCoreApplication.translate("MainWindow", u"Overlay Appearance\u2026", None))
-#if QT_CONFIG(shortcut)
-        self.actionConfigOverlay.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+Shift+O", None))
-#endif // QT_CONFIG(shortcut)
-        self.actionConfigMarkers.setText(QCoreApplication.translate("MainWindow", u"Marker Display\u2026", None))
-        self.actionConfigPipeline.setText(QCoreApplication.translate("MainWindow", u"Pipeline Settings\u2026", None))
-        self.actionConfigPreprocessing.setText(QCoreApplication.translate("MainWindow", u"Preprocessing\u2026", None))
-        self.actionConfigEdgeDetection.setText(QCoreApplication.translate("MainWindow", u"Edge Detection\u2026", None))
-        self.actionConfigGeometry.setText(QCoreApplication.translate("MainWindow", u"Geometry\u2026", None))
-        self.actionConfigPhysics.setText(QCoreApplication.translate("MainWindow", u"Physics\u2026", None))
-        self.actionConfigAcquisition.setText(QCoreApplication.translate("MainWindow", u"Acquisition\u2026", None))
-        self.menuFile.setTitle(QCoreApplication.translate("MainWindow", u"&File", None))
-        self.menuConfig.setTitle(QCoreApplication.translate("MainWindow", u"&Config", None))
-        self.menuView.setTitle(QCoreApplication.translate("MainWindow", u"&View", None))
-        self.menuRun.setTitle(QCoreApplication.translate("MainWindow", u"&Run", None))
-        self.menuPlugins.setTitle(QCoreApplication.translate("MainWindow", u"&Plugins", None))
-        self.menuHelp.setTitle(QCoreApplication.translate("MainWindow", u"&Help", None))
-        self.actionOpenImageBtn.setText(QCoreApplication.translate("MainWindow", u"Open Image", None))
-        self.workflowAutoCalibrateBtn.setText(QCoreApplication.translate("MainWindow", u"Auto-Calibrate", None))
-        self.actionRunBtn.setText(QCoreApplication.translate("MainWindow", u"Run Analysis", None))
-        self.actionExportCsvBtn.setText(QCoreApplication.translate("MainWindow", u"Export CSV", None))
-        self.workflowAdvancedBtn.setText(QCoreApplication.translate("MainWindow", u"Advanced +", None))
-        self.inspectTabs.setTabText(self.inspectTabs.indexOf(self.resultsTab), QCoreApplication.translate("MainWindow", u"Results", None))
-        self.inspectTabs.setTabText(self.inspectTabs.indexOf(self.residualsTab), QCoreApplication.translate("MainWindow", u"Residuals", None))
-        self.inspectTabs.setTabText(self.inspectTabs.indexOf(self.timingsTab), QCoreApplication.translate("MainWindow", u"Timings", None))
-        self.inspectTabs.setTabText(self.inspectTabs.indexOf(self.logTab), QCoreApplication.translate("MainWindow", u"Log", None))
-    # retranslateUi
+        MainWindow.setWindowTitle(
+            QCoreApplication.translate("MainWindow", "Menipy ADSA", None)
+        )
+        self.actionOpenImage.setText(
+            QCoreApplication.translate("MainWindow", "Open &Image\u2026", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.actionOpenImage.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+O", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.actionPreview.setText(
+            QCoreApplication.translate("MainWindow", "&Preview", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.actionPreview.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+P", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.actionExportCsv.setText(
+            QCoreApplication.translate("MainWindow", "Export &CSV\u2026", None)
+        )
+        self.actionOpenCamera.setText(
+            QCoreApplication.translate("MainWindow", "Open &Camera", None)
+        )
+        self.actionRunFull.setText(
+            QCoreApplication.translate("MainWindow", "Run &Full", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.actionRunFull.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+R", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.actionRunSelected.setText(
+            QCoreApplication.translate("MainWindow", "Run &Selected", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.actionRunSelected.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+Shift+R", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.actionStop.setText(QCoreApplication.translate("MainWindow", "&Stop", None))
+        self.actionQuit.setText(QCoreApplication.translate("MainWindow", "&Quit", None))
+        # if QT_CONFIG(shortcut)
+        self.actionQuit.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+Q", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.actionAbout.setText(
+            QCoreApplication.translate("MainWindow", "&About", None)
+        )
+        self.actionOverlay.setText(
+            QCoreApplication.translate("MainWindow", "&Overlay\u2026", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.actionOverlay.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+Shift+O", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        # if QT_CONFIG(tooltip)
+        self.actionOverlay.setToolTip(
+            QCoreApplication.translate(
+                "MainWindow",
+                "Open overlay configuration and preview overlay styling",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        # if QT_CONFIG(statustip)
+        self.actionOverlay.setStatusTip(
+            QCoreApplication.translate(
+                "MainWindow", "Configure overlay appearance", None
+            )
+        )
+        # endif // QT_CONFIG(statustip)
+        self.actionConfigOverlay.setText(
+            QCoreApplication.translate("MainWindow", "Overlay Appearance\u2026", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.actionConfigOverlay.setShortcut(
+            QCoreApplication.translate("MainWindow", "Ctrl+Shift+O", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.actionConfigMarkers.setText(
+            QCoreApplication.translate("MainWindow", "Marker Display\u2026", None)
+        )
+        self.actionConfigPipeline.setText(
+            QCoreApplication.translate("MainWindow", "Pipeline Settings\u2026", None)
+        )
+        self.actionConfigPreprocessing.setText(
+            QCoreApplication.translate("MainWindow", "Preprocessing\u2026", None)
+        )
+        self.actionConfigEdgeDetection.setText(
+            QCoreApplication.translate("MainWindow", "Edge Detection\u2026", None)
+        )
+        self.actionConfigGeometry.setText(
+            QCoreApplication.translate("MainWindow", "Geometry\u2026", None)
+        )
+        self.actionConfigPhysics.setText(
+            QCoreApplication.translate("MainWindow", "Physics\u2026", None)
+        )
+        self.actionConfigAcquisition.setText(
+            QCoreApplication.translate("MainWindow", "Acquisition\u2026", None)
+        )
+        self.menuFile.setTitle(QCoreApplication.translate("MainWindow", "&File", None))
+        self.menuConfig.setTitle(
+            QCoreApplication.translate("MainWindow", "&Config", None)
+        )
+        self.menuView.setTitle(QCoreApplication.translate("MainWindow", "&View", None))
+        self.menuRun.setTitle(QCoreApplication.translate("MainWindow", "&Run", None))
+        self.menuPlugins.setTitle(
+            QCoreApplication.translate("MainWindow", "&Plugins", None)
+        )
+        self.menuHelp.setTitle(QCoreApplication.translate("MainWindow", "&Help", None))
+        self.actionOpenImageBtn.setText(
+            QCoreApplication.translate("MainWindow", "Open Image", None)
+        )
+        self.workflowAutoCalibrateBtn.setText(
+            QCoreApplication.translate("MainWindow", "Auto-Calibrate", None)
+        )
+        self.actionRunBtn.setText(
+            QCoreApplication.translate("MainWindow", "Run Analysis", None)
+        )
+        self.actionExportCsvBtn.setText(
+            QCoreApplication.translate("MainWindow", "Export CSV", None)
+        )
+        self.workflowAdvancedBtn.setText(
+            QCoreApplication.translate("MainWindow", "Advanced +", None)
+        )
+        self.inspectTabs.setTabText(
+            self.inspectTabs.indexOf(self.resultsTab),
+            QCoreApplication.translate("MainWindow", "Results", None),
+        )
+        self.inspectTabs.setTabText(
+            self.inspectTabs.indexOf(self.residualsTab),
+            QCoreApplication.translate("MainWindow", "Residuals", None),
+        )
+        self.inspectTabs.setTabText(
+            self.inspectTabs.indexOf(self.timingsTab),
+            QCoreApplication.translate("MainWindow", "Timings", None),
+        )
+        self.inspectTabs.setTabText(
+            self.inspectTabs.indexOf(self.logTab),
+            QCoreApplication.translate("MainWindow", "Log", None),
+        )
 
+    # retranslateUi

--- a/src/menipy/gui/widgets/__init__.py
+++ b/src/menipy/gui/widgets/__init__.py
@@ -1,4 +1,5 @@
 """Widgets package for ADSA UI."""
+
 from menipy.gui.widgets.experiment_card import (
     ExperimentCard,
     EXPERIMENT_DEFINITIONS,

--- a/src/menipy/gui/widgets/experiment_card.py
+++ b/src/menipy/gui/widgets/experiment_card.py
@@ -3,10 +3,15 @@ Experiment Card Widget
 
 A clickable card widget representing an experiment type in the selector screen.
 """
+
 from PySide6.QtCore import Qt, Signal, QPropertyAnimation, QEasingCurve, Property
 from PySide6.QtGui import QFont, QColor, QPainter, QPainterPath
 from PySide6.QtWidgets import (
-    QFrame, QVBoxLayout, QLabel, QPushButton, QGraphicsDropShadowEffect
+    QFrame,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QGraphicsDropShadowEffect,
 )
 
 from menipy.gui import theme
@@ -15,20 +20,20 @@ from menipy.gui import theme
 class ExperimentCard(QFrame):
     """
     A card widget displaying an experiment type with icon, title, and description.
-    
+
     Signals:
         selected: Emitted when the card is clicked, with the experiment type string.
     """
-    
+
     selected = Signal(str)
-    
+
     def __init__(
         self,
         experiment_type: str,
         title: str,
         description: str,
         icon: str = "💧",
-        parent=None
+        parent=None,
     ):
         """Initialize.
 
@@ -49,29 +54,29 @@ class ExperimentCard(QFrame):
         self.experiment_type = experiment_type
         self._hover = False
         self._elevation = 0
-        
+
         self.setObjectName("experimentCard")
         self.setProperty("class", "experiment-card")
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setFixedSize(240, 280)
-        
+
         self._setup_ui(icon, title, description)
         self._setup_shadow()
         self._setup_animations()
-    
+
     def _setup_ui(self, icon: str, title: str, description: str):
         """Set up the card UI components."""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(12)
-        
+
         # Icon label
         self.icon_label = QLabel(icon)
         self.icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         icon_font = QFont(theme.FONT_FAMILY, 48)
         self.icon_label.setFont(icon_font)
         layout.addWidget(self.icon_label)
-        
+
         # Illustration placeholder (could be replaced with actual graphics)
         self.illustration_frame = QFrame()
         self.illustration_frame.setFixedHeight(60)
@@ -80,7 +85,7 @@ class ExperimentCard(QFrame):
             border-radius: 8px;
         """)
         layout.addWidget(self.illustration_frame)
-        
+
         # Title
         self.title_label = QLabel(title)
         self.title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -89,23 +94,23 @@ class ExperimentCard(QFrame):
         self.title_label.setFont(title_font)
         self.title_label.setStyleSheet(f"color: {theme.TEXT_PRIMARY};")
         layout.addWidget(self.title_label)
-        
+
         # Description
         self.description_label = QLabel(description)
         self.description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.description_label.setWordWrap(True)
         self.description_label.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         layout.addWidget(self.description_label)
-        
+
         # Spacer
         layout.addStretch()
-        
+
         # Select button
         self.select_button = QPushButton("Select →")
         self.select_button.setCursor(Qt.CursorShape.PointingHandCursor)
         self.select_button.clicked.connect(self._on_select)
         layout.addWidget(self.select_button)
-    
+
     def _setup_shadow(self):
         """Set up the drop shadow effect for elevation."""
         self.shadow = QGraphicsDropShadowEffect(self)
@@ -113,24 +118,24 @@ class ExperimentCard(QFrame):
         self.shadow.setBlurRadius(20)
         self.shadow.setOffset(0, 4)
         self.setGraphicsEffect(self.shadow)
-    
+
     def _setup_animations(self):
         """Set up hover animations."""
         self._elevation_animation = QPropertyAnimation(self, b"elevation")
         self._elevation_animation.setDuration(theme.TRANSITION_DURATION_MS)
         self._elevation_animation.setEasingCurve(QEasingCurve.Type.OutCubic)
-    
+
     def _get_elevation(self) -> int:
         return self._elevation
-    
+
     def _set_elevation(self, value: int):
         self._elevation = value
         self.shadow.setBlurRadius(20 + value)
         self.shadow.setOffset(0, 4 + value // 2)
         self.update()
-    
+
     elevation = Property(int, _get_elevation, _set_elevation)
-    
+
     def enterEvent(self, event):
         """Handle mouse enter - show hover state."""
         self._hover = True
@@ -140,7 +145,7 @@ class ExperimentCard(QFrame):
         self._elevation_animation.start()
         self._update_style()
         super().enterEvent(event)
-    
+
     def leaveEvent(self, event):
         """Handle mouse leave - remove hover state."""
         self._hover = False
@@ -150,13 +155,13 @@ class ExperimentCard(QFrame):
         self._elevation_animation.start()
         self._update_style()
         super().leaveEvent(event)
-    
+
     def mousePressEvent(self, event):
         """Handle mouse click on card."""
         if event.button() == Qt.MouseButton.LeftButton:
             self._on_select()
         super().mousePressEvent(event)
-    
+
     def _update_style(self):
         """Update the card style based on hover state."""
         border_color = theme.ACCENT_BLUE if self._hover else theme.BORDER_DEFAULT
@@ -167,7 +172,7 @@ class ExperimentCard(QFrame):
                 border-radius: 12px;
             }}
         """)
-    
+
     def _on_select(self):
         """Handle selection of this experiment type."""
         self.selected.emit(self.experiment_type)
@@ -217,11 +222,11 @@ EXPERIMENT_DEFINITIONS = [
 def create_experiment_card(experiment_type: str, parent=None) -> ExperimentCard:
     """
     Factory function to create an experiment card from a type string.
-    
+
     Args:
         experiment_type: One of the EXPERIMENT_* constants from theme.
         parent: Parent widget.
-    
+
     Returns:
         Configured ExperimentCard widget.
     """
@@ -232,6 +237,6 @@ def create_experiment_card(experiment_type: str, parent=None) -> ExperimentCard:
                 title=defn["title"],
                 description=defn["description"],
                 icon=defn["icon"],
-                parent=parent
+                parent=parent,
             )
     raise ValueError(f"Unknown experiment type: {experiment_type}")

--- a/src/menipy/gui/widgets/interactive_image_viewer.py
+++ b/src/menipy/gui/widgets/interactive_image_viewer.py
@@ -4,10 +4,16 @@ Interactive Image Viewer
 A widget for displaying images with interactive tool support (zooming, panning,
 drawing lines/ROIs).
 """
+
 from PySide6.QtCore import Qt, Signal, QPointF, QRectF, QSize
 from PySide6.QtGui import QPixmap, QPainter, QPen, QColor, QWheelEvent, QMouseEvent
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QScrollArea, QLabel, QFrame, QSizePolicy
+    QWidget,
+    QVBoxLayout,
+    QScrollArea,
+    QLabel,
+    QFrame,
+    QSizePolicy,
 )
 
 from menipy.gui import theme
@@ -16,30 +22,30 @@ from menipy.gui import theme
 class InteractiveImageViewer(QWidget):
     """
     Image viewer that supports zoom, pan, and interactive drawing tools.
-    
+
     Tools:
         - None: Navigation only (pan/zoom)
     - Line: Draw a line (click point A, drag/click point B)
     - Rect: Draw a rectangle (not yet implemented)
-    
+
     Signals:
         line_drawn(start_point, end_point, distance_px): Emitted when a line is drawn
         clicked(point): Emitted on click
     """
-    
+
     line_drawn = Signal(QPointF, QPointF, float)
     clicked = Signal(QPointF)
     overlay_painted = Signal(object, object, float)  # painter, visible_rect, zoom
-    
+
     TOOL_NONE = "none"
     TOOL_LINE = "line"
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._pixmap: QPixmap | None = None
         self._zoom = 1.0
         self._tool = self.TOOL_NONE
-        
+
         # Interaction state
         self._last_mouse_pos = QPointF()
         self._is_panning = False
@@ -47,14 +53,14 @@ class InteractiveImageViewer(QWidget):
         self._draw_start = QPointF()
         self._draw_current = QPointF()
         self._static_line: tuple[QPointF, QPointF] | None = None
-        
+
         self.setMouseTracking(True)
         self._setup_ui()
-        
+
     def _setup_ui(self):
         """Set up the UI components."""
         self.setStyleSheet(f"background-color: {theme.BG_TERTIARY};")
-        
+
         # We draw directly on the widget, so no layout needed for basics,
         # but we use a specialized paint event.
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
@@ -63,7 +69,7 @@ class InteractiveImageViewer(QWidget):
         """Set a static line to display (e.g. from auto-detect)."""
         self._static_line = (p1, p2)
         self.update()
-        
+
     def set_image(self, pixmap: QPixmap | None):
         """Set the image to display."""
         self._pixmap = pixmap
@@ -71,7 +77,7 @@ class InteractiveImageViewer(QWidget):
             # Reset view to fit
             self.fit_to_view()
         self.update()
-        
+
     def set_tool(self, tool: str):
         """Set the active tool."""
         self._tool = tool
@@ -79,100 +85,109 @@ class InteractiveImageViewer(QWidget):
             self.setCursor(Qt.CursorShape.CrossCursor)
         else:
             self.setCursor(Qt.CursorShape.ArrowCursor)
-            
+
     def set_zoom(self, zoom: float):
         """Set zoom level manually."""
         self._zoom = max(0.1, min(20.0, zoom))
         self.update()
-        
+
     def fit_to_view(self):
         """Fit image to current widget size."""
-        if self._pixmap and not self._pixmap.isNull() and self.width() > 0 and self.height() > 0:
+        if (
+            self._pixmap
+            and not self._pixmap.isNull()
+            and self.width() > 0
+            and self.height() > 0
+        ):
             w_ratio = self.width() / self._pixmap.width()
             h_ratio = self.height() / self._pixmap.height()
             self._zoom = min(w_ratio, h_ratio) * 0.95
-            
+
             # Center image
             self._view_offset = QPointF(
                 (self.width() - self._pixmap.width() * self._zoom) / 2,
-                (self.height() - self._pixmap.height() * self._zoom) / 2
+                (self.height() - self._pixmap.height() * self._zoom) / 2,
             )
             self.update()
-            
+
     # -------------------------------------------------------------------------
     # Event Handlers
     # -------------------------------------------------------------------------
-    
+
     def paintEvent(self, event):
         """Custom paint event."""
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
         painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
-        
+
         # Draw background
         painter.fillRect(self.rect(), QColor(theme.BG_TERTIARY))
-        
+
         if self._pixmap and not self._pixmap.isNull():
             # Apply transforms
             # For simplicity, we calculate target rect
             # We assume zooming is centered or handled via simple scaling for now
             # A proper implementation would handle offset (pan) + zoom
-            
+
             # Use stored offset if we have panning logic, otherwise center
-            if not hasattr(self, '_view_offset'):
+            if not hasattr(self, "_view_offset"):
                 self.fit_to_view()
-                
+
             # Draw image
             target_rect = QRectF(
                 self._view_offset.x(),
                 self._view_offset.y(),
                 self._pixmap.width() * self._zoom,
-                self._pixmap.height() * self._zoom
+                self._pixmap.height() * self._zoom,
             )
             painter.drawPixmap(target_rect.toRect(), self._pixmap)
-            
+
             # Emit overlay signal
             self.overlay_painted.emit(painter, target_rect, self._zoom)
-            
+
             # Draw active drawing (e.g. line being dragged)
             if self._is_drawing and self._tool == self.TOOL_LINE:
                 pen = QPen(QColor(theme.ACCENT_BLUE))
                 pen.setWidth(2)
                 painter.setPen(pen)
                 painter.drawLine(self._draw_start, self._draw_current)
-                
+
                 # Draw coordinates text
                 dist_px = self._image_dist(self._draw_start, self._draw_current)
                 mid = (self._draw_start + self._draw_current) / 2
                 painter.drawText(mid.toPoint(), f"{dist_px:.1f} px")
-                
+
             elif self._static_line is not None and self._tool == self.TOOL_LINE:
                 # Draw static line (stored in IMAGE coordinates)
                 p1_img, p2_img = self._static_line
-                
+
                 # Transform to view coordinates
                 p1 = self._view_offset + p1_img * self._zoom
                 p2 = self._view_offset + p2_img * self._zoom
-                
+
                 pen = QPen(QColor(theme.ACCENT_BLUE))
                 pen.setWidth(2)
                 pen.setStyle(Qt.PenStyle.DashLine)
                 painter.setPen(pen)
                 painter.drawLine(p1, p2)
-                
+
                 # Distance is just the length in image coords (which is what we want)
-                dist_px = ((p1_img.x() - p2_img.x())**2 + (p1_img.y() - p2_img.y())**2)**0.5
+                dist_px = (
+                    (p1_img.x() - p2_img.x()) ** 2 + (p1_img.y() - p2_img.y()) ** 2
+                ) ** 0.5
                 mid = (p1 + p2) / 2
                 painter.drawText(mid.toPoint(), f"{dist_px:.1f} px")
 
         else:
             painter.setPen(QColor(theme.TEXT_SECONDARY))
-            painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, "No Image Loaded")
+            painter.drawText(
+                self.rect(), Qt.AlignmentFlag.AlignCenter, "No Image Loaded"
+            )
 
     def mousePressEvent(self, event: QMouseEvent):
         if not self._pixmap:
             return
-            
+
         if event.button() == Qt.MouseButton.LeftButton:
             if self._tool == self.TOOL_LINE:
                 self._is_drawing = True
@@ -183,7 +198,7 @@ class InteractiveImageViewer(QWidget):
                 self._is_panning = True
                 self._last_mouse_pos = event.position()
                 self.setCursor(Qt.CursorShape.ClosedHandCursor)
-                
+
     def mouseMoveEvent(self, event: QMouseEvent):
         if self._is_drawing:
             self._draw_current = event.position()
@@ -193,7 +208,7 @@ class InteractiveImageViewer(QWidget):
             self._last_mouse_pos = event.position()
             self._view_offset += delta
             self.update()
-            
+
     def mouseReleaseEvent(self, event: QMouseEvent):
         """mouseReleaseEvent.
 
@@ -207,14 +222,14 @@ class InteractiveImageViewer(QWidget):
                 self._is_drawing = False
                 self._draw_current = event.position()
                 self.update()
-                
+
                 # Emit result mapped to image coordinates?
                 # For simplicity, sending widget coords involves complexity in receiver.
                 # Let's send PIXEL distance on image.
                 dist = self._image_dist(self._draw_start, self._draw_current)
                 if dist > 0:
                     self.line_drawn.emit(self._draw_start, self._draw_current, dist)
-                    
+
             elif self._is_panning:
                 self._is_panning = False
                 self.setCursor(Qt.CursorShape.ArrowCursor)
@@ -223,18 +238,18 @@ class InteractiveImageViewer(QWidget):
         """Handle zoom."""
         if not self._pixmap:
             return
-            
+
         delta = event.angleDelta().y()
         factor = 1.1 if delta > 0 else 0.9
-        
+
         # Zoom centered on cursor would be better, but center is safer for MVP
         self._zoom *= factor
         self._zoom = max(0.1, min(20.0, self._zoom))
-        
+
         # Adjust offset to keep center?
         # For now, simple zoom
         self.update()
-        
+
     def zoom_in(self):
         """Zoom in."""
         self.set_zoom(self._zoom * 1.25)
@@ -242,12 +257,12 @@ class InteractiveImageViewer(QWidget):
     def zoom_out(self):
         """Zoom out."""
         self.set_zoom(self._zoom / 1.25)
-        
+
     def reset_view(self):
         """Reset zoom and fit."""
         self.fit_to_view()
 
     def _image_dist(self, p1: QPointF, p2: QPointF) -> float:
         """Calculate distance in IMAGE pixels (accounting for zoom)."""
-        widget_dist = ((p1.x() - p2.x())**2 + (p1.y() - p2.y())**2)**0.5
+        widget_dist = ((p1.x() - p2.x()) ** 2 + (p1.y() - p2.y()) ** 2) ** 0.5
         return widget_dist / self._zoom

--- a/src/menipy/gui/widgets/measurements_table.py
+++ b/src/menipy/gui/widgets/measurements_table.py
@@ -3,9 +3,14 @@ Measurements Table Widget
 
 A table to display analysis results.
 """
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem, QHeaderView
+    QWidget,
+    QVBoxLayout,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
 )
 
 from menipy.gui import theme
@@ -13,7 +18,7 @@ from menipy.gui import theme
 
 class MeasurementsTableWidget(QWidget):
     """Table widget for displaying measurement results."""
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -24,18 +29,27 @@ class MeasurementsTableWidget(QWidget):
         """
         super().__init__(parent)
         self._setup_ui()
-        
+
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         self._table = QTableWidget()
         self._table.setColumnCount(9)
-        self._table.setHorizontalHeaderLabels([
-            "ID", "θ_L (°)", "θ_R (°)", "θ_M (°)",
-            "Vol (µL)", "Area (mm²)", "Radius (mm)", "Height (mm)", "Fit Error"
-        ])
-        
+        self._table.setHorizontalHeaderLabels(
+            [
+                "ID",
+                "θ_L (°)",
+                "θ_R (°)",
+                "θ_M (°)",
+                "Vol (µL)",
+                "Area (mm²)",
+                "Radius (mm)",
+                "Height (mm)",
+                "Fit Error",
+            ]
+        )
+
         # Styling
         self._table.setStyleSheet(f"""
             QTableWidget {{
@@ -58,53 +72,53 @@ class MeasurementsTableWidget(QWidget):
                 color: white;
             }}
         """)
-        
+
         # Adjust headers
         header = self._table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
         header.setStretchLastSection(True)
-        
+
         self._table.verticalHeader().setVisible(False)
         self._table.setAlternatingRowColors(True)
         self._table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self._table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
-        
+
         layout.addWidget(self._table)
-        
+
     def add_result(self, data: dict):
         """Add a result row to the table."""
         row_idx = self._table.rowCount()
         self._table.insertRow(row_idx)
-        
+
         # Extract values with safe defaults
         # Assuming data keys from simulate_analysis or real pipeline
-        
+
         # ID/Frame
         frame_id = str(data.get("frame_index", row_idx + 1))
-        
+
         # Angles
         th_l = f"{data.get('angle_left', 0):.1f}"
         th_r = f"{data.get('angle_right', 0):.1f}"
         th_m = f"{data.get('angle_mean', 0):.1f}"
-        
+
         # Geometry
         vol = f"{data.get('volume', 0):.3f}"
         area = f"{data.get('surface_area', 0):.2f}"
         radius = f"{data.get('contact_radius', 0):.3f}"
         height = f"{data.get('height', 0):.3f}"
-        
+
         # Error
         error = f"{data.get('fit_error', 0):.4f}"
-        
+
         items = [frame_id, th_l, th_r, th_m, vol, area, radius, height, error]
-        
+
         for col_idx, text in enumerate(items):
             item = QTableWidgetItem(text)
             item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self._table.setItem(row_idx, col_idx, item)
-            
+
         self._table.scrollToBottom()
-        
+
     def clear(self):
         """Clear table."""
         self._table.setRowCount(0)

--- a/src/menipy/gui/widgets/notification.py
+++ b/src/menipy/gui/widgets/notification.py
@@ -3,8 +3,16 @@ Notification Widget
 
 Premium toast-style notifications.
 """
+
 from PySide6.QtCore import Qt, QTimer, QPropertyAnimation, QEasingCurve, QPoint
-from PySide6.QtWidgets import QWidget, QLabel, QHBoxLayout, QVBoxLayout, QGraphicsOpacityEffect, QPushButton
+from PySide6.QtWidgets import (
+    QWidget,
+    QLabel,
+    QHBoxLayout,
+    QVBoxLayout,
+    QGraphicsOpacityEffect,
+    QPushButton,
+)
 
 from menipy.gui import theme
 
@@ -14,12 +22,12 @@ class NotificationToast(QWidget):
     Floating notification toast.
     Autoclose after duration.
     """
-    
+
     TYPE_INFO = "info"
     TYPE_SUCCESS = "success"
     TYPE_WARNING = "warning"
     TYPE_ERROR = "error"
-    
+
     def __init__(self, parent=None, text="", n_type="info", duration=3000):
         """Initialize.
 
@@ -38,34 +46,34 @@ class NotificationToast(QWidget):
         self.setWindowFlags(Qt.WindowType.FramelessWindowHint | Qt.WindowType.SubWindow)
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, False)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
-        
+
         self._setup_ui(text, n_type)
-        
+
         # Animation
         self._opacity = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self._opacity)
-        
+
         self._anim = QPropertyAnimation(self._opacity, b"opacity")
         self._anim.setDuration(300)
         self._anim.setStartValue(0.0)
         self._anim.setEndValue(1.0)
         self._anim.setEasingCurve(QEasingCurve.Type.OutCubic)
         self._anim.start()
-        
+
         # Timer
         if duration > 0:
             QTimer.singleShot(duration, self.close_toast)
-            
+
     def _setup_ui(self, text, n_type):
         """Set up UI based on type."""
         colors = {
             self.TYPE_INFO: theme.ACCENT_BLUE,
             self.TYPE_SUCCESS: theme.SUCCESS_GREEN,
             self.TYPE_WARNING: theme.WARNING_ORANGE,
-            self.TYPE_ERROR: theme.ERROR_RED
+            self.TYPE_ERROR: theme.ERROR_RED,
         }
         color = colors.get(n_type, theme.ACCENT_BLUE)
-        
+
         self.setStyleSheet(f"""
             QWidget {{
                 background-color: {theme.BG_SECONDARY};
@@ -77,28 +85,28 @@ class NotificationToast(QWidget):
                 border: none;
             }}
         """)
-        
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(16, 12, 16, 12)
         layout.setSpacing(12)
-        
+
         # Icon (text based for now)
         icons = {
             self.TYPE_INFO: "ℹ️",
             self.TYPE_SUCCESS: "✓",
             self.TYPE_WARNING: "⚠️",
-            self.TYPE_ERROR: "❌"
+            self.TYPE_ERROR: "❌",
         }
         icon_lbl = QLabel(icons.get(n_type, "i"))
         icon_lbl.setStyleSheet("font-size: 18px; border: none;")
         layout.addWidget(icon_lbl)
-        
+
         # Text
         msg_lbl = QLabel(text)
         msg_lbl.setStyleSheet(f"font-size: {theme.FONT_SIZE_NORMAL}px; border: none;")
         msg_lbl.setWordWrap(True)
         layout.addWidget(msg_lbl, stretch=1)
-        
+
         # Close button
         close_btn = QPushButton("✕")
         close_btn.setFixedSize(20, 20)
@@ -116,10 +124,10 @@ class NotificationToast(QWidget):
         """)
         close_btn.clicked.connect(self.close_toast)
         layout.addWidget(close_btn)
-        
+
         # Shadow via QSS on parent usually, or just simple border
         # Adding a border to this widget
-        
+
     def close_toast(self):
         """Fade out and close."""
         self._anim.setDirection(QPropertyAnimation.Direction.Backward)
@@ -129,30 +137,30 @@ class NotificationToast(QWidget):
 
 class NotificationManager:
     """Helper to manage notifications on a window."""
-    
+
     def __init__(self, parent_widget):
         self.parent = parent_widget
         self._toasts = []
-        
+
     def show(self, text, n_type="info", duration=3000):
         """Show a notification."""
         toast = NotificationToast(self.parent, text, n_type, duration)
-        
+
         # Position logic
         # Bottom right, stacking up
         margin = 20
         start_y = self.parent.height() - margin
-        
+
         target_y = start_y - toast.sizeHint().height()
-        
+
         # Ideally calculate stack position, for now just simple absolute
         # Just show one at a time or overlay logic needed
         # Simple for now: Center bottom
-        
+
         toast.resize(300, toast.sizeHint().height())
         x = (self.parent.width() - toast.width()) // 2
         y = self.parent.height() - 80
-        
+
         toast.move(x, y)
         toast.show()
         toast.raise_()

--- a/src/menipy/gui/widgets/pendant_results_widget.py
+++ b/src/menipy/gui/widgets/pendant_results_widget.py
@@ -4,10 +4,16 @@ Pendant Results Widget
 Widget displaying pendant drop specific results including surface tension,
 Bond number, and drop shape parameters.
 """
+
 from PySide6.QtCore import Qt
 import math
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame, QGridLayout
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QGridLayout,
 )
 
 from menipy.gui import theme
@@ -16,20 +22,20 @@ from menipy.gui import theme
 class PendantResultsWidget(QFrame):
     """
     Widget showing pendant drop measurement results.
-    
+
     Displays:
         - Surface/Interfacial tension (primary result)
     - Bond number
     - Drop shape parameters (De, Ds, apex radius)
     - Confidence indicator
     """
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("pendantResultsWidget")
         self._setup_ui()
         self._reset_display()
-    
+
     def _setup_ui(self):
         """Set up the widget UI."""
         self.setStyleSheet(f"""
@@ -39,11 +45,11 @@ class PendantResultsWidget(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel("Measurement Results")
         header.setStyleSheet(f"""
@@ -52,7 +58,7 @@ class PendantResultsWidget(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Primary result - Surface Tension
         st_section = QFrame()
         st_section.setObjectName("surfaceTensionSection")
@@ -66,12 +72,12 @@ class PendantResultsWidget(QFrame):
         st_layout = QVBoxLayout(st_section)
         st_layout.setContentsMargins(12, 12, 12, 12)
         st_layout.setSpacing(4)
-        
+
         st_title = QLabel("Surface Tension")
         # Use simple hex with opacity if needed, or just semi-transparent white
         st_title.setStyleSheet("color: #E6FFFFFF; font-weight: bold;")
         st_layout.addWidget(st_title)
-        
+
         self._surface_tension_label = QLabel("--")
         self._surface_tension_label.setStyleSheet(f"""
             color: white;
@@ -80,23 +86,25 @@ class PendantResultsWidget(QFrame):
             font-weight: bold;
         """)
         st_layout.addWidget(self._surface_tension_label)
-        
+
         self._st_uncertainty_label = QLabel("")
-        self._st_uncertainty_label.setStyleSheet(f"color: #B3FFFFFF; font-family: \"{theme.FONT_FAMILY}\";")
+        self._st_uncertainty_label.setStyleSheet(
+            f'color: #B3FFFFFF; font-family: "{theme.FONT_FAMILY}";'
+        )
         st_layout.addWidget(self._st_uncertainty_label)
-        
+
         layout.addWidget(st_section)
-        
+
         # Shape Parameters section
         shape_section = self._create_section("📐 Shape Parameters")
         shape_grid = QGridLayout()
         shape_grid.setSpacing(8)
-        
+
         self._de_label = self._create_value_label()
         self._ds_label = self._create_value_label()
         self._apex_label = self._create_value_label()
         self._bond_label = self._create_value_label()
-        
+
         shape_grid.addWidget(QLabel("De (equator):"), 0, 0)
         shape_grid.addWidget(self._de_label, 0, 1)
         shape_grid.addWidget(QLabel("Ds (at De):"), 1, 0)
@@ -105,52 +113,52 @@ class PendantResultsWidget(QFrame):
         shape_grid.addWidget(self._apex_label, 2, 1)
         shape_grid.addWidget(QLabel("Bond Number:"), 3, 0)
         shape_grid.addWidget(self._bond_label, 3, 1)
-        
+
         shape_section.layout().addLayout(shape_grid)
         layout.addWidget(shape_section)
-        
+
         # Physical Properties section
         props_section = self._create_section("🧪 Physical Properties")
         props_grid = QGridLayout()
         props_grid.setSpacing(8)
-        
+
         self._volume_label = self._create_value_label()
         self._area_label = self._create_value_label()
         self._density_diff_label = self._create_value_label()
-        
+
         props_grid.addWidget(QLabel("Drop Volume:"), 0, 0)
         props_grid.addWidget(self._volume_label, 0, 1)
         props_grid.addWidget(QLabel("Surface Area:"), 1, 0)
         props_grid.addWidget(self._area_label, 1, 1)
         props_grid.addWidget(QLabel("Δρ:"), 2, 0)
         props_grid.addWidget(self._density_diff_label, 2, 1)
-        
+
         props_section.layout().addLayout(props_grid)
         layout.addWidget(props_section)
-        
+
         # Fit Quality section
         fit_section = self._create_section("📊 Fit Quality")
         fit_grid = QGridLayout()
         fit_grid.setSpacing(8)
-        
+
         self._rmse_label = self._create_value_label()
         self._iterations_label = self._create_value_label()
-        
+
         fit_grid.addWidget(QLabel("RMSE:"), 0, 0)
         fit_grid.addWidget(self._rmse_label, 0, 1)
         fit_grid.addWidget(QLabel("Iterations:"), 1, 0)
         fit_grid.addWidget(self._iterations_label, 1, 1)
-        
+
         fit_section.layout().addLayout(fit_grid)
         layout.addWidget(fit_section)
-        
+
         # Confidence indicator
         self._confidence_label = QLabel()
         self._confidence_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._confidence_label)
-        
+
         layout.addStretch()
-    
+
     def _create_section(self, title: str) -> QFrame:
         """Create a section with a title."""
         section = QFrame()
@@ -161,27 +169,29 @@ class PendantResultsWidget(QFrame):
                 padding: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(section)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
-        
+
         title_label = QLabel(title)
         title_label.setStyleSheet(f"""
             color: {theme.TEXT_PRIMARY};
             font-weight: bold;
         """)
         layout.addWidget(title_label)
-        
+
         return section
-    
+
     def _create_value_label(self) -> QLabel:
         """Create a styled value label."""
         label = QLabel("--")
-        label.setStyleSheet(f"color: {theme.TEXT_PRIMARY}; font-family: \"{theme.FONT_FAMILY}\"; font-size: {theme.FONT_SIZE_LARGE}px;")
+        label.setStyleSheet(
+            f'color: {theme.TEXT_PRIMARY}; font-family: "{theme.FONT_FAMILY}"; font-size: {theme.FONT_SIZE_LARGE}px;'
+        )
         label.setAlignment(Qt.AlignmentFlag.AlignRight)
         return label
-    
+
     def _reset_display(self):
         """Reset all values to default."""
         self._surface_tension_label.setText("--")
@@ -196,13 +206,13 @@ class PendantResultsWidget(QFrame):
         self._rmse_label.setText("--")
         self._iterations_label.setText("--")
         self._set_confidence(None)
-    
+
     def _set_confidence(self, confidence: float | None):
         """Set the confidence indicator."""
         if confidence is None:
             self._confidence_label.setText("")
             return
-        
+
         if confidence >= 90:
             color = theme.SUCCESS_GREEN
             icon = "✓"
@@ -215,18 +225,20 @@ class PendantResultsWidget(QFrame):
             color = theme.ERROR_RED
             icon = "❌"
             level = "Low"
-        
-        self._confidence_label.setText(f"{icon} Fit Confidence: {level} ({confidence:.0f}%)")
+
+        self._confidence_label.setText(
+            f"{icon} Fit Confidence: {level} ({confidence:.0f}%)"
+        )
         self._confidence_label.setStyleSheet(f"color: {color}; font-weight: bold;")
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_results(self, results: dict):
         """
         Set measurement results.
-        
+
         Args:
             results: Dictionary with measurement values:
                 - surface_tension: Surface tension (mN/m)
@@ -276,11 +288,11 @@ class PendantResultsWidget(QFrame):
                 self._surface_tension_label.setText(f"γ = {st:.2f} mN/m")
             else:
                 self._surface_tension_label.setText("γ = --")
-            
+
             if "surface_tension_uncertainty" in results:
                 unc = results["surface_tension_uncertainty"]
                 self._st_uncertainty_label.setText(f"± {unc:.2f} mN/m")
-        
+
             # Shape parameters
             if val := fmt(results.get("de"), "{:.3f} mm"):
                 self._de_label.setText(val)
@@ -290,7 +302,7 @@ class PendantResultsWidget(QFrame):
                 self._apex_label.setText(val)
             if val := fmt(results.get("bond_number"), "{:.4f}"):
                 self._bond_label.setText(val)
-        
+
             # Physical properties
             if val := fmt(results.get("volume"), "{:.2f} μL"):
                 self._volume_label.setText(val)
@@ -298,16 +310,16 @@ class PendantResultsWidget(QFrame):
                 self._area_label.setText(val)
             if val := fmt(results.get("density_diff"), "{:.1f} kg/m³"):
                 self._density_diff_label.setText(val)
-        
+
             # Fit quality
             if val := fmt(results.get("rmse"), "{:.4f}"):
                 self._rmse_label.setText(val)
             if val := fmt(results.get("iterations"), "{}"):
                 self._iterations_label.setText(val)
-        
+
             # Confidence
             self._set_confidence(results.get("confidence"))
-    
+
     def clear(self):
         """Clear all displayed results."""
         self._reset_display()

--- a/src/menipy/gui/widgets/quick_stats_widget.py
+++ b/src/menipy/gui/widgets/quick_stats_widget.py
@@ -4,9 +4,15 @@ Quick Stats Widget
 Card-style widget displaying the current measurement summary.
 Shows contact angles, drop properties, surface tension, and confidence.
 """
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame, QGridLayout
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QGridLayout,
 )
 
 from menipy.gui import theme
@@ -15,14 +21,14 @@ from menipy.gui import theme
 class QuickStatsWidget(QFrame):
     """
     Card widget showing current measurement results.
-    
+
     Displays:
         - Contact angles (left, right, mean with uncertainty)
     - Drop properties (volume, diameter, height, base width)
     - Surface tension
     - Confidence indicator
     """
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -35,7 +41,7 @@ class QuickStatsWidget(QFrame):
         self.setObjectName("quickStatsWidget")
         self._setup_ui()
         self._reset_display()
-    
+
     def _setup_ui(self):
         """Set up the widget UI."""
         self.setStyleSheet(f"""
@@ -45,11 +51,11 @@ class QuickStatsWidget(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel("Current Measurement")
         header.setStyleSheet(f"""
@@ -58,36 +64,36 @@ class QuickStatsWidget(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Contact Angles section
         angles_section = self._create_section("📐 Contact Angles")
         angles_grid = QGridLayout()
         angles_grid.setSpacing(4)
-        
+
         self._angle_left_label = self._create_value_label()
         self._angle_right_label = self._create_value_label()
         self._angle_mean_label = self._create_value_label()
-        
+
         angles_grid.addWidget(QLabel("Left:"), 0, 0)
         angles_grid.addWidget(self._angle_left_label, 0, 1)
         angles_grid.addWidget(QLabel("Right:"), 1, 0)
         angles_grid.addWidget(self._angle_right_label, 1, 1)
         angles_grid.addWidget(QLabel("Mean:"), 2, 0)
         angles_grid.addWidget(self._angle_mean_label, 2, 1)
-        
+
         angles_section.layout().addLayout(angles_grid)
         layout.addWidget(angles_section)
-        
+
         # Drop Properties section
         props_section = self._create_section("💧 Drop Properties")
         props_grid = QGridLayout()
         props_grid.setSpacing(4)
-        
+
         self._volume_label = self._create_value_label()
         self._diameter_label = self._create_value_label()
         self._height_label = self._create_value_label()
         self._base_label = self._create_value_label()
-        
+
         props_grid.addWidget(QLabel("Volume:"), 0, 0)
         props_grid.addWidget(self._volume_label, 0, 1)
         props_grid.addWidget(QLabel("Diameter:"), 1, 0)
@@ -96,10 +102,10 @@ class QuickStatsWidget(QFrame):
         props_grid.addWidget(self._height_label, 2, 1)
         props_grid.addWidget(QLabel("Base:"), 3, 0)
         props_grid.addWidget(self._base_label, 3, 1)
-        
+
         props_section.layout().addLayout(props_grid)
         layout.addWidget(props_section)
-        
+
         # Surface Tension section
         st_section = self._create_section("🧪 Surface Tension")
         self._surface_tension_label = self._create_value_label()
@@ -110,14 +116,14 @@ class QuickStatsWidget(QFrame):
         """)
         st_section.layout().addWidget(self._surface_tension_label)
         layout.addWidget(st_section)
-        
+
         # Confidence indicator
         self._confidence_label = QLabel()
         self._confidence_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._confidence_label)
-        
+
         layout.addStretch()
-    
+
     def _create_section(self, title: str) -> QFrame:
         """Create a section with a title."""
         section = QFrame()
@@ -128,27 +134,27 @@ class QuickStatsWidget(QFrame):
                 padding: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(section)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
-        
+
         title_label = QLabel(title)
         title_label.setStyleSheet(f"""
             color: {theme.TEXT_PRIMARY};
             font-weight: bold;
         """)
         layout.addWidget(title_label)
-        
+
         return section
-    
+
     def _create_value_label(self) -> QLabel:
         """Create a styled value label."""
         label = QLabel("--")
         label.setStyleSheet(f"color: {theme.TEXT_PRIMARY};")
         label.setAlignment(Qt.AlignmentFlag.AlignRight)
         return label
-    
+
     def _reset_display(self):
         """Reset all values to default."""
         self._angle_left_label.setText("--")
@@ -160,13 +166,13 @@ class QuickStatsWidget(QFrame):
         self._base_label.setText("--")
         self._surface_tension_label.setText("--")
         self._set_confidence(None)
-    
+
     def _set_confidence(self, confidence: float | None):
         """Set the confidence indicator."""
         if confidence is None:
             self._confidence_label.setText("")
             return
-        
+
         if confidence >= 90:
             color = theme.SUCCESS_GREEN
             icon = "✓"
@@ -179,18 +185,20 @@ class QuickStatsWidget(QFrame):
             color = theme.ERROR_RED
             icon = "❌"
             level = "Low"
-        
-        self._confidence_label.setText(f"{icon} Confidence: {level} ({confidence:.0f}%)")
+
+        self._confidence_label.setText(
+            f"{icon} Confidence: {level} ({confidence:.0f}%)"
+        )
         self._confidence_label.setStyleSheet(f"color: {color}; font-weight: bold;")
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_results(self, results: dict):
         """
         Set measurement results.
-        
+
         Args:
             results: Dictionary with measurement values:
                 - angle_left: Left contact angle (degrees)
@@ -209,14 +217,14 @@ class QuickStatsWidget(QFrame):
         angle_right = results.get("angle_right")
         angle_mean = results.get("angle_mean")
         uncertainty = results.get("angle_uncertainty", 0.5)
-        
+
         if angle_left is not None:
             self._angle_left_label.setText(f"{angle_left:.1f}° ± {uncertainty:.1f}°")
         if angle_right is not None:
             self._angle_right_label.setText(f"{angle_right:.1f}° ± {uncertainty:.1f}°")
         if angle_mean is not None:
             self._angle_mean_label.setText(f"{angle_mean:.1f}° ± {uncertainty:.1f}°")
-        
+
         # Drop properties
         if "volume" in results:
             self._volume_label.setText(f"{results['volume']:.2f} μL")
@@ -226,14 +234,16 @@ class QuickStatsWidget(QFrame):
             self._height_label.setText(f"{results['height']:.2f} mm")
         if "base_width" in results:
             self._base_label.setText(f"{results['base_width']:.2f} mm")
-        
+
         # Surface tension
         if "surface_tension" in results:
-            self._surface_tension_label.setText(f"γ: {results['surface_tension']:.1f} mN/m")
-        
+            self._surface_tension_label.setText(
+                f"γ: {results['surface_tension']:.1f} mN/m"
+            )
+
         # Confidence
         self._set_confidence(results.get("confidence"))
-    
+
     def clear(self):
         """Clear all displayed results."""
         self._reset_display()

--- a/src/menipy/gui/widgets/tilted_sessile_results_widget.py
+++ b/src/menipy/gui/widgets/tilted_sessile_results_widget.py
@@ -4,9 +4,15 @@ Tilted Sessile Results Widget
 Widget displaying tilted sessile specific results including
 advancing and receding contact angles, hysteresis, and roll-off angle.
 """
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame, QGridLayout
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QGridLayout,
 )
 
 from menipy.gui import theme
@@ -15,7 +21,7 @@ from menipy.gui import theme
 class TiltedSessileResultsWidget(QFrame):
     """
     Widget showing tilted sessile measurement results.
-    
+
     Displays:
         - Advancing contact angle (θA)
     - Receding contact angle (θR)
@@ -23,7 +29,7 @@ class TiltedSessileResultsWidget(QFrame):
     - Roll-off angle
     - Tilt angle
     """
-    
+
     def __init__(self, parent=None):
         """Initialize.
 
@@ -36,7 +42,7 @@ class TiltedSessileResultsWidget(QFrame):
         self.setObjectName("tiltedSessileResultsWidget")
         self._setup_ui()
         self._reset_display()
-    
+
     def _setup_ui(self):
         """Set up the widget UI."""
         self.setStyleSheet(f"""
@@ -46,11 +52,11 @@ class TiltedSessileResultsWidget(QFrame):
                 border-radius: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
-        
+
         # Header
         header = QLabel("Measurement Results")
         header.setStyleSheet(f"""
@@ -59,7 +65,7 @@ class TiltedSessileResultsWidget(QFrame):
             color: {theme.TEXT_PRIMARY};
         """)
         layout.addWidget(header)
-        
+
         # Current tilt angle
         tilt_display = QFrame()
         tilt_display.setStyleSheet(f"""
@@ -69,11 +75,11 @@ class TiltedSessileResultsWidget(QFrame):
         tilt_layout = QVBoxLayout(tilt_display)
         tilt_layout.setContentsMargins(12, 8, 12, 8)
         tilt_layout.setSpacing(2)
-        
+
         tilt_title = QLabel("Current Tilt Angle")
         tilt_title.setStyleSheet(f"color: {theme.TEXT_SECONDARY};")
         tilt_layout.addWidget(tilt_title)
-        
+
         self._tilt_angle_label = QLabel("0.0°")
         self._tilt_angle_label.setStyleSheet(f"""
             color: {theme.TEXT_PRIMARY};
@@ -81,9 +87,9 @@ class TiltedSessileResultsWidget(QFrame):
             font-weight: bold;
         """)
         tilt_layout.addWidget(self._tilt_angle_label)
-        
+
         layout.addWidget(tilt_display)
-        
+
         # Advancing angle section
         advancing_section = QFrame()
         advancing_section.setStyleSheet(f"""
@@ -96,11 +102,11 @@ class TiltedSessileResultsWidget(QFrame):
         adv_layout = QVBoxLayout(advancing_section)
         adv_layout.setContentsMargins(12, 8, 12, 8)
         adv_layout.setSpacing(4)
-        
+
         adv_title = QLabel("Advancing Angle (θA)")
         adv_title.setStyleSheet("color: rgba(0,0,0,0.7); font-weight: bold;")
         adv_layout.addWidget(adv_title)
-        
+
         self._advancing_label = QLabel("--")
         self._advancing_label.setStyleSheet("""
             color: rgba(0,0,0,0.9);
@@ -108,9 +114,9 @@ class TiltedSessileResultsWidget(QFrame):
             font-weight: bold;
         """)
         adv_layout.addWidget(self._advancing_label)
-        
+
         layout.addWidget(advancing_section)
-        
+
         # Receding angle section
         receding_section = QFrame()
         receding_section.setStyleSheet(f"""
@@ -123,11 +129,11 @@ class TiltedSessileResultsWidget(QFrame):
         rec_layout = QVBoxLayout(receding_section)
         rec_layout.setContentsMargins(12, 8, 12, 8)
         rec_layout.setSpacing(4)
-        
+
         rec_title = QLabel("Receding Angle (θR)")
         rec_title.setStyleSheet("color: rgba(0,0,0,0.7); font-weight: bold;")
         rec_layout.addWidget(rec_title)
-        
+
         self._receding_label = QLabel("--")
         self._receding_label.setStyleSheet("""
             color: rgba(0,0,0,0.9);
@@ -135,51 +141,51 @@ class TiltedSessileResultsWidget(QFrame):
             font-weight: bold;
         """)
         rec_layout.addWidget(self._receding_label)
-        
+
         layout.addWidget(receding_section)
-        
+
         # Hysteresis section
         hyst_section = self._create_section("📊 Hysteresis & Roll-off")
         hyst_grid = QGridLayout()
         hyst_grid.setSpacing(8)
-        
+
         self._hysteresis_label = self._create_value_label()
         self._rolloff_label = self._create_value_label()
-        
+
         hyst_grid.addWidget(QLabel("Hysteresis (θA - θR):"), 0, 0)
         hyst_grid.addWidget(self._hysteresis_label, 0, 1)
         hyst_grid.addWidget(QLabel("Roll-off Angle:"), 1, 0)
         hyst_grid.addWidget(self._rolloff_label, 1, 1)
-        
+
         hyst_section.layout().addLayout(hyst_grid)
         layout.addWidget(hyst_section)
-        
+
         # Drop properties section
         props_section = self._create_section("💧 Drop Properties")
         props_grid = QGridLayout()
         props_grid.setSpacing(8)
-        
+
         self._volume_label = self._create_value_label()
         self._base_left_label = self._create_value_label()
         self._base_right_label = self._create_value_label()
-        
+
         props_grid.addWidget(QLabel("Volume:"), 0, 0)
         props_grid.addWidget(self._volume_label, 0, 1)
         props_grid.addWidget(QLabel("Base (left):"), 1, 0)
         props_grid.addWidget(self._base_left_label, 1, 1)
         props_grid.addWidget(QLabel("Base (right):"), 2, 0)
         props_grid.addWidget(self._base_right_label, 2, 1)
-        
+
         props_section.layout().addLayout(props_grid)
         layout.addWidget(props_section)
-        
+
         # Confidence
         self._confidence_label = QLabel()
         self._confidence_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._confidence_label)
-        
+
         layout.addStretch()
-    
+
     def _create_section(self, title: str) -> QFrame:
         """Create a section with a title."""
         section = QFrame()
@@ -190,27 +196,27 @@ class TiltedSessileResultsWidget(QFrame):
                 padding: 8px;
             }}
         """)
-        
+
         layout = QVBoxLayout(section)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
-        
+
         title_label = QLabel(title)
         title_label.setStyleSheet(f"""
             color: {theme.TEXT_PRIMARY};
             font-weight: bold;
         """)
         layout.addWidget(title_label)
-        
+
         return section
-    
+
     def _create_value_label(self) -> QLabel:
         """Create a styled value label."""
         label = QLabel("--")
         label.setStyleSheet(f"color: {theme.TEXT_PRIMARY};")
         label.setAlignment(Qt.AlignmentFlag.AlignRight)
         return label
-    
+
     def _reset_display(self):
         """Reset all values to default."""
         self._tilt_angle_label.setText("0.0°")
@@ -222,13 +228,13 @@ class TiltedSessileResultsWidget(QFrame):
         self._base_left_label.setText("--")
         self._base_right_label.setText("--")
         self._set_confidence(None)
-    
+
     def _set_confidence(self, confidence: float | None):
         """Set the confidence indicator."""
         if confidence is None:
             self._confidence_label.setText("")
             return
-        
+
         if confidence >= 90:
             color = theme.SUCCESS_GREEN
             icon = "✓"
@@ -241,22 +247,24 @@ class TiltedSessileResultsWidget(QFrame):
             color = theme.ERROR_RED
             icon = "❌"
             level = "Low"
-        
-        self._confidence_label.setText(f"{icon} Confidence: {level} ({confidence:.0f}%)")
+
+        self._confidence_label.setText(
+            f"{icon} Confidence: {level} ({confidence:.0f}%)"
+        )
         self._confidence_label.setStyleSheet(f"color: {color}; font-weight: bold;")
-    
+
     # -------------------------------------------------------------------------
     # Public Methods
     # -------------------------------------------------------------------------
-    
+
     def set_tilt_angle(self, angle: float):
         """Set the current tilt angle display."""
         self._tilt_angle_label.setText(f"{angle:.1f}°")
-    
+
     def set_results(self, results: dict):
         """
         Set measurement results.
-        
+
         Args:
             results: Dictionary with measurement values:
                 - tilt_angle: Current tilt angle (degrees)
@@ -271,36 +279,40 @@ class TiltedSessileResultsWidget(QFrame):
         """
         if "tilt_angle" in results:
             self.set_tilt_angle(results["tilt_angle"])
-        
+
         if "advancing_angle" in results:
             unc = results.get("advancing_uncertainty", 0.5)
-            self._advancing_label.setText(f"{results['advancing_angle']:.1f}° ± {unc:.1f}°")
-        
+            self._advancing_label.setText(
+                f"{results['advancing_angle']:.1f}° ± {unc:.1f}°"
+            )
+
         if "receding_angle" in results:
             unc = results.get("receding_uncertainty", 0.5)
-            self._receding_label.setText(f"{results['receding_angle']:.1f}° ± {unc:.1f}°")
-        
+            self._receding_label.setText(
+                f"{results['receding_angle']:.1f}° ± {unc:.1f}°"
+            )
+
         if "hysteresis" in results:
             self._hysteresis_label.setText(f"{results['hysteresis']:.1f}°")
-        
+
         if "rolloff_angle" in results:
             self._rolloff_label.setText(f"{results['rolloff_angle']:.1f}°")
         elif results.get("advancing_angle") and results.get("receding_angle"):
             # Calculate hysteresis if not provided
             hyst = results["advancing_angle"] - results["receding_angle"]
             self._hysteresis_label.setText(f"{hyst:.1f}°")
-        
+
         if "volume" in results:
             self._volume_label.setText(f"{results['volume']:.2f} μL")
-        
+
         if "base_left" in results:
             self._base_left_label.setText(f"{results['base_left']:.2f} mm")
-        
+
         if "base_right" in results:
             self._base_right_label.setText(f"{results['base_right']:.2f} mm")
-        
+
         self._set_confidence(results.get("confidence"))
-    
+
     def clear(self):
         """Clear all displayed results."""
         self._reset_display()

--- a/src/menipy/math/jurin.py
+++ b/src/menipy/math/jurin.py
@@ -1,21 +1,28 @@
 import math
 
-def jurin_surface_tension(h_m: float, rho_kg_m3: float, g: float, tube_radius_m: float, contact_angle_rad: float = 0.0) -> float:
+
+def jurin_surface_tension(
+    h_m: float,
+    rho_kg_m3: float,
+    g: float,
+    tube_radius_m: float,
+    contact_angle_rad: float = 0.0,
+) -> float:
     """
     Calculate surface tension using Jurin's Law for capillary rise.
-    
+
     Args:
         h_m: Height of the capillary rise in meters.
         rho_kg_m3: Density of the fluid in kg/m^3.
         g: Acceleration due to gravity in m/s^2.
         tube_radius_m: Radius of the capillary tube in meters.
         contact_angle_rad: Contact angle in radians (default 0.0).
-        
+
     Returns:
         Surface tension (gamma) in N/m.
     """
     if math.isclose(h_m, 0.0):
         return 0.0
-    
+
     gamma = (rho_kg_m3 * g * h_m * tube_radius_m) / (2.0 * math.cos(contact_angle_rad))
     return gamma

--- a/src/menipy/math/young_laplace.py
+++ b/src/menipy/math/young_laplace.py
@@ -2,17 +2,22 @@ import numpy as np
 from scipy.integrate import solve_ivp
 from typing import Tuple, Dict, Any, Optional
 
-def young_laplace_ode(params: np.ndarray, physics: Dict[str, Any], geometry: Optional[Dict[str, Any]] = None) -> np.ndarray:
+
+def young_laplace_ode(
+    params: np.ndarray,
+    physics: Dict[str, Any],
+    geometry: Optional[Dict[str, Any]] = None,
+) -> np.ndarray:
     """
     Integrate the axisymmetric Young-Laplace ODE using Bashforth-Adams formulation.
-    
+
     Args:
         params: Array of [R0_mm, beta]
             R0_mm: Radius of curvature at the apex in mm.
             beta: Bond number (dimensionless shape parameter).
         physics: Dictionary containing physical properties.
         geometry: Optional geometry dictionary (ignored, included for signature compatibility).
-        
+
     Returns:
         (N, 2) array of [r, z] profile coordinates in mm.
     """
@@ -27,71 +32,75 @@ def young_laplace_ode(params: np.ndarray, physics: Dict[str, Any], geometry: Opt
     # For safety against extreme params
     if R0_mm <= 0:
         return np.array([[0.0, 0.0]])
-        
+
     def odesys(s, y):
         # y = [r, z, psi]
         r, z, psi = y
-        
+
         # Avoid division by zero at apex (s=0, r=0)
-        # Using L'Hopital's rule: lim(s->0) sin(psi)/r = dpsi/ds 
+        # Using L'Hopital's rule: lim(s->0) sin(psi)/r = dpsi/ds
         # Since r=0, z=0, dpsi/ds = 2/R0_mm + beta*z = 2/R0_mm
-        # And since dimensionless, if we scale by R0 it is 2. 
-        # We integrate in real units (mm), but usually beta is defined dimensionless. 
+        # And since dimensionless, if we scale by R0 it is 2.
+        # We integrate in real units (mm), but usually beta is defined dimensionless.
         # The ODE in real units (arc-length s in mm):
         # dr/ds = cos(psi)
         # dz/ds = sin(psi)
         # dpsi/ds = 2/R0_mm + (beta/R0_mm^2) * z - sin(psi)/r
-        
+
         if r < 1e-12:
             sin_psi_r = 1.0 / R0_mm
         else:
             sin_psi_r = np.sin(psi) / r
-            
+
         drds = np.cos(psi)
         dzds = np.sin(psi)
         dpsids = (2.0 / R0_mm) + (beta / (R0_mm**2)) * z - sin_psi_r
-        
+
         return [drds, dzds, dpsids]
 
     # Stop integration when profile curls back up to axis (pendant drop pinch-off)
     # or max length reached
     def hit_axis(s, y):
         return y[0] - 1e-6 if s > 0.1 else 1.0
+
     hit_axis.terminal = True
     hit_axis.direction = -1
 
     # Max arc length to integrate (scale by R0)
-    s_max = 5.0 * R0_mm * max(1.0, 1.0/max(1e-3, abs(beta)))
-    
+    s_max = 5.0 * R0_mm * max(1.0, 1.0 / max(1e-3, abs(beta)))
+
     y0 = [0.0, 0.0, 0.0]
-    
+
     # We want a dense enough output to compare with contours
     sol = solve_ivp(
-        odesys, 
-        [0.0, s_max], 
-        y0, 
-        method='RK45',
+        odesys,
+        [0.0, s_max],
+        y0,
+        method="RK45",
         events=hit_axis,
         max_step=s_max / 200.0,
-        rtol=1e-5, atol=1e-6
+        rtol=1e-5,
+        atol=1e-6,
     )
-    
+
     # Combine the symmetric halves (left and right)
     # sol.y[0] is r, sol.y[1] is z
     r_right = sol.y[0]
     z_right = sol.y[1]
-    
+
     # For a full drop silhouette, we mirror the r coordinate
     # But usually the solver residual function compares against [r, z] format.
     # The solver pointwise expects (x, y) where x is horizontal and y is vertical.
     # We center r around 0, appending the left side.
     r_left = -r_right[::-1]
     z_left = z_right[::-1]
-    
+
     r_full = np.concatenate([r_left[:-1], r_right])
     z_full = np.concatenate([z_left[:-1], z_right])
-    
+
     return np.column_stack([r_full, z_full])
 
+
 from menipy.common.registry import SOLVERS
+
 SOLVERS.register("young_laplace_ode", young_laplace_ode)

--- a/src/menipy/models/config.py
+++ b/src/menipy/models/config.py
@@ -96,7 +96,7 @@ class ContactLineSettings(BaseModel):
 
 class ContourSmoothingSettings(BaseModel):
     """Configuration for optional Savitzky-Golay contour smoothing.
-    
+
     When enabled, applies smoothing to the extracted contour to reduce noise
     and computes tangent-based contact angles from the smoothed curve.
     """
@@ -182,12 +182,20 @@ class PreprocessingSettings(BaseModel):
 
     class AutoDetectSettings(BaseModel):
         """Configuration for automatic feature detection (ROI, Needle, etc.)."""
-        
-        enabled: bool = Field(default=True, description="Enable automatic feature detection")
-        detect_roi: bool = Field(default=True, description="Automatically detect Region of Interest")
-        detect_needle: bool = Field(default=True, description="Automatically detect Needle/Nozzle")
-        detect_substrate: bool = Field(default=True, description="Automatically detect Substrate/Baseline")
-        
+
+        enabled: bool = Field(
+            default=True, description="Enable automatic feature detection"
+        )
+        detect_roi: bool = Field(
+            default=True, description="Automatically detect Region of Interest"
+        )
+        detect_needle: bool = Field(
+            default=True, description="Automatically detect Needle/Nozzle"
+        )
+        detect_substrate: bool = Field(
+            default=True, description="Automatically detect Substrate/Baseline"
+        )
+
     auto_detect: AutoDetectSettings = Field(default_factory=AutoDetectSettings)
     preset_id: Optional[str] = Field(default=None)
 
@@ -197,8 +205,16 @@ class EdgeDetectionSettings(BaseModel):
 
     enabled: bool = Field(default=True)
     method: Literal[
-        "canny", "sobel", "scharr", "laplacian", "threshold", "active_contour",
-        "otsu", "adaptive", "log", "improved_snake"
+        "canny",
+        "sobel",
+        "scharr",
+        "laplacian",
+        "threshold",
+        "active_contour",
+        "otsu",
+        "adaptive",
+        "log",
+        "improved_snake",
     ] = Field(default="otsu", description="Edge detection algorithm to use")
     # Common preprocessing for edge detection
     gaussian_blur_before: bool = Field(
@@ -273,9 +289,7 @@ class EdgeDetectionSettings(BaseModel):
     snake_beta: float = Field(
         default=10.0, ge=0.0, description="Snake smoothness energy weight"
     )
-    snake_gamma: float = Field(
-        default=0.001, ge=0.0, description="Snake time step"
-    )
+    snake_gamma: float = Field(default=0.001, ge=0.0, description="Snake time step")
 
     plugin_settings: Dict[str, Any] = Field(
         default_factory=dict,

--- a/src/menipy/models/context.py
+++ b/src/menipy/models/context.py
@@ -20,10 +20,13 @@ class Context(BaseModel):
     Mutable bag of state shared across pipeline stages.
     Pipelines freely attach fields here. Commonly used keys are predeclared.
     """
-    model_config = ConfigDict(extra='forbid', arbitrary_types_allowed=True)
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     # Acquisition / images
-    frames: Union[np.ndarray, List[np.ndarray], List[Frame], None] = None  # np.ndarray or list[np.ndarray]
+    frames: Union[np.ndarray, List[np.ndarray], List[Frame], None] = (
+        None  # np.ndarray or list[np.ndarray]
+    )
     current_frame: Optional[Frame] = None
     image_path: Optional[str] = None  # Path to input image file
     image: Optional[np.ndarray] = None  # Loaded image data
@@ -99,7 +102,7 @@ class Context(BaseModel):
     contact_line_mask: Optional[np.ndarray] = None
     preprocessed: Optional[np.ndarray] = None
     gray: Optional[np.ndarray] = None
-    
+
     # Specific algorithm variables (found during refactor)
     contact_points: Optional[Tuple[Tuple[int, int], Tuple[int, int]]] = None
     apex_point: Optional[Tuple[int, int]] = None

--- a/src/menipy/models/datatypes.py
+++ b/src/menipy/models/datatypes.py
@@ -1,5 +1,6 @@
 # src/menipy/models/datatypes.py
 """Common data types and structures for analysis records and preprocessing state."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Optional, Tuple, TYPE_CHECKING
@@ -8,6 +9,7 @@ from datetime import datetime
 if TYPE_CHECKING:
     from .frame import Frame, Calibration, CameraMeta
     from .geometry import Contour, Geometry
+
     # PhysicsParams is not exported from models.physics; use a loose alias for typing
     from typing import Any as PhysicsParams
 
@@ -67,7 +69,6 @@ class PreprocessingState(BaseModel):
         Description.
         """
         return self.model_copy(deep=True)
-
 
         # ---- Aggregated analysis record --------------------------------------------
 

--- a/src/menipy/models/drop_extras.py
+++ b/src/menipy/models/drop_extras.py
@@ -44,10 +44,10 @@ def surface_area_mm2(contour_px: np.ndarray, px_per_mm: float) -> float:
     r_mm, z_mm = r_mm[order], z_mm[order]
     z_mm, unique_idx = np.unique(z_mm, return_index=True)
     r_mm = r_mm[unique_idx].astype(float)
-    
+
     if len(r_mm) < 3 or len(z_mm) < 3:
         return 0.0
-        
+
     dr_dz: np.ndarray = np.gradient(r_mm, z_mm, edge_order=2)
     integrand: np.ndarray = np.asarray(r_mm * np.sqrt(1.0 + dr_dz**2), dtype=float)
     trapz_val = float(trapezoid(integrand, z_mm))

--- a/src/menipy/models/results.py
+++ b/src/menipy/models/results.py
@@ -132,9 +132,12 @@ class ResultsHistory:
 
         return headers, rows
 
-    def export_csv(self, file_path: str | Path, pipeline_filter: Optional[str] = None) -> bool:
+    def export_csv(
+        self, file_path: str | Path, pipeline_filter: Optional[str] = None
+    ) -> bool:
         """Export measurement history to a CSV file."""
         import csv
+
         try:
             headers, rows = self.get_table_data(pipeline_filter=pipeline_filter)
             if not headers:

--- a/src/menipy/models/state.py
+++ b/src/menipy/models/state.py
@@ -68,8 +68,9 @@ class PreprocessingState(BaseModel):
         """
         return self.model_copy(deep=True)
 
-
         # Convenience constructors (migrated)
+
+
 def make_frame(
     image: np.ndarray,
     timestamp: Optional[datetime] = None,

--- a/src/menipy/models/surface_tension.py
+++ b/src/menipy/models/surface_tension.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.integrate import trapezoid
 
-
 # Jennings–Pallas cubic correlation -----------------------------------------
 
 

--- a/src/menipy/models/typing.py
+++ b/src/menipy/models/typing.py
@@ -1,5 +1,6 @@
 # src/menipy/models/typing.py
 """Type aliases for numpy arrays used throughout Menipy."""
+
 from __future__ import annotations
 
 from typing import Union, TypeAlias

--- a/src/menipy/models/unit_types.py
+++ b/src/menipy/models/unit_types.py
@@ -1,5 +1,6 @@
 # src/menipy/models/unit_types.py
 """Pydantic-Pint unit types for physical quantities."""
+
 from typing import Annotated
 from pint.facets.plain import PlainQuantity as Quantity
 from pydantic_pint import PydanticPintQuantity

--- a/src/menipy/pipelines/base.py
+++ b/src/menipy/pipelines/base.py
@@ -1,5 +1,6 @@
 # src/menipy/pipelines/base.py
 """Base pipeline class with template method pattern for stage-based execution."""
+
 from __future__ import annotations
 
 import logging
@@ -60,15 +61,15 @@ class PipelineBase:
     DEFAULT_SEQ = [
         ("acquisition", None),
         ("preprocessing", None),
-        ("feature_detection", None),      # NEW: detect ROI, needle, substrate
-        ("contour_extraction", None),     # was: edge_detection
-        ("contour_refinement", None),     # NEW: clip/smooth contour
-        ("calibration", None),            # was: scaling
-        ("geometric_features", None),     # was: geometry
+        ("feature_detection", None),  # NEW: detect ROI, needle, substrate
+        ("contour_extraction", None),  # was: edge_detection
+        ("contour_refinement", None),  # NEW: clip/smooth contour
+        ("calibration", None),  # was: scaling
+        ("geometric_features", None),  # was: geometry
         ("physics", None),
-        ("profile_fitting", None),        # was: solver
+        ("profile_fitting", None),  # was: solver
         # optimization stage REMOVED
-        ("compute_metrics", None),        # was: outputs
+        ("compute_metrics", None),  # was: outputs
         ("overlay", None),
         ("validation", None),
     ]
@@ -88,7 +89,7 @@ class PipelineBase:
 
     def do_feature_detection(self, ctx: Context) -> Optional[Context]:
         """Detect features like ROI, needle, substrate, and contact points.
-        
+
         This stage runs automatic detection algorithms to identify key image
         features before contour extraction. Results are stored in ctx for use
         by subsequent stages.
@@ -97,7 +98,7 @@ class PipelineBase:
 
     def do_contour_extraction(self, ctx: Context) -> Optional[Context]:
         """Extract the droplet contour from the preprocessed image.
-        
+
         Previously named 'edge_detection'. Uses Canny or registered plugins
         to extract contour points as (x, y) coordinate arrays.
         """
@@ -109,7 +110,7 @@ class PipelineBase:
 
     def do_contour_refinement(self, ctx: Context) -> Optional[Context]:
         """Refine the extracted contour by clipping, smoothing, or filtering.
-        
+
         Operations may include:
             - Clipping contour at substrate line
         - Removing noise points
@@ -120,7 +121,7 @@ class PipelineBase:
 
     def do_calibration(self, ctx: Context) -> Optional[Context]:
         """Convert pixel measurements to physical units (mm).
-        
+
         Previously named 'scaling'. Calculates px_per_mm from calibration
         objects (needle diameter) and scales contour coordinates.
         """
@@ -128,13 +129,13 @@ class PipelineBase:
 
     def do_geometric_features(self, ctx: Context) -> Optional[Context]:
         """Extract geometric features from the contour.
-        
+
         Previously named 'geometry'. Calculates:
             - Axis of symmetry
         - Apex point location
         - Baseline/substrate line
         - Tilt angle
-        
+
         Note: Metric computation has been moved to do_compute_metrics.
         """
         return ctx
@@ -145,7 +146,7 @@ class PipelineBase:
 
     def do_profile_fitting(self, ctx: Context) -> Optional[Context]:
         """Fit the physical model (Young-Laplace) to the contour data.
-        
+
         Previously named 'solver'. Uses least-squares optimization to fit
         theoretical curves to measured contour points.
         """
@@ -153,7 +154,7 @@ class PipelineBase:
 
     def do_compute_metrics(self, ctx: Context) -> Optional[Context]:
         """Aggregate and compute final measurement results.
-        
+
         Previously named 'outputs'. Computes derived metrics like:
             - Surface tension (from fit parameters)
         - Volume (disk integration)
@@ -168,35 +169,35 @@ class PipelineBase:
 
     def do_validation(self, ctx: Context) -> Optional[Context]:
         """Quality assurance checks on analysis results.
-        
+
         This stage should verify:
-        
+
             1. RESIDUAL MAGNITUDES
            - Check if fit residuals are within acceptable bounds
            - Flag results with high residual RMS (> threshold)
            - Compute goodness-of-fit metrics (R², chi-squared)
-        
+
         2. PHYSICAL PLAUSIBILITY
            - Verify surface tension is in expected range (e.g., 15-80 mN/m)
            - Check contact angles are valid (0-180°)
            - Validate volume is positive and reasonable
            - Ensure Bond number is physically meaningful
-        
+
         3. CONTOUR QUALITY
            - Check contour point density (too few points = unreliable fit)
            - Detect contour artifacts (gaps, noise spikes)
            - Verify contour is closed/continuous
            - Check for asymmetry beyond threshold
-        
+
         4. GEOMETRIC CONSISTENCY
            - Validate apex is at expected location
            - Check baseline detection quality
            - Verify needle/calibration object detection
-        
+
         5. REPEATABILITY (for batch processing)
            - Compare with previous frames if available
            - Flag sudden jumps in measured values
-        
+
         Sets ctx.qa dict with:
            - 'ok': bool - overall pass/fail
            - 'warnings': list - non-fatal issues
@@ -204,6 +205,7 @@ class PipelineBase:
            - 'scores': dict - quality scores per check
         """
         from menipy.common.validation import validate
+
         ctx.qa = validate(ctx)
         return ctx
 
@@ -355,12 +357,30 @@ class PipelineBase:
 
         # Store any other kwargs into context (e.g. auto_detect_features)
         known_keys = {
-            "image", "image_path", "camera", "cam_id", "frames", "roi", "roi_rect",
-            "detected_roi", "needle_rect", "contact_line", "substrate_line",
-            "drop_contour", "detected_contour", "contact_points", "apex_point",
-            "px_per_mm", "needle_diameter_mm", "calibration_params",
-            "preprocessing_settings", "edge_detection_settings",
-            "measurement_id", "measurement_sequence", "scale", "physics"
+            "image",
+            "image_path",
+            "camera",
+            "cam_id",
+            "frames",
+            "roi",
+            "roi_rect",
+            "detected_roi",
+            "needle_rect",
+            "contact_line",
+            "substrate_line",
+            "drop_contour",
+            "detected_contour",
+            "contact_points",
+            "apex_point",
+            "px_per_mm",
+            "needle_diameter_mm",
+            "calibration_params",
+            "preprocessing_settings",
+            "edge_detection_settings",
+            "measurement_id",
+            "measurement_sequence",
+            "scale",
+            "physics",
         }
         for k, v in kwargs.items():
             if k not in known_keys:

--- a/src/menipy/pipelines/capillary_rise/stages.py
+++ b/src/menipy/pipelines/capillary_rise/stages.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 from typing import Optional
@@ -32,7 +31,12 @@ class CapillaryRisePipeline(PipelineBase):
         "display_name": "Capillary Rise",
         "icon": "capillary_rise.svg",
         "color": "#9B59B6",
-        "stages": ["acquisition", "contour_extraction", "calibration", "profile_fitting"],
+        "stages": [
+            "acquisition",
+            "contour_extraction",
+            "calibration",
+            "profile_fitting",
+        ],
         "calibration_params": [
             "tube_diameter_mm",
             "fluid_density_kg_m3",
@@ -106,13 +110,25 @@ class CapillaryRisePipeline(PipelineBase):
 
     def do_overlay(self, ctx: Context) -> Optional[Context]:
         xy = ensure_contour(ctx)
-        
-        baseline_y = int(round(ctx.geometry.baseline_y)) if ctx.geometry and ctx.geometry.baseline_y is not None else 0
-        axis_x = int(round(ctx.geometry.axis_x)) if ctx.geometry and ctx.geometry.axis_x is not None else 0
-        apex_xy = ctx.geometry.apex_xy if ctx.geometry and ctx.geometry.apex_xy is not None else (0, 0)
+
+        baseline_y = (
+            int(round(ctx.geometry.baseline_y))
+            if ctx.geometry and ctx.geometry.baseline_y is not None
+            else 0
+        )
+        axis_x = (
+            int(round(ctx.geometry.axis_x))
+            if ctx.geometry and ctx.geometry.axis_x is not None
+            else 0
+        )
+        apex_xy = (
+            ctx.geometry.apex_xy
+            if ctx.geometry and ctx.geometry.apex_xy is not None
+            else (0, 0)
+        )
         apex_x, apex_y = apex_xy
         h_px = float(getattr(ctx, "h_px", 0))
-        
+
         text = f"R0≈{ctx.results.get('R0_mm','?')} mm | h≈{h_px:.0f}px"
         x0 = int(axis_x)
         cmds = [
@@ -153,5 +169,3 @@ class CapillaryRisePipeline(PipelineBase):
             },
         ]
         return ovl.run(ctx, commands=cmds, alpha=0.6)
-
-

--- a/src/menipy/pipelines/captive_bubble/physics.py
+++ b/src/menipy/pipelines/captive_bubble/physics.py
@@ -1,27 +1,27 @@
 """Physics functions for captive bubble."""
+
 from __future__ import annotations
 
 from typing import Optional
 
+
 def compute_physics(
-    physics_config: dict,
-    r0_mm: float,
-    beta: float
+    physics_config: dict, r0_mm: float, beta: float
 ) -> tuple[Optional[float], Optional[float]]:
     """
     Computes gamma and capillary length from a captive bubble fit.
     Captive bubble fits are inverted sessile drops mathematically.
-    
+
     Returns:
         tuple containing (surface_tension_mN_m, capillary_length_mm)
         If beta is invalid or negative, returns (None, None).
     """
     d_rho = abs(physics_config.get("rho1", 1000.0) - physics_config.get("rho2", 1.2))
     g = physics_config.get("g", 9.80665)
-    
+
     gamma_mN_m = None
     capillary_length_mm = None
-    
+
     if r0_mm is not None and beta is not None and beta > 1e-6:
         r0_m = r0_mm / 1000.0
         # beta = (d_rho * g * r0_m**2) / gamma
@@ -29,7 +29,8 @@ def compute_physics(
         gamma_mN_m = gamma_N_m * 1000.0
         if gamma_N_m > 0:
             import math
+
             cl_m = math.sqrt(gamma_N_m / (d_rho * g))
             capillary_length_mm = cl_m * 1000.0
-            
+
     return gamma_mN_m, capillary_length_mm

--- a/src/menipy/pipelines/captive_bubble/stages.py
+++ b/src/menipy/pipelines/captive_bubble/stages.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 from typing import Optional
 import numpy as np
@@ -15,6 +14,7 @@ from menipy.pipelines.captive_bubble.physics import compute_physics
 
 # Get solver from registry (loaded at startup)
 from menipy.math.young_laplace import young_laplace_ode as yl_ode
+
 young_laplace_ode = get_solver("young_laplace_ode", fallback=yl_ode)
 
 
@@ -36,7 +36,12 @@ class CaptiveBubblePipeline(PipelineBase):
         "display_name": "Captive Bubble",
         "icon": "captive_bubble.svg",
         "color": "#50E3C2",
-        "stages": ["acquisition", "contour_extraction", "geometric_features", "physics"],
+        "stages": [
+            "acquisition",
+            "contour_extraction",
+            "geometric_features",
+            "physics",
+        ],
         "calibration_params": [
             "needle_diameter_mm",
             "drop_density_kg_m3",
@@ -88,7 +93,7 @@ class CaptiveBubblePipeline(PipelineBase):
         """Fit spherical Young-Laplace profile."""
         integrator = get_solver(self.solver_name, fallback=young_laplace_ode)
         assert integrator is not None, f"Solver {self.solver_name} not found."
-        
+
         cfg = FitConfig(
             x0=[5.0, 0.5],
             bounds=([0.1, 0.0], [50.0, 50.0]),
@@ -113,19 +118,19 @@ class CaptiveBubblePipeline(PipelineBase):
             geometry.cap_depth_px if geometry.cap_depth_px is not None else None
         )
         res["residuals"] = fit.get("residuals", {})
-        
+
         physics_config = ctx.physics or {"rho1": 1000.0, "rho2": 1.2, "g": 9.80665}
         r0_mm = res.get("r0_mm")
         beta = res.get("beta")
-        
+
         gamma, cl_mm = compute_physics(physics_config, r0_mm, beta)
-        
+
         res["surface_tension_mN_m"] = gamma
         res["capillary_length_mm"] = cl_mm
-        
+
         # Geometry defaults (diameter, volume placeholder)
         res.setdefault("volume_uL", None)
-        
+
         ctx.results = res
         return ctx
 
@@ -212,5 +217,3 @@ class CaptiveBubblePipeline(PipelineBase):
             },
         ]
         return ovl.run(ctx, commands=cmds, alpha=0.6)
-
-

--- a/src/menipy/pipelines/discover.py
+++ b/src/menipy/pipelines/discover.py
@@ -53,6 +53,7 @@ def _discover_pipelines_from_subdirs():
 
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 PIPELINE_MAP = _discover_pipelines_from_subdirs()

--- a/src/menipy/pipelines/oscillating/stages.py
+++ b/src/menipy/pipelines/oscillating/stages.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 # pipeline/pendant/stages.py (test-specific overrides)
 from __future__ import annotations
 
@@ -31,6 +30,7 @@ def _contour_from_frame(ctx: Context, frame) -> np.ndarray:
     original = ctx.frames
     ctx.frames = [frame]
     from menipy.models.config import EdgeDetectionSettings
+
     edged.run(ctx, settings=EdgeDetectionSettings(method="canny"))
     if ctx.contour is not None and ctx.contour.xy is not None:
         xy = np.asarray(ctx.contour.xy, dtype=float)
@@ -121,15 +121,16 @@ class OscillatingPipeline(PipelineBase):
                 r, (cx, cy) = _area_equiv_radius(np.asarray(C.xy))
                 series.append(r)
                 centers.append((cx, cy))
-                
+
             ctx.r_eq_series_px = series
             ctx.centers_px = centers
-            
+
             # Assign a few handy refs from frame 0
             xy0 = np.asarray(ctx.contours_by_frame[0].xy)
         else:
             # Single contour fallback
             from menipy.models.config import EdgeDetectionSettings
+
             edged.run(ctx, settings=EdgeDetectionSettings(method="canny"))
             if ctx.contour is not None and ctx.contour.xy is not None:
                 xy0 = np.asarray(ctx.contour.xy, dtype=float)
@@ -143,14 +144,14 @@ class OscillatingPipeline(PipelineBase):
 
         # Store frame-0 equivalent radius/center for overlay
         r0, (c0x, c0y) = _area_equiv_radius(xy0)
-        
+
         ctx.geometry = Geometry(
             axis_x=axis_x,
             apex_xy=apex_xy,
         )
         ctx.r0_eq_px = float(r0)
         ctx.c0_xy = (float(c0x), float(c0y))
-        
+
         return ctx
 
     def do_calibration(self, ctx: Context) -> Optional[Context]:
@@ -197,17 +198,17 @@ class OscillatingPipeline(PipelineBase):
                 mag[0] = 0.0
                 k = int(np.argmax(mag))
                 f0 = float(freqs[k])
-        
+
         # Collect fit results
         fit = ctx.fit or {}
         names = list(fit.get("param_names") or [])
         params = list(fit.get("params", []))
-        
+
         # Add frequency if found
         if f0 is not None:
             names.append("f0_Hz")
             params.append(f0)
-        
+
         results = {n: p for n, p in zip(names, params)}
         results["residuals"] = fit.get("residuals", {})
         # Export a couple of geometry refs
@@ -220,16 +221,18 @@ class OscillatingPipeline(PipelineBase):
             xy = np.asarray(ctx.contour.xy, dtype=float)
         else:
             xy = np.empty((0, 2), dtype=float)
-        
+
         if xy.size > 0:
-            cx, cy = getattr(ctx, "c0_xy", (float(np.mean(xy[:, 0])), float(np.mean(xy[:, 1]))))
+            cx, cy = getattr(
+                ctx, "c0_xy", (float(np.mean(xy[:, 0])), float(np.mean(xy[:, 1])))
+            )
         else:
             cx, cy = getattr(ctx, "c0_xy", (0.0, 0.0))
         r = float(getattr(ctx, "r0_eq_px", 10.0))
-        
+
         geom_axis_x = getattr(ctx.geometry, "axis_x", cx) if ctx.geometry else cx
         axis_x = int(round(geom_axis_x))
-        
+
         text = f"R0≈{ctx.results.get('R0_mm','?')} mm"
         f0 = ctx.results.get("f0_Hz", None)
         if f0 is not None:
@@ -272,5 +275,3 @@ class OscillatingPipeline(PipelineBase):
             },
         ]
         return ovl.run(ctx, commands=cmds, alpha=0.6)
-
-

--- a/src/menipy/pipelines/pendant/approximations.py
+++ b/src/menipy/pipelines/pendant/approximations.py
@@ -14,7 +14,6 @@ from menipy.pipelines.pendant.strict_young_laplace import (
     integrate_young_laplace_profile_mm,
 )
 
-
 DEFAULT_SELECTED_PLANES = (0.6, 0.7, 0.8, 0.9, 1.0)
 
 
@@ -53,19 +52,25 @@ def _r0_mm_from_context(ctx: Any) -> float | None:
     return None
 
 
-def _surface_tension_from_h(delta_rho: float, g: float, de_mm: float, h: float) -> float:
+def _surface_tension_from_h(
+    delta_rho: float, g: float, de_mm: float, h: float
+) -> float:
     de_m = de_mm / 1000.0
     return delta_rho * g * de_m**2 / h
 
 
-def _beta_from_gamma(delta_rho: float, g: float, r0_mm: float | None, gamma_n_m: float) -> float | None:
+def _beta_from_gamma(
+    delta_rho: float, g: float, r0_mm: float | None, gamma_n_m: float
+) -> float | None:
     if r0_mm is None or gamma_n_m <= 0:
         return None
     return float(delta_rho * g * (r0_mm / 1000.0) ** 2 / gamma_n_m)
 
 
 @lru_cache(maxsize=1)
-def _selected_plane_lookup_all() -> dict[float, tuple[np.ndarray, np.ndarray, np.ndarray]]:
+def _selected_plane_lookup_all() -> (
+    dict[float, tuple[np.ndarray, np.ndarray, np.ndarray]]
+):
     beta_grid = np.linspace(0.03, 2.5, 24)
     height_grid = np.linspace(0.8, 4.5, 24)
     by_plane = {
@@ -106,11 +111,17 @@ def _selected_plane_lookup_all() -> dict[float, tuple[np.ndarray, np.ndarray, np
 
 
 def _selected_plane_lookup(k: float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    empty = (np.array([], dtype=float), np.array([], dtype=float), np.array([], dtype=float))
+    empty = (
+        np.array([], dtype=float),
+        np.array([], dtype=float),
+        np.array([], dtype=float),
+    )
     return _selected_plane_lookup_all().get(round(float(k), 4), empty)
 
 
-def _lookup_h_from_s(k: float, s: float, height_over_de: float) -> tuple[float | None, str]:
+def _lookup_h_from_s(
+    k: float, s: float, height_over_de: float
+) -> tuple[float | None, str]:
     s_arr, hde_arr, h_arr = _selected_plane_lookup(round(float(k), 4))
     if s_arr.size < 3 or not np.isfinite(s):
         return None, "lookup_unavailable"
@@ -169,7 +180,9 @@ def _selected_plane_estimate(
     return out
 
 
-def selected_plane(ctx: Any, profile_mm: np.ndarray, physics: dict[str, Any]) -> dict[str, Any]:
+def selected_plane(
+    ctx: Any, profile_mm: np.ndarray, physics: dict[str, Any]
+) -> dict[str, Any]:
     """Approximate IFT from one selected plane at ``k=1.0``."""
     return _selected_plane_estimate(ctx, profile_mm, physics, k=1.0)
 
@@ -245,7 +258,9 @@ def _volume_lookup(height_over_r0: float) -> tuple[np.ndarray, np.ndarray]:
     return v_unique, beta_arr[idx]
 
 
-def volume_apex_lookup(ctx: Any, profile_mm: np.ndarray, physics: dict[str, Any]) -> dict[str, Any]:
+def volume_apex_lookup(
+    ctx: Any, profile_mm: np.ndarray, physics: dict[str, Any]
+) -> dict[str, Any]:
     """Approximate IFT from volume, height, and apex radius."""
     prefix = "approx_volume_apex"
     r, z = _profile(profile_mm)
@@ -263,7 +278,11 @@ def volume_apex_lookup(ctx: Any, profile_mm: np.ndarray, physics: dict[str, Any]
         f"{prefix}_height_over_r0": height_dim,
         f"{prefix}_volume_over_r0_cubed": volume_dim,
     }
-    if v_arr.size < 3 or volume_dim < float(np.min(v_arr)) or volume_dim > float(np.max(v_arr)):
+    if (
+        v_arr.size < 3
+        or volume_dim < float(np.min(v_arr))
+        or volume_dim > float(np.max(v_arr))
+    ):
         out[f"{prefix}_status"] = "outside_lookup_range"
         return out
 

--- a/src/menipy/pipelines/pendant/geometry.py
+++ b/src/menipy/pipelines/pendant/geometry.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/menipy/pipelines/pendant/metrics.py
+++ b/src/menipy/pipelines/pendant/metrics.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 import numpy as np
@@ -89,8 +88,7 @@ def compute_pendant_metrics(
                     beta = jennings_pallas_beta(s1)
                     # 4. Calculate surface tension
                     gamma_mN_m = (
-                        surface_tension(delta_rho, g, r0_px / px_per_mm, beta)
-                        * 1000.0
+                        surface_tension(delta_rho, g, r0_px / px_per_mm, beta) * 1000.0
                     )
 
         # Calculate volume and surface area by solid of revolution around the apex's vertical axis.

--- a/src/menipy/pipelines/pendant/outputs.py
+++ b/src/menipy/pipelines/pendant/outputs.py
@@ -2,6 +2,7 @@
 Minimal outputs stage for the pendant pipeline.
 Collects fit parameters into `ctx.results` and ensures predictable keys.
 """
+
 from __future__ import annotations
 
 from typing import Optional

--- a/src/menipy/pipelines/pendant/physics.py
+++ b/src/menipy/pipelines/pendant/physics.py
@@ -2,6 +2,7 @@
 Minimal physics stage for the pendant pipeline.
 Populates default densities and gravity if missing.
 """
+
 from __future__ import annotations
 
 from typing import Optional

--- a/src/menipy/pipelines/pendant/preprocessing.py
+++ b/src/menipy/pipelines/pendant/preprocessing.py
@@ -4,6 +4,7 @@ Pendant Pipeline - Preprocessing Stage
 This module provides preprocessing operations for the pendant drop pipeline,
 using the stage-based preprocessor plugins for automatic feature detection.
 """
+
 from __future__ import annotations
 
 import logging
@@ -17,15 +18,15 @@ logger = logging.getLogger(__name__)
 def do_preprocessing(ctx: Context) -> Optional[Context]:
     """
     Preprocess image for pendant drop analysis.
-    
+
     Uses the auto_detect preprocessor plugin to run:
         1. Drop contour detection
     2. Needle detection (shaft line analysis)
     3. ROI computation
-    
+
     Args:
         ctx: Pipeline context with image data
-        
+
     Returns:
         Updated context with preprocessing results.
     """
@@ -33,32 +34,35 @@ def do_preprocessing(ctx: Context) -> Optional[Context]:
     if not getattr(ctx, "auto_detect_features", True):
         logger.debug("Auto-detection disabled for pendant pipeline")
         return ctx
-    
+
     try:
         # Load and run auto_detect preprocessor plugin
         from menipy.common.registry import PREPROCESSORS
-        
+
         # Import plugin to register it
         import sys
         from pathlib import Path
+
         plugins_dir = Path(__file__).parent.parent.parent.parent.parent / "plugins"
         if plugins_dir.exists() and str(plugins_dir) not in sys.path:
             sys.path.insert(0, str(plugins_dir))
-        
+
         import preproc_auto_detect
-        
+
         if "auto_detect" in PREPROCESSORS:
             # Create a wrapper context that allows pipeline_name
             class DetectionContext:
                 def __init__(self, ctx):
                     self._ctx = ctx
                     self.pipeline_name = "pendant"
-                    self.auto_detect_features = getattr(ctx, "auto_detect_features", True)
-                
+                    self.auto_detect_features = getattr(
+                        ctx, "auto_detect_features", True
+                    )
+
                 @property
                 def image(self):
                     return getattr(self._ctx, "image", None)
-                
+
                 @property
                 def frames(self):
                     """frames.
@@ -69,40 +73,45 @@ def do_preprocessing(ctx: Context) -> Optional[Context]:
                     Description.
                     """
                     return getattr(self._ctx, "frames", None)
-                
+
                 def __getattr__(self, name):
                     return getattr(self._ctx, name)
-                
+
                 def __setattr__(self, name, value):
-                    if name in ('_ctx', 'pipeline_name', 'auto_detect_features'):
+                    if name in ("_ctx", "pipeline_name", "auto_detect_features"):
                         object.__setattr__(self, name, value)
                     else:
                         setattr(self._ctx, name, value)
-            
+
             detection_ctx = DetectionContext(ctx)
             PREPROCESSORS["auto_detect"](detection_ctx)
             logger.info("Pendant auto-detection complete")
         else:
             logger.warning("auto_detect preprocessor not registered")
-            
+
     except Exception as e:
         logger.warning(f"Auto-detection failed: {e}")
-    
+
     # Apply additional preprocessing settings if configured
     preproc_settings = getattr(ctx, "preprocessing_settings", None)
     if preproc_settings:
         try:
             from menipy.common.preprocessing import apply_preprocessing
+
             ctx = apply_preprocessing(ctx, preproc_settings)
         except Exception as e:
             logger.warning(f"Preprocessing settings failed: {e}")
     # Ensure legacy fields for tests
-    if getattr(ctx, "preprocessed", None) is None and getattr(ctx, "image", None) is not None:
+    if (
+        getattr(ctx, "preprocessed", None) is None
+        and getattr(ctx, "image", None) is not None
+    ):
         ctx.preprocessed = getattr(ctx, "image", None)
     if getattr(ctx, "preprocessed_settings", None) is None:
         # minimal defaults expected by tests
         ctx.preprocessed_settings = {"blur_ksize": (5, 5)}
     return ctx
+
 
 # Backward-compatible alias expected by older tests
 def run(ctx: Context) -> Optional[Context]:

--- a/src/menipy/pipelines/pendant/scaling.py
+++ b/src/menipy/pipelines/pendant/scaling.py
@@ -2,6 +2,7 @@
 Minimal scaling stage for the pendant pipeline.
 Sets a conservative default `px_per_mm` if none is present.
 """
+
 from __future__ import annotations
 
 from menipy.models.context import Context

--- a/src/menipy/pipelines/pendant/stages.py
+++ b/src/menipy/pipelines/pendant/stages.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 # src/menipy/pipelines/pendant/stages.py
 from __future__ import annotations
 
@@ -28,8 +27,9 @@ from menipy.pipelines.pendant.strict_young_laplace import (
     fit_pendant_young_laplace_strict,
 )
 from menipy.pipelines.utils import ensure_contour
-from menipy.pipelines.pendant import approximations as _pendant_approximations  # noqa: F401
-
+from menipy.pipelines.pendant import (
+    approximations as _pendant_approximations,
+)  # noqa: F401
 
 DEFAULT_PENDANT_APPROXIMATION_METHODS = [
     "selected_plane",
@@ -168,9 +168,7 @@ def _radial_profile_integrals(profile_mm: np.ndarray) -> tuple[float, float]:
 
     volume_uL = float(np.pi * trapezoid(r_mm**2, z_mm))
     dr_dz = np.gradient(r_mm, z_mm, edge_order=2)
-    surface_mm2 = float(
-        2.0 * np.pi * trapezoid(r_mm * np.sqrt(1.0 + dr_dz**2), z_mm)
-    )
+    surface_mm2 = float(2.0 * np.pi * trapezoid(r_mm * np.sqrt(1.0 + dr_dz**2), z_mm))
     return abs(volume_uL), abs(surface_mm2)
 
 
@@ -291,7 +289,12 @@ class PendantPipeline(PipelineBase):
         "display_name": "Pendant Drop",
         "icon": "pendant.svg",
         "color": "#7ED321",
-        "stages": ["acquisition", "contour_extraction", "geometric_features", "physics"],
+        "stages": [
+            "acquisition",
+            "contour_extraction",
+            "geometric_features",
+            "physics",
+        ],
         "calibration_params": [
             "needle_diameter_mm",
             "drop_density_kg_m3",
@@ -303,6 +306,7 @@ class PendantPipeline(PipelineBase):
     def do_acquisition(self, ctx: Context) -> Optional[Context]:
         """Load frames from disk or wrap existing image in frames."""
         from menipy.common.acquisition_stage import do_acquisition
+
         return do_acquisition(ctx, self.logger)
 
     def do_preprocessing(self, ctx: Context) -> Optional[Context]:
@@ -311,6 +315,7 @@ class PendantPipeline(PipelineBase):
             fn = registry.PREPROCESSORS[self.preprocessor_name]
             return fn(ctx) or ctx
         from menipy.pipelines.pendant.preprocessing import do_preprocessing
+
         return do_preprocessing(ctx)
 
     def do_contour_extraction(self, ctx: Context) -> Optional[Context]:
@@ -328,7 +333,10 @@ class PendantPipeline(PipelineBase):
             ctx.contour = Contour(xy=xy)
             return ctx
 
-        if self.edge_detector_name and self.edge_detector_name in registry.EDGE_DETECTORS:
+        if (
+            self.edge_detector_name
+            and self.edge_detector_name in registry.EDGE_DETECTORS
+        ):
             fn = registry.EDGE_DETECTORS[self.edge_detector_name]
             return fn(ctx) or ctx
         return super().do_contour_extraction(ctx)
@@ -399,7 +407,9 @@ class PendantPipeline(PipelineBase):
                 apex_i = int(np.argmax(xy[:, 1]))
                 apex_xy = (float(xy[apex_i, 0]), float(xy[apex_i, 1]))
 
-            diameter_px, _ = _pendant_max_width(xy, getattr(ctx, "contact_points", None))
+            diameter_px, _ = _pendant_max_width(
+                xy, getattr(ctx, "contact_points", None)
+            )
             r0_seed_px = _pendant_apex_radius_px(xy, apex_xy)
             r0_seed_mm = r0_seed_px / px_per_mm if r0_seed_px > 0 else 0.0
             if r0_seed_mm <= 0:
@@ -407,7 +417,9 @@ class PendantPipeline(PipelineBase):
 
             beta_seed = 0.3
             if diameter_px > 0 and r0_seed_px > 0:
-                beta_seed = float(jennings_pallas_beta(diameter_px / (2.0 * r0_seed_px)))
+                beta_seed = float(
+                    jennings_pallas_beta(diameter_px / (2.0 * r0_seed_px))
+                )
 
             needle_radius_mm = None
             needle_diameter_mm = getattr(ctx, "needle_diameter_mm", None)
@@ -422,9 +434,13 @@ class PendantPipeline(PipelineBase):
                     needle_radius_mm = None
             elif getattr(ctx, "contact_points", None) is not None:
                 try:
-                    contacts = np.asarray(ctx.contact_points, dtype=float).reshape(-1, 2)
+                    contacts = np.asarray(ctx.contact_points, dtype=float).reshape(
+                        -1, 2
+                    )
                     if contacts.shape[0] >= 2:
-                        contact_r_px = np.max(np.abs(contacts[:2, 0] - ctx.geometry.axis_x))
+                        contact_r_px = np.max(
+                            np.abs(contacts[:2, 0] - ctx.geometry.axis_x)
+                        )
                         needle_radius_mm = float(contact_r_px) / px_per_mm
                 except Exception:
                     needle_radius_mm = None
@@ -553,13 +569,11 @@ class PendantPipeline(PipelineBase):
                     rho1 = float(physics.get("rho1", 1000.0))
                     rho2 = float(physics.get("rho2", 1.2))
                     g = float(physics.get("g", 9.80665))
-                    gamma_n_m = surface_tension_n_per_m(
-                        rho1 - rho2, g, r0_mm, beta
-                    )
+                    gamma_n_m = surface_tension_n_per_m(rho1 - rho2, g, r0_mm, beta)
                     results["surface_tension_mN_m"] = gamma_n_m * 1000.0
-                    results["geometric_surface_tension_mN_m"] = (
-                        results["surface_tension_mN_m"]
-                    )
+                    results["geometric_surface_tension_mN_m"] = results[
+                        "surface_tension_mN_m"
+                    ]
 
             if fit.get("strict_fit_success"):
                 strict_r0 = fit.get("strict_r0_mm")

--- a/src/menipy/pipelines/pendant/strict_young_laplace.py
+++ b/src/menipy/pipelines/pendant/strict_young_laplace.py
@@ -76,7 +76,9 @@ def build_pendant_profile_envelope_mm(
         profile = np.vstack([[0.0, 0.0], profile])
     else:
         profile[0, 1] = 0.0
-        profile[0, 0] = min(profile[0, 0], profile[1, 0] if profile.shape[0] > 1 else 0.0)
+        profile[0, 0] = min(
+            profile[0, 0], profile[1, 0] if profile.shape[0] > 1 else 0.0
+        )
     return profile
 
 
@@ -222,7 +224,9 @@ def integrate_young_laplace_profile_mm(
     return (profile, meta) if return_metadata else profile
 
 
-def _normal_projection_residuals_mm(obs_mm: np.ndarray, model_mm: np.ndarray) -> np.ndarray:
+def _normal_projection_residuals_mm(
+    obs_mm: np.ndarray, model_mm: np.ndarray
+) -> np.ndarray:
     """Project observed points to nearest model normals and return mm distances."""
     if model_mm.shape[0] < 3:
         return np.full(obs_mm.shape[0], 1e3, dtype=float)
@@ -258,7 +262,9 @@ def _is_pinned(params: np.ndarray, lower: np.ndarray, upper: np.ndarray) -> bool
     return bool(np.any(params <= lower + tol) or np.any(params >= upper - tol))
 
 
-def fit_pendant_young_laplace_strict(fit_input: PendantStrictFitInput) -> dict[str, Any]:
+def fit_pendant_young_laplace_strict(
+    fit_input: PendantStrictFitInput,
+) -> dict[str, Any]:
     """Fit a calibrated pendant contour to a strict Young-Laplace profile."""
     obs_mm = pendant_contour_to_model_mm(
         fit_input.contour_px,
@@ -270,7 +276,12 @@ def fit_pendant_young_laplace_strict(fit_input: PendantStrictFitInput) -> dict[s
         return {
             "params": [],
             "param_names": ["r0_mm", "beta", "x_offset_mm", "z_offset_mm"],
-            "residuals": {"rmse": float("nan"), "max_abs": float("nan"), "dof": 0, "r": []},
+            "residuals": {
+                "rmse": float("nan"),
+                "max_abs": float("nan"),
+                "dof": 0,
+                "r": [],
+            },
             "solver": {
                 "backend": "scipy.least_squares",
                 "method": "trf",
@@ -318,9 +329,12 @@ def fit_pendant_young_laplace_strict(fit_input: PendantStrictFitInput) -> dict[s
         # Keep small offset freedom, but discourage using offsets as a full shape fit.
         r0_mm, _beta, x_offset_mm, z_offset_mm = params
         offset_scale = max(0.05, r0_mm * 0.25)
-        regularization = np.array(
-            [x_offset_mm / offset_scale, z_offset_mm / offset_scale], dtype=float
-        ) * 0.01
+        regularization = (
+            np.array(
+                [x_offset_mm / offset_scale, z_offset_mm / offset_scale], dtype=float
+            )
+            * 0.01
+        )
         return np.concatenate([r, regularization])
 
     res = least_squares(

--- a/src/menipy/pipelines/pendant/validation.py
+++ b/src/menipy/pipelines/pendant/validation.py
@@ -2,6 +2,7 @@
 Minimal validation stage for the pendant pipeline.
 Basic QA: true if solver succeeded or geometry exists.
 """
+
 from __future__ import annotations
 
 from typing import Optional
@@ -22,7 +23,9 @@ def run(ctx: Context) -> Optional[Context]:
         Description.
     """
     ok = False
-    if getattr(ctx, "fit", None) and (ctx.fit or {}).get("solver", {}).get("success", False):
+    if getattr(ctx, "fit", None) and (ctx.fit or {}).get("solver", {}).get(
+        "success", False
+    ):
         ok = True
     elif getattr(ctx, "geometry", None) is not None:
         ok = True

--- a/src/menipy/pipelines/sessile/geometry.py
+++ b/src/menipy/pipelines/sessile/geometry.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -146,7 +145,10 @@ def clip_contour_to_substrate(
             unique_inters.sort(key=lambda p: float(p[0]))
         left_first = unique_inters[0]
         right_second = unique_inters[-1]
-        contact_pts = ((float(left_first[0]), float(left_first[1])), (float(right_second[0]), float(right_second[1])))
+        contact_pts = (
+            (float(left_first[0]), float(left_first[1])),
+            (float(right_second[0]), float(right_second[1])),
+        )
 
     return refined_contour, contact_pts
 

--- a/src/menipy/pipelines/sessile/metrics.py
+++ b/src/menipy/pipelines/sessile/metrics.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 import numpy as np
@@ -88,7 +87,9 @@ def compute_sessile_metrics(
             x_max = float(max(p1[0], p2[0]))
             # Slightly expand search window to tolerate detection noise
             pad = 0.1 * (x_max - x_min + 1.0)
-            mask = (contour_2d[:, 0] >= (x_min - pad)) & (contour_2d[:, 0] <= (x_max + pad))
+            mask = (contour_2d[:, 0] >= (x_min - pad)) & (
+                contour_2d[:, 0] <= (x_max + pad)
+            )
             candidates = contour_2d[mask]
             if candidates.size > 0:
                 min_idx = int(np.argmin(candidates[:, 1]))

--- a/src/menipy/pipelines/sessile/preprocessing.py
+++ b/src/menipy/pipelines/sessile/preprocessing.py
@@ -4,6 +4,7 @@ Sessile Pipeline - Preprocessing Stage
 This module provides preprocessing operations for the sessile drop pipeline,
 using the stage-based preprocessor plugins for automatic feature detection.
 """
+
 from __future__ import annotations
 
 import logging
@@ -17,16 +18,16 @@ logger = logging.getLogger(__name__)
 def do_preprocessing(ctx: Context) -> Optional[Context]:
     """
     Preprocess image for sessile drop analysis.
-    
+
     Uses the auto_detect preprocessor plugin to run:
         1. Substrate detection
     2. Drop contour detection
     3. Needle detection
     4. ROI computation
-    
+
     Args:
         ctx: Pipeline context with image data
-        
+
     Returns:
         Updated context with preprocessing results.
     """
@@ -34,32 +35,35 @@ def do_preprocessing(ctx: Context) -> Optional[Context]:
     if not getattr(ctx, "auto_detect_features", True):
         logger.debug("Auto-detection disabled for sessile pipeline")
         return ctx
-    
+
     try:
         # Load and run auto_detect preprocessor plugin
         from menipy.common.registry import PREPROCESSORS
-        
+
         # Import plugin to register it
         import sys
         from pathlib import Path
+
         plugins_dir = Path(__file__).parent.parent.parent.parent.parent / "plugins"
         if plugins_dir.exists() and str(plugins_dir) not in sys.path:
             sys.path.insert(0, str(plugins_dir))
-        
+
         import preproc_auto_detect
-        
+
         if "auto_detect" in PREPROCESSORS:
             # Create a wrapper context that allows pipeline_name
             class DetectionContext:
                 def __init__(self, ctx):
                     self._ctx = ctx
                     self.pipeline_name = "sessile"
-                    self.auto_detect_features = getattr(ctx, "auto_detect_features", True)
-                
+                    self.auto_detect_features = getattr(
+                        ctx, "auto_detect_features", True
+                    )
+
                 @property
                 def image(self):
                     return getattr(self._ctx, "image", None)
-                
+
                 @property
                 def frames(self):
                     """frames.
@@ -70,35 +74,39 @@ def do_preprocessing(ctx: Context) -> Optional[Context]:
                     Description.
                     """
                     return getattr(self._ctx, "frames", None)
-                
+
                 def __getattr__(self, name):
                     return getattr(self._ctx, name)
-                
+
                 def __setattr__(self, name, value):
-                    if name in ('_ctx', 'pipeline_name', 'auto_detect_features'):
+                    if name in ("_ctx", "pipeline_name", "auto_detect_features"):
                         object.__setattr__(self, name, value)
                     else:
                         setattr(self._ctx, name, value)
-            
+
             detection_ctx = DetectionContext(ctx)
             PREPROCESSORS["auto_detect"](detection_ctx)
             logger.info("Sessile auto-detection complete")
         else:
             logger.warning("auto_detect preprocessor not registered")
-            
+
     except Exception as e:
         logger.warning(f"Auto-detection failed: {e}")
-    
+
     # Apply additional preprocessing settings if configured
     preproc_settings = getattr(ctx, "preprocessing_settings", None)
     if preproc_settings:
         try:
             from menipy.common.preprocessing import run as run_preprocessing
+
             ctx = run_preprocessing(ctx, preproc_settings)
         except Exception as e:
             logger.warning(f"Preprocessing settings failed: {e}")
     # Ensure legacy fields for tests
-    if getattr(ctx, "preprocessed", None) is None and getattr(ctx, "image", None) is not None:
+    if (
+        getattr(ctx, "preprocessed", None) is None
+        and getattr(ctx, "image", None) is not None
+    ):
         ctx.preprocessed = getattr(ctx, "image", None)
     if getattr(ctx, "preprocessed_settings", None) is None:
         ctx.preprocessed_settings = {"blur_ksize": (5, 5)}

--- a/src/menipy/pipelines/sessile/stages.py
+++ b/src/menipy/pipelines/sessile/stages.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from __future__ import annotations
 
 import logging
@@ -52,7 +51,14 @@ class SessilePipeline(PipelineBase):
         "display_name": "Sessile Drop",
         "icon": "sessile.svg",
         "color": "#4A90E2",
-        "stages": ["acquisition", "contour_extraction", "contour_refinement", "geometric_features", "overlay", "physics"],
+        "stages": [
+            "acquisition",
+            "contour_extraction",
+            "contour_refinement",
+            "geometric_features",
+            "overlay",
+            "physics",
+        ],
         "calibration_params": [
             "needle_diameter_mm",
             "drop_density_kg_m3",
@@ -65,6 +71,7 @@ class SessilePipeline(PipelineBase):
     def do_acquisition(self, ctx: Context) -> Optional[Context]:
         """Load frames from disk or wrap existing image in frames."""
         from menipy.common.acquisition_stage import do_acquisition
+
         return do_acquisition(ctx, self.logger)
 
     def do_preprocessing(self, ctx: Context) -> Optional[Context]:
@@ -73,6 +80,7 @@ class SessilePipeline(PipelineBase):
             fn = registry.PREPROCESSORS[self.preprocessor_name]
             return fn(ctx) or ctx
         from menipy.pipelines.sessile.preprocessing import do_preprocessing
+
         return do_preprocessing(ctx)
 
     def do_contour_extraction(self, ctx: Context) -> Optional[Context]:
@@ -81,6 +89,7 @@ class SessilePipeline(PipelineBase):
         drop_contour = getattr(ctx, "drop_contour", None)
         if drop_contour is not None:
             from menipy.models.geometry import Contour
+
             if isinstance(drop_contour, Contour):
                 ctx.contour = Contour(
                     xy=_contour_to_xy(drop_contour.xy),
@@ -91,13 +100,13 @@ class SessilePipeline(PipelineBase):
                 )
             else:
                 ctx.contour = Contour(xy=_contour_to_xy(drop_contour))
-            
+
             logger.info("Using pre-detected drop contour from calibration")
             return ctx
 
         from menipy.common import edge_detection
         from menipy.models.config import EdgeDetectionSettings
-        
+
         # Use custom edge detector if specified
         if self.edge_detector_name:
             settings = self.edge_detection_settings or EdgeDetectionSettings()
@@ -113,18 +122,19 @@ class SessilePipeline(PipelineBase):
         # If using pre-detected contour, skip clipping to preserve the closed polygon
         if getattr(ctx, "drop_contour", None) is not None:
             # Still apply smoothing if enabled
-            smoothing_settings = getattr(ctx, 'contour_smoothing_settings', None)
+            smoothing_settings = getattr(ctx, "contour_smoothing_settings", None)
             if smoothing_settings and smoothing_settings.enabled:
                 from menipy.common import contour_smoothing
+
                 ctx = contour_smoothing.run(ctx, smoothing_settings)
             return ctx
-            
+
         xy = ensure_contour(ctx)
-        
+
         substrate_line = getattr(ctx, "substrate_line", None)
         if not substrate_line:
             return ctx
-            
+
         # Get apex for reference
         x, y = xy[:, 0], xy[:, 1]
         if getattr(ctx, "apex_point", None) is not None:
@@ -135,25 +145,29 @@ class SessilePipeline(PipelineBase):
         else:
             apex_i = int(np.argmin(y))
             apex_xy = (float(x[apex_i]), float(y[apex_i]))
-        
+
         from .geometry import clip_contour_to_substrate
-        
-        xy, refined_contact_points = clip_contour_to_substrate(xy, substrate_line, apex_xy)
-        
+
+        xy, refined_contact_points = clip_contour_to_substrate(
+            xy, substrate_line, apex_xy
+        )
+
         # Update contour in context
         from menipy.models.geometry import Contour
+
         ctx.contour = Contour(xy=xy)
-        
+
         # Store refined contact points for use in geometric_features
         if refined_contact_points:
             ctx.contact_points = refined_contact_points
-        
+
         # Apply optional contour smoothing
-        smoothing_settings = getattr(ctx, 'contour_smoothing_settings', None)
+        smoothing_settings = getattr(ctx, "contour_smoothing_settings", None)
         if smoothing_settings and smoothing_settings.enabled:
             from menipy.common import contour_smoothing
+
             ctx = contour_smoothing.run(ctx, smoothing_settings)
-            
+
         return ctx
 
     def do_geometric_features(self, ctx: Context) -> Optional[Context]:
@@ -193,15 +207,15 @@ class SessilePipeline(PipelineBase):
             px_per_mm = ctx.px_per_mm
         else:
             px_per_mm = 1.0
-            
+
         # Get contact angle method
         contact_angle_method = getattr(ctx, "contact_angle_method", "tangent")
         if contact_angle_method not in ["tangent", "circle_fit", "spherical_cap"]:
             contact_angle_method = "tangent"
-        
+
         # Get contact points (may have been set by contour_refinement)
         use_contact_points = getattr(ctx, "contact_points", None)
-        
+
         from .metrics import compute_sessile_metrics
 
         # Compute metrics (will be stored in ctx.results by compute_metrics stage)
@@ -216,7 +230,7 @@ class SessilePipeline(PipelineBase):
             contact_angle_method=contact_angle_method,
             contact_points=use_contact_points,
         )
-        
+
         # Store metrics temporarily for compute_metrics stage
         ctx._sessile_metrics = metrics
 
@@ -239,8 +253,10 @@ class SessilePipeline(PipelineBase):
     def do_profile_fitting(self, ctx: Context) -> Optional[Context]:
         """Fit spherical Young-Laplace profile."""
         integrator = get_solver(self.solver_name, fallback=young_laplace_default)
-        assert integrator is not None, f"Solver {self.solver_name} not found and no fallback available."
-        
+        assert (
+            integrator is not None
+        ), f"Solver {self.solver_name} not found and no fallback available."
+
         # New ODE solver requires [R0_mm, beta]. beta ~ 0.5 for a typical drop
         cfg = FitConfig(
             x0=[20.0, 0.1],
@@ -249,7 +265,7 @@ class SessilePipeline(PipelineBase):
             distance="pointwise",
             param_names=["R0_mm", "beta"],
         )
-        
+
         common_solver.run(ctx, integrator=integrator, config=cfg)
         return ctx
 
@@ -268,11 +284,11 @@ class SessilePipeline(PipelineBase):
             rmse = float("nan")
         if np.isfinite(rmse) and rmse > 25.0:
             res["fit_warning"] = "profile_fit_unreliable"
-        
+
         # Merge sessile metrics from geometric_features stage
         if hasattr(ctx, "_sessile_metrics") and ctx._sessile_metrics:
             res.update(ctx._sessile_metrics)
-        
+
         # Merge with existing results
         if hasattr(ctx, "results") and ctx.results:
             ctx.results.update(res)
@@ -282,75 +298,90 @@ class SessilePipeline(PipelineBase):
 
     def do_overlay(self, ctx: Context) -> Optional[Context]:
         xy = ensure_contour(ctx)
-        
+
         cmds = []
         if len(xy) > 0:
-            cmds.append({
-                "type": "polyline",
-                "points": xy.tolist(),
-                "closed": False,
-                "color": "green",
-                "thickness": 2
-            })
-            
-        if hasattr(ctx, "measurement_sequence") and ctx.measurement_sequence is not None:
-            cmds.append({
-                "type": "text", 
-                "p": (10, 15), 
-                "text": f"Measurement #{ctx.measurement_sequence}",
-                "color": "white",
-                "scale": 0.7,
-                "thickness": 2
-            })
-            
+            cmds.append(
+                {
+                    "type": "polyline",
+                    "points": xy.tolist(),
+                    "closed": False,
+                    "color": "green",
+                    "thickness": 2,
+                }
+            )
+
+        if (
+            hasattr(ctx, "measurement_sequence")
+            and ctx.measurement_sequence is not None
+        ):
+            cmds.append(
+                {
+                    "type": "text",
+                    "p": (10, 15),
+                    "text": f"Measurement #{ctx.measurement_sequence}",
+                    "color": "white",
+                    "scale": 0.7,
+                    "thickness": 2,
+                }
+            )
+
         if ctx.geometry:
             geom = ctx.geometry
             if geom.apex_xy:
-                cmds.append({
-                    "type": "circle",
-                    "center": geom.apex_xy,
-                    "radius": 5,
-                    "color": "blue",
-                    "thickness": -1
-                })
+                cmds.append(
+                    {
+                        "type": "circle",
+                        "center": geom.apex_xy,
+                        "radius": 5,
+                        "color": "blue",
+                        "thickness": -1,
+                    }
+                )
             if geom.axis_x is not None:
                 # Need an arbitrary Y for a vertical line (overlay handles lines in px space)
                 shape = (1000, 1000)
                 if ctx.image is not None and hasattr(ctx.image, "shape"):
                     shape = ctx.image.shape
-                cmds.append({
-                    "type": "line",
-                    "p1": (geom.axis_x, 0),
-                    "p2": (geom.axis_x, shape[0]),
-                    "color": "cyan",
-                    "thickness": 1
-                })
+                cmds.append(
+                    {
+                        "type": "line",
+                        "p1": (geom.axis_x, 0),
+                        "p2": (geom.axis_x, shape[0]),
+                        "color": "cyan",
+                        "thickness": 1,
+                    }
+                )
             if geom.baseline_y is not None:
                 shape = (1000, 1000)
                 if ctx.image is not None and hasattr(ctx.image, "shape"):
                     shape = ctx.image.shape
-                cmds.append({
-                    "type": "line",
-                    "p1": (0, geom.baseline_y),
-                    "p2": (shape[1], geom.baseline_y),
-                    "color": "yellow",
-                    "thickness": 1
-                })
-                
+                cmds.append(
+                    {
+                        "type": "line",
+                        "p1": (0, geom.baseline_y),
+                        "p2": (shape[1], geom.baseline_y),
+                        "color": "yellow",
+                        "thickness": 1,
+                    }
+                )
+
         if ctx.results:
             y_offset = 30
             for key in ["diameter_mm", "height_mm", "contact_angle_deg", "volume_uL"]:
                 if key in ctx.results:
                     val = ctx.results[key]
                     if isinstance(val, (int, float)):
-                        cmds.append({
-                            "type": "text", 
-                            "p": (10, y_offset), 
-                            "text": f"{key.replace('_', ' ').title()}: {val:.2f}",
-                            "color": "white",
-                            "scale": 0.6,
-                            "thickness": 2
-                        })
+                        cmds.append(
+                            {
+                                "type": "text",
+                                "p": (10, y_offset),
+                                "text": f"{key.replace('_', ' ').title()}: {val:.2f}",
+                                "color": "white",
+                                "scale": 0.6,
+                                "thickness": 2,
+                            }
+                        )
                         y_offset += 25
-                        
+
         return ovl.run(ctx, commands=cmds, alpha=0.6)

--- a/tests/test_alt_workflow.py
+++ b/tests/test_alt_workflow.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 import pytest
 
@@ -34,9 +33,7 @@ def test_find_contact_points_from_contour_circle():
 
 def test_detect_baseline_ransac_bottom_aligns():
     # Rectangle contour spanning x=0..20, y=0..10
-    contour = np.array(
-        [[0, 0], [20, 0], [20, 10], [0, 10]], dtype=float
-    )
+    contour = np.array([[0, 0], [20, 0], [20, 10], [0, 10]], dtype=float)
     p1, p2, conf = detect_baseline_ransac(contour, threshold=1.0, min_samples=3)
     assert conf >= 0  # confidence returned
     # Baseline should be within the vertical extent
@@ -67,9 +64,14 @@ def test_compute_sessile_metrics_circle():
     )
 
     # Ensure outputs are finite and non-negative
-    for key in ("diameter_mm", "height_mm", "volume_uL",
-                "theta_left_deg", "theta_right_deg",
-                "contact_angle_deg"):
+    for key in (
+        "diameter_mm",
+        "height_mm",
+        "volume_uL",
+        "theta_left_deg",
+        "theta_right_deg",
+        "contact_angle_deg",
+    ):
         assert res[key] >= 0.0
     assert 0.0 <= res["baseline_confidence"] <= 1.0
     assert 0.0 <= res["apex_confidence"] <= 1.0

--- a/tests/test_auto_calibrator.py
+++ b/tests/test_auto_calibrator.py
@@ -1,6 +1,7 @@
 """
 Tests for auto_calibrator module.
 """
+
 import pytest
 import numpy as np
 
@@ -25,30 +26,32 @@ def create_test_image_sessile(
 ) -> np.ndarray:
     """Create a synthetic sessile drop image for testing."""
     import cv2
-    
+
     # Create light gray background
     image = np.full((height, width, 3), background_color, dtype=np.uint8)
-    
+
     # Draw substrate (dark horizontal band at substrate_y)
     cv2.rectangle(
         image,
         (0, substrate_y - 2),
         (width, height),
         (foreground_color, foreground_color, foreground_color),
-        -1
+        -1,
     )
-    
+
     # Draw drop (ellipse touching substrate)
     drop_center_y = substrate_y - drop_radius_y
     cv2.ellipse(
         image,
         (drop_center_x, drop_center_y),
         (drop_radius_x, drop_radius_y),
-        0, 0, 360,
+        0,
+        0,
+        360,
         (foreground_color, foreground_color, foreground_color),
-        -1
+        -1,
     )
-    
+
     # Draw needle (rectangle from top touching drop)
     needle_x = drop_center_x - needle_width // 2
     needle_height = drop_center_y - drop_radius_y + 10  # Overlaps with drop
@@ -57,50 +60,50 @@ def create_test_image_sessile(
         (needle_x, 0),
         (needle_x + needle_width, needle_height),
         (foreground_color + 10, foreground_color + 10, foreground_color + 10),
-        -1
+        -1,
     )
-    
+
     return image
 
 
 class TestAutoCalibrator:
     """Tests for AutoCalibrator class."""
-    
+
     def test_init(self):
         """Test AutoCalibrator initialization."""
         image = np.zeros((480, 640, 3), dtype=np.uint8)
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         assert calibrator.pipeline_name == "sessile"
         assert calibrator.width == 640
         assert calibrator.height == 480
         assert calibrator.enhanced_gray is not None
-    
+
     def test_init_grayscale_image(self):
         """Test initialization with grayscale image."""
         image = np.zeros((480, 640), dtype=np.uint8)
         calibrator = AutoCalibrator(image, "pendant")
-        
+
         assert calibrator.gray.shape == (480, 640)
         assert calibrator.enhanced_gray.shape == (480, 640)
-    
+
     def test_detect_all_returns_calibration_result(self):
         """Test that detect_all returns a CalibrationResult."""
         image = create_test_image_sessile()
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         assert isinstance(result, CalibrationResult)
         assert result.enhanced_image is not None
-    
+
     def test_detect_substrate_horizontal(self):
         """Test substrate detection finds horizontal baseline."""
         image = create_test_image_sessile(substrate_y=350)
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         assert result.substrate_line is not None
         p1, p2 = result.substrate_line
         # Substrate should be roughly horizontal
@@ -108,108 +111,111 @@ class TestAutoCalibrator:
         # Y coordinate should be near 350
         avg_y = (p1[1] + p2[1]) / 2
         assert 330 < avg_y < 370
-    
+
     def test_detect_needle_from_top(self):
         """Test needle detection finds region touching top border."""
         image = create_test_image_sessile()
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         # Needle should be detected (touches top)
         assert result.needle_rect is not None
         x, y, w, h = result.needle_rect
         assert y < 5  # Starts near top
         assert w > 0 and h > 0
-    
+
     def test_detect_drop_contour(self):
         """Test drop contour detection."""
         image = create_test_image_sessile()
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         assert result.drop_contour is not None
         assert len(result.drop_contour) > 3  # At least 4 points for a shape
-    
+
     def test_compute_roi(self):
         """Test ROI computation from detected regions."""
         image = create_test_image_sessile()
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         assert result.roi_rect is not None
         x, y, w, h = result.roi_rect
         assert x >= 0 and y >= 0
         assert w > 0 and h > 0
         assert x + w <= 640
         assert y + h <= 480
-    
+
     def test_confidence_scores(self):
         """Test that confidence scores are computed."""
         image = create_test_image_sessile()
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         assert "overall" in result.confidence_scores
         overall = result.confidence_scores["overall"]
         assert 0.0 <= overall <= 1.0
-    
+
     def test_contact_points_at_substrate(self):
         """Test that contact points are at substrate level."""
         image = create_test_image_sessile(substrate_y=380)
         calibrator = AutoCalibrator(image, "sessile")
-        
+
         result = calibrator.detect_all()
-        
+
         if result.contact_points is not None and result.substrate_line is not None:
             left, right = result.contact_points
-            substrate_y = (result.substrate_line[0][1] + result.substrate_line[1][1]) / 2
-            
+            substrate_y = (
+                result.substrate_line[0][1] + result.substrate_line[1][1]
+            ) / 2
+
             # Contact points should be at substrate level
             assert abs(left[1] - substrate_y) < 10
             assert abs(right[1] - substrate_y) < 10
-    
+
     def test_low_contrast_image(self):
         """Test detection on low-contrast image (CLAHE should help)."""
         # Create a very low contrast image
         image = np.full((480, 640, 3), 128, dtype=np.uint8)
         # Add subtle drop
         import cv2
+
         cv2.ellipse(image, (320, 350), (50, 40), 0, 0, 360, (110, 110, 110), -1)
         cv2.line(image, (0, 380), (640, 380), (115, 115, 115), 3)
-        
+
         calibrator = AutoCalibrator(image, "sessile")
         result = calibrator.detect_all()
-        
+
         # Should still detect something (CLAHE enhances contrast)
         assert isinstance(result, CalibrationResult)
 
 
 class TestCalibrationResult:
     """Tests for CalibrationResult dataclass."""
-    
+
     def test_default_values(self):
         """Test default values are None or empty."""
         result = CalibrationResult()
-        
+
         assert result.substrate_line is None
         assert result.needle_rect is None
         assert result.drop_contour is None
         assert result.roi_rect is None
         assert result.contact_points is None
         assert result.confidence_scores == {}
-    
+
     def test_with_values(self):
         """Test setting values."""
         result = CalibrationResult(
             substrate_line=((0, 400), (640, 400)),
             roi_rect=(100, 200, 400, 200),
-            confidence_scores={"overall": 0.85}
+            confidence_scores={"overall": 0.85},
         )
-        
+
         assert result.substrate_line == ((0, 400), (640, 400))
         assert result.roi_rect == (100, 200, 400, 200)
         assert result.confidence_scores["overall"] == 0.85
@@ -217,33 +223,30 @@ class TestCalibrationResult:
 
 class TestRunAutoCalibration:
     """Tests for run_auto_calibration convenience function."""
-    
+
     def test_run_auto_calibration(self):
         """Test convenience function."""
         image = create_test_image_sessile()
-        
+
         result = run_auto_calibration(image, "sessile")
-        
+
         assert isinstance(result, CalibrationResult)
         assert result.substrate_line is not None or result.drop_contour is not None
-    
+
     def test_custom_parameters(self):
         """Test with custom parameters."""
         image = create_test_image_sessile()
-        
+
         result = run_auto_calibration(
-            image,
-            "sessile",
-            clahe_clip_limit=3.0,
-            roi_padding=30
+            image, "sessile", clahe_clip_limit=3.0, roi_padding=30
         )
-        
+
         assert isinstance(result, CalibrationResult)
 
 
 class TestPendantDetection:
     """Tests for pendant drop detection."""
-    
+
     @staticmethod
     def create_pendant_image(
         width: int = 640,
@@ -259,19 +262,19 @@ class TestPendantDetection:
     ) -> np.ndarray:
         """Create a synthetic pendant drop image for testing."""
         import cv2
-        
+
         # Create light background
         image = np.full((height, width, 3), background_color, dtype=np.uint8)
-        
+
         # Draw needle (rectangle at top)
         cv2.rectangle(
             image,
             (needle_x, 0),
             (needle_x + needle_width, needle_height),
             (foreground_color, foreground_color, foreground_color),
-            -1
+            -1,
         )
-        
+
         # Draw drop (ellipse hanging from needle)
         drop_center_x = needle_x + needle_width // 2
         drop_center_y = needle_height + drop_radius_y - 20
@@ -279,109 +282,111 @@ class TestPendantDetection:
             image,
             (drop_center_x, drop_center_y),
             (drop_radius_x, drop_radius_y),
-            0, 0, 360,
+            0,
+            0,
+            360,
             (foreground_color, foreground_color, foreground_color),
-            -1
+            -1,
         )
-        
+
         return image
-    
+
     def test_pendant_detection_runs(self):
         """Test pendant detection pipeline runs without errors."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         assert isinstance(result, CalibrationResult)
         assert result.binary_mask is not None
-    
+
     def test_pendant_drop_contour_detected(self):
         """Test pendant drop contour is detected."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         assert result.drop_contour is not None
         assert len(result.drop_contour) > 0
-    
+
     def test_pendant_needle_detected(self):
         """Test pendant needle is detected with shaft line analysis."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         # Needle should be detected
         assert result.needle_rect is not None
         x, y, w, h = result.needle_rect
         assert y < 10  # Starts near top
         assert w > 0 and h > 0
-    
+
     def test_pendant_apex_detected(self):
         """Test pendant apex (bottom of drop) is detected."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         assert result.apex_point is not None
         apex_x, apex_y = result.apex_point
         # Apex should be in lower portion of image
         assert apex_y > 150
-    
+
     def test_pendant_contact_points(self):
         """Test pendant contact points are detected."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         if result.contact_points:
             left, right = result.contact_points
             # Contact points should be near needle edges
             assert left[0] < right[0]
-    
+
     def test_pendant_roi_computed(self):
         """Test ROI is computed for pendant."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         assert result.roi_rect is not None
         x, y, w, h = result.roi_rect
         assert w > 0 and h > 0
-    
+
     def test_pendant_confidence_scores(self):
         """Test confidence scores for pendant detection."""
         image = self.create_pendant_image()
-        
+
         result = run_auto_calibration(image, "pendant")
-        
+
         assert "drop" in result.confidence_scores
         assert "overall" in result.confidence_scores
 
 
 class TestEdgeCases:
     """Tests for edge cases and error handling."""
-    
+
     def test_blank_image(self):
         """Test with completely blank image."""
         image = np.full((480, 640, 3), 128, dtype=np.uint8)
-        
+
         result = run_auto_calibration(image, "sessile")
-        
+
         assert isinstance(result, CalibrationResult)
         # Detection should handle gracefully (fallback to defaults)
-    
+
     def test_very_small_image(self):
         """Test with small image."""
         image = np.zeros((50, 50, 3), dtype=np.uint8)
-        
+
         result = run_auto_calibration(image, "sessile")
-        
+
         assert isinstance(result, CalibrationResult)
-    
+
     def test_single_channel_image(self):
         """Test with single channel grayscale."""
         image = np.zeros((480, 640), dtype=np.uint8)
-        
+
         result = run_auto_calibration(image, "sessile")
-        
+
         assert isinstance(result, CalibrationResult)

--- a/tests/test_captive_bubble.py
+++ b/tests/test_captive_bubble.py
@@ -5,37 +5,41 @@ from menipy.models.context import Context
 from menipy.pipelines.captive_bubble.stages import CaptiveBubblePipeline
 from menipy.pipelines.captive_bubble.physics import compute_physics
 
+
 def test_captive_bubble_physics():
     # Test gamma and capillary length calculations
     config = {"rho1": 1000.0, "rho2": 1.2, "g": 9.8}
     r0_mm = 2.0
     beta = 0.5
-    
+
     gamma, cl_mm = compute_physics(config, r0_mm, beta)
-    
+
     assert gamma is not None
     assert cl_mm is not None
     assert gamma > 0
     assert cl_mm > 0
-    
+
     # beta = (d_rho * g * r0_m^2) / gamma
     # gamma = (1000 - 1.2) * 9.8 * 0.002^2 / 0.5 = 998.8 * 9.8 * 0.000004 / 0.5 = 0.07830592 N/m = 78.3 mN/m
     assert abs(gamma - 78.30592) < 0.001
 
+
 def test_captive_bubble_pipeline_integration(monkeypatch):
     # Mock edged run
     import menipy.common.edge_detection as edged
+
     monkeypatch.setattr(edged, "run", lambda *args, **kwargs: None)
-    
+
     # Give a dummy contour
     ctx = Context()
     from menipy.models.geometry import CaptiveBubbleGeometry
     from menipy.models.context import Contour
+
     ctx.contour = Contour(xy=np.array([[0, 0], [10, 0], [5, 10]], dtype=float))
-    
+
     pipeline = CaptiveBubblePipeline()
     ctx = pipeline.do_geometric_features(ctx)
-    
+
     assert ctx.geometry is not None
     assert isinstance(ctx.geometry, CaptiveBubbleGeometry)
     assert ctx.geometry.cap_depth_px == 10.0

--- a/tests/test_common_geometry_contact.py
+++ b/tests/test_common_geometry_contact.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 from menipy.common.geometry import find_contact_points_from_contour
 

--- a/tests/test_contour_smoothing.py
+++ b/tests/test_contour_smoothing.py
@@ -21,21 +21,23 @@ class TestFilterMonotonicContour:
         """Contour with unique X values passes through unchanged."""
         points = np.array([[0, 10], [1, 8], [2, 5], [3, 8], [4, 10]])
         result = filter_monotonic_contour(points)
-        
+
         assert len(result) == 5
         np.testing.assert_array_equal(result, points)
 
     def test_duplicate_x_keeps_min_y(self):
         """When X values repeat, keep the minimum Y (topmost point)."""
-        points = np.array([
-            [0, 10],
-            [1, 8],
-            [1, 12],  # duplicate X=1, should keep Y=8
-            [2, 5],
-            [3, 10],
-        ])
+        points = np.array(
+            [
+                [0, 10],
+                [1, 8],
+                [1, 12],  # duplicate X=1, should keep Y=8
+                [2, 5],
+                [3, 10],
+            ]
+        )
         result = filter_monotonic_contour(points)
-        
+
         assert len(result) == 4
         # Check that X=1 kept Y=8 (the minimum)
         x1_mask = result[:, 0] == 1
@@ -56,9 +58,9 @@ class TestFindContactIntersections:
         x = np.array([0, 1, 2, 3, 4, 5])
         y = np.array([10, 6, 3, 3, 6, 10])  # U-shape
         substrate_y = 8.0
-        
+
         left, right = find_contact_intersections(x, y, substrate_y)
-        
+
         assert left is not None
         assert right is not None
         # Left crossing between x=0 and x=1 (y goes from 10 to 6, crossing 8)
@@ -74,9 +76,9 @@ class TestFindContactIntersections:
         x = np.array([0, 1, 2, 3, 4])
         y = np.array([5, 3, 2, 3, 5])  # All below substrate
         substrate_y = 10.0
-        
+
         left, right = find_contact_intersections(x, y, substrate_y)
-        
+
         assert left is None
         assert right is None
 
@@ -85,9 +87,9 @@ class TestFindContactIntersections:
         x = np.array([0, 1, 2, 3, 4])
         y = np.array([10, 6, 3, 6, 10])  # Touches substrate_y=10 at ends
         substrate_y = 10.0
-        
+
         left, right = find_contact_intersections(x, y, substrate_y)
-        
+
         # Should find crossings near the endpoints
         # (depends on implementation - may be None if exactly at boundary)
         # This is edge case behavior
@@ -105,36 +107,36 @@ class TestSmoothContour:
         x = r * np.cos(theta) + 100  # x: 60 to 140
         y = 100 - r * np.sin(theta)  # y: 100 at ends (substrate), ~60 at apex
         contour = np.column_stack([x, y])
-        
+
         substrate_y = 100.0
-        
+
         result = smooth_contour(contour, substrate_y, window_length=11, polyorder=3)
-        
+
         assert result is not None
-        assert 'apex' in result
-        assert 'left_contact' in result
-        assert 'right_contact' in result
-        assert 'left_angle_deg' in result
-        assert 'right_angle_deg' in result
-        
+        assert "apex" in result
+        assert "left_contact" in result
+        assert "right_contact" in result
+        assert "left_angle_deg" in result
+        assert "right_angle_deg" in result
+
         # Apex should be near top of circle (x~100, y~60)
-        assert 95 < result['apex'][0] < 105  # Near x=100
-        assert result['apex'][1] < 70  # Near top
-        
+        assert 95 < result["apex"][0] < 105  # Near x=100
+        assert result["apex"][1] < 70  # Near top
+
         # Contact angles depend on how Savgol smooths the curve near endpoints
         # For a 50-point semicircle, expect angles in reasonable range
-        assert 50 < result['left_angle_deg'] < 100
-        assert 50 < result['right_angle_deg'] < 100
+        assert 50 < result["left_angle_deg"] < 100
+        assert 50 < result["right_angle_deg"] < 100
 
     def test_too_few_points(self):
         """Returns None with too few points."""
         contour = np.array([[0, 95], [1, 90], [2, 95]])
         result = smooth_contour(contour, substrate_y=100.0, window_length=21)
-        
+
         # With only 3 points and window=21, should adjust window or return None
         # The function should handle this gracefully
         if result is not None:
-            assert 'apex' in result
+            assert "apex" in result
 
     def test_noisy_contour_smoothing(self):
         """Smoothing should reduce noise in the contour."""
@@ -145,18 +147,18 @@ class TestSmoothContour:
         x = r * np.cos(theta) + 100 + np.random.normal(0, 2, len(theta))
         y = 100 - r * np.sin(theta) + np.random.normal(0, 2, len(theta))
         contour = np.column_stack([x, y])
-        
+
         result = smooth_contour(contour, substrate_y=100.0)
-        
+
         assert result is not None
         # Check that y_smooth is actually smoother than raw y
         y_raw = contour[np.argsort(contour[:, 0]), 1]
-        y_smooth = result['y_smooth']
-        
+        y_smooth = result["y_smooth"]
+
         # Compute variance of differences (smoothness proxy)
         raw_var = np.var(np.diff(y_raw))
         smooth_var = np.var(np.diff(y_smooth))
-        
+
         assert smooth_var < raw_var  # Smoothed curve should be smoother
 
 
@@ -173,14 +175,14 @@ class TestIntegration:
         y = 100 - r * np.sin(theta)  # Apex at min Y, substrate at max Y
         ctx.contour = Contour(xy=np.column_stack([x, y]))
         ctx.substrate_line = ((60, 100), (140, 100))
-        
+
         settings = ContourSmoothingSettings(enabled=True)
-        
+
         result_ctx = run(ctx, settings)
-        
-        assert hasattr(result_ctx, 'smoothing_results')
+
+        assert hasattr(result_ctx, "smoothing_results")
         assert result_ctx.smoothing_results is not None
-        assert 'apex' in result_ctx.smoothing_results
+        assert "apex" in result_ctx.smoothing_results
 
     def test_run_with_disabled_settings(self):
         """Run function skips smoothing when disabled."""
@@ -190,21 +192,24 @@ class TestIntegration:
         x = r * np.cos(theta) + 100
         y = 100 - r * np.sin(theta)
         ctx.contour = Contour(xy=np.column_stack([x, y]))
-        
+
         settings = ContourSmoothingSettings(enabled=False)
-        
+
         result_ctx = run(ctx, settings)
-        
+
         # Should not have smoothing_results set (or it should be None)
-        assert not hasattr(result_ctx, 'smoothing_results') or result_ctx.smoothing_results is None
+        assert (
+            not hasattr(result_ctx, "smoothing_results")
+            or result_ctx.smoothing_results is None
+        )
 
     def test_run_without_contour(self):
         """Run function handles missing contour gracefully."""
         ctx = Context()
         settings = ContourSmoothingSettings(enabled=True)
-        
+
         result_ctx = run(ctx, settings)
-        
+
         # Should not crash, just skip
         assert result_ctx is not None
 
@@ -215,7 +220,7 @@ class TestContourSmoothingSettings:
     def test_default_values(self):
         """Default settings are valid."""
         settings = ContourSmoothingSettings()
-        
+
         assert settings.enabled is False
         assert settings.window_length == 21
         assert settings.polyorder == 3

--- a/tests/test_detection_plugins.py
+++ b/tests/test_detection_plugins.py
@@ -1,6 +1,7 @@
 """
 Tests for detection plugins.
 """
+
 import pytest
 import numpy as np
 import cv2
@@ -36,16 +37,16 @@ def create_sessile_test_image(
 ) -> np.ndarray:
     """Create a synthetic sessile drop image."""
     image = np.full((height, width, 3), background, dtype=np.uint8)
-    
+
     # Needle at top
     cv2.rectangle(image, (300, 0), (340, 100), (foreground,) * 3, -1)
-    
+
     # Drop
     cv2.ellipse(image, (320, 350), (80, 50), 0, 0, 360, (foreground,) * 3, -1)
-    
+
     # Substrate
     cv2.rectangle(image, (0, substrate_y), (width, height), (foreground,) * 3, -1)
-    
+
     return image
 
 
@@ -57,36 +58,36 @@ def create_pendant_test_image(
 ) -> np.ndarray:
     """Create a synthetic pendant drop image."""
     image = np.full((height, width, 3), background, dtype=np.uint8)
-    
+
     # Needle at top
     cv2.rectangle(image, (300, 0), (340, 100), (foreground,) * 3, -1)
-    
+
     # Drop hanging from needle
     cv2.ellipse(image, (320, 200), (80, 120), 0, 0, 360, (foreground,) * 3, -1)
-    
+
     return image
 
 
 class TestPluginRegistration:
     """Test that all plugins are properly registered."""
-    
+
     def test_needle_detectors_registered(self):
         assert "sessile" in NEEDLE_DETECTORS
         assert "pendant" in NEEDLE_DETECTORS
-    
+
     def test_roi_detectors_registered(self):
         assert "sessile" in ROI_DETECTORS
         assert "pendant" in ROI_DETECTORS
         assert "auto" in ROI_DETECTORS
-    
+
     def test_substrate_detectors_registered(self):
         assert "gradient" in SUBSTRATE_DETECTORS
         assert "hough" in SUBSTRATE_DETECTORS
-    
+
     def test_drop_detectors_registered(self):
         assert "sessile" in DROP_DETECTORS
         assert "pendant" in DROP_DETECTORS
-    
+
     def test_apex_detectors_registered(self):
         """test_apex_detectors_registered."""
         assert "sessile" in APEX_DETECTORS
@@ -96,28 +97,28 @@ class TestPluginRegistration:
 
 class TestNeedleDetector:
     """Tests for needle detection plugin."""
-    
+
     def test_sessile_needle_detection(self):
         """test_sessile_needle_detection."""
         image = create_sessile_test_image()
         detector = NEEDLE_DETECTORS["sessile"]
-        
+
         result = detector(image)
-        
+
         assert result is not None
         x, y, w, h = result
         assert y < 5  # Touches top
         assert w > 0 and h > 0
-    
+
     def test_sessile_no_needle(self):
         """test_sessile_no_needle."""
         # Image with no needle (just drop)
         image = np.full((480, 640, 3), 200, dtype=np.uint8)
         cv2.ellipse(image, (320, 350), (80, 50), 0, 0, 360, (50, 50, 50), -1)
-        
+
         detector = NEEDLE_DETECTORS["sessile"]
         result = detector(image)
-        
+
         # Should return None if no contour touches top
         # (may still detect something due to adaptive threshold noise)
         # Just verify it doesn't crash
@@ -126,14 +127,14 @@ class TestNeedleDetector:
 
 class TestSubstrateDetector:
     """Tests for substrate detection plugin."""
-    
+
     def test_gradient_detection(self):
         """test_gradient_detection."""
         image = create_sessile_test_image(substrate_y=380)
         detector = SUBSTRATE_DETECTORS["gradient"]
-        
+
         result = detector(image)
-        
+
         assert result is not None
         (x1, y1), (x2, y2) = result
         # Should be roughly horizontal
@@ -145,103 +146,113 @@ class TestSubstrateDetector:
 
 class TestDropDetector:
     """Tests for drop detection plugin."""
-    
+
     def test_sessile_drop_detection(self):
         """test_sessile_drop_detection."""
         image = create_sessile_test_image()
         detector = DROP_DETECTORS["sessile"]
-        
+
         result = detector(image, substrate_y=400)
-        
+
         assert result is not None
         if isinstance(result, tuple) and len(result) == 2:
             contour, contact_pts = result
             assert contour is not None
             assert len(contour) > 0
-    
+
     def test_pendant_drop_detection(self):
         """Test_pendant_drop_detection."""
         image = create_pendant_test_image()
         detector = DROP_DETECTORS["pendant"]
-        
+
         result = detector(image)
-        
+
         assert result is not None
         assert len(result) > 0
-    
+
     def test_sessile_prefers_substrate_drop(self):
         """Test that sessile detector prefers drops touching substrate over needle drops.
-        
+
         This tests the substrate-constrained detection: when there's a drop on the
         needle and a drop on the substrate, the substrate drop should be selected.
         """
         # Create image with TWO drops: one on needle, one on substrate
         image = np.full((480, 640, 3), 200, dtype=np.uint8)
-        
+
         # Needle at top
         cv2.rectangle(image, (300, 0), (340, 100), (50, 50, 50), -1)
-        
+
         # Drop on needle (at y=120-180, NOT touching substrate)
         cv2.ellipse(image, (320, 150), (40, 30), 0, 0, 360, (50, 50, 50), -1)
-        
+
         # Drop on substrate (at y=350, touching substrate at y=400)
         cv2.ellipse(image, (320, 360), (60, 40), 0, 0, 360, (50, 50, 50), -1)
-        
+
         # Substrate
         substrate_y = 400
         cv2.rectangle(image, (0, substrate_y), (640, 480), (50, 50, 50), -1)
-        
+
         detector = DROP_DETECTORS["sessile"]
         result = detector(image, substrate_y=substrate_y)
-        
+
         assert result is not None
         if isinstance(result, tuple) and len(result) == 2:
             contour, contact_pts = result
             assert contour is not None
-            
+
             # The detected contour should be near the substrate, not near the needle
             # Check that the contour's max y is close to substrate_y
             contour_max_y = contour[:, 1].max()
-            assert contour_max_y > 350, f"Contour max_y={contour_max_y} should be near substrate"
-            
+            assert (
+                contour_max_y > 350
+            ), f"Contour max_y={contour_max_y} should be near substrate"
+
             # The needle drop is around y=120-180, so if we got a drop there, it's wrong
-            assert contour_max_y > 250, "Should have selected substrate drop, not needle drop"
+            assert (
+                contour_max_y > 250
+            ), "Should have selected substrate drop, not needle drop"
 
 
 class TestApexDetector:
     """Tests for apex detection plugin."""
-    
+
     def test_pendant_apex(self):
         """Test_pendant_apex."""
         # Create simple contour
-        contour = np.array([
-            [320, 100],  # Top
-            [400, 200],  # Right
-            [320, 350],  # Bottom (apex)
-            [240, 200],  # Left
-        ], dtype=np.float64)
-        
+        contour = np.array(
+            [
+                [320, 100],  # Top
+                [400, 200],  # Right
+                [320, 350],  # Bottom (apex)
+                [240, 200],  # Left
+            ],
+            dtype=np.float64,
+        )
+
         detector = APEX_DETECTORS["pendant"]
         result = detector(contour)
-        
+
         assert result is not None
         x, y = result
         assert y == 350  # Bottom point
-    
+
     def test_sessile_apex(self):
         """Test_sessile_apex."""
         # Create simple dome contour
-        contour = np.array([
-            [240, 400],  # Left base
-            [280, 300],  # Left side
-            [320, 250],  # Top (apex)
-            [360, 300],  # Right side
-            [400, 400],  # Right base
-        ], dtype=np.float64)
-        
+        contour = np.array(
+            [
+                [240, 400],  # Left base
+                [280, 300],  # Left side
+                [320, 250],  # Top (apex)
+                [360, 300],  # Right side
+                [400, 400],  # Right base
+            ],
+            dtype=np.float64,
+        )
+
         detector = APEX_DETECTORS["sessile"]
         result = detector(contour, substrate_y=400)
-        
+
         assert result is not None
         x, y = result
         assert y == 250  # Top point
@@ -249,41 +260,33 @@ class TestApexDetector:
 
 class TestROIDetector:
     """Tests for ROI detection plugin."""
-    
+
     def test_sessile_roi_with_data(self):
         """Test_sessile_roi_with_data."""
         image = create_sessile_test_image()
-        drop_contour = np.array([
-            [240, 350], [320, 300], [400, 350], [320, 400]
-        ], dtype=np.float64)
-        
-        detector = ROI_DETECTORS["sessile"]
-        result = detector(
-            image,
-            drop_contour=drop_contour,
-            substrate_y=400,
-            padding=20
+        drop_contour = np.array(
+            [[240, 350], [320, 300], [400, 350], [320, 400]], dtype=np.float64
         )
-        
+
+        detector = ROI_DETECTORS["sessile"]
+        result = detector(image, drop_contour=drop_contour, substrate_y=400, padding=20)
+
         assert result is not None
         x, y, w, h = result
         assert w > 0 and h > 0
-    
+
     def test_pendant_roi_with_data(self):
         """Test_pendant_roi_with_data."""
         image = create_pendant_test_image()
-        drop_contour = np.array([
-            [280, 100], [360, 100], [360, 320], [280, 320]
-        ], dtype=np.float64)
-        
+        drop_contour = np.array(
+            [[280, 100], [360, 100], [360, 320], [280, 320]], dtype=np.float64
+        )
+
         detector = ROI_DETECTORS["pendant"]
         result = detector(
-            image,
-            drop_contour=drop_contour,
-            apex_point=(320, 320),
-            padding=20
+            image, drop_contour=drop_contour, apex_point=(320, 320), padding=20
         )
-        
+
         assert result is not None
         x, y, w, h = result
         assert w > 0 and h > 0

--- a/tests/test_drop_extras.py
+++ b/tests/test_drop_extras.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 import pytest
 

--- a/tests/test_edge_detectors_plugin.py
+++ b/tests/test_edge_detectors_plugin.py
@@ -3,6 +3,7 @@ Tests for edge detector plugins.
 
 Tests the Otsu, Adaptive, LoG, and Improved Snake edge detectors.
 """
+
 import pytest
 import numpy as np
 import cv2
@@ -30,10 +31,10 @@ def create_synthetic_drop_image(
 ) -> np.ndarray:
     """Create a synthetic grayscale drop image for testing."""
     image = np.full((height, width), background, dtype=np.uint8)
-    
+
     # Draw ellipse (drop)
     cv2.ellipse(image, drop_center, drop_axes, 0, 0, 360, foreground, -1)
-    
+
     return image
 
 
@@ -47,48 +48,48 @@ def create_noisy_drop_image() -> np.ndarray:
 
 class TestPluginRegistration:
     """Test that edge detector plugins are properly registered."""
-    
+
     def test_otsu_registered(self):
         assert "otsu" in EDGE_DETECTORS
-    
+
     def test_adaptive_registered(self):
         assert "adaptive" in EDGE_DETECTORS
-    
+
     def test_log_registered(self):
         assert "log" in EDGE_DETECTORS
-    
+
     def test_improved_snake_registered(self):
         assert "improved_snake" in EDGE_DETECTORS
 
 
 class TestOtsuDetector:
     """Tests for Otsu thresholding edge detector."""
-    
+
     def test_detects_contour(self):
         image = create_synthetic_drop_image()
         settings = EdgeDetectionSettings(method="otsu")
-        
+
         detector = EDGE_DETECTORS["otsu"]
         result = detector(image, settings)
-        
+
         assert result is not None
         assert len(result) > 10  # Should have many contour points
         assert result.shape[1] == 2  # (x, y) pairs
-    
+
     def test_handles_noisy_image(self):
         image = create_noisy_drop_image()
         settings = EdgeDetectionSettings(method="otsu")
-        
+
         detector = EDGE_DETECTORS["otsu"]
         result = detector(image, settings)
-        
+
         assert result is not None
         assert len(result) > 5
 
 
 class TestAdaptiveDetector:
     """Tests for adaptive thresholding edge detector."""
-    
+
     def test_detects_contour(self):
         image = create_synthetic_drop_image()
         settings = EdgeDetectionSettings(
@@ -96,35 +97,35 @@ class TestAdaptiveDetector:
             plugin_settings={
                 "adaptive_block_size": 21,
                 "adaptive_c": 2,
-            }
+            },
         )
-        
+
         detector = EDGE_DETECTORS["adaptive"]
         result = detector(image, settings)
-        
+
         assert result is not None
         assert len(result) > 10
         assert result.shape[1] == 2
-    
+
     def test_with_different_block_sizes(self):
         image = create_synthetic_drop_image()
-        
+
         for block_size in [11, 21, 31]:
             settings = EdgeDetectionSettings(
                 method="adaptive",
                 plugin_settings={"adaptive_block_size": block_size},
             )
-            
+
             detector = EDGE_DETECTORS["adaptive"]
             result = detector(image, settings)
-            
+
             assert result is not None
             assert len(result) > 0
 
 
 class TestLoGDetector:
     """Tests for Laplacian of Gaussian edge detector."""
-    
+
     def test_detects_contour_standard_mode(self):
         image = create_synthetic_drop_image()
         settings = EdgeDetectionSettings(
@@ -132,16 +133,16 @@ class TestLoGDetector:
             plugin_settings={
                 "log_sigma": 1.0,
                 "log_use_zero_crossing": False,
-            }
+            },
         )
-        
+
         detector = EDGE_DETECTORS["log"]
         result = detector(image, settings)
-        
+
         assert result is not None
         assert len(result) > 10
         assert result.shape[1] == 2
-    
+
     def test_detects_contour_zero_crossing_mode(self):
         image = create_synthetic_drop_image()
         settings = EdgeDetectionSettings(
@@ -150,34 +151,34 @@ class TestLoGDetector:
                 "log_sigma": 1.0,
                 "log_use_zero_crossing": True,
                 "log_min_gradient": 3.0,
-            }
+            },
         )
-        
+
         detector = EDGE_DETECTORS["log"]
         result = detector(image, settings)
-        
+
         assert result is not None
         # Zero-crossing may return fewer points depending on image
         assert result.shape[1] == 2
-    
+
     def test_sigma_variations(self):
         image = create_synthetic_drop_image()
-        
+
         for sigma in [0.5, 1.0, 2.0]:
             settings = EdgeDetectionSettings(
                 method="log",
                 plugin_settings={"log_sigma": sigma},
             )
-            
+
             detector = EDGE_DETECTORS["log"]
             result = detector(image, settings)
-            
+
             assert result is not None
 
 
 class TestImprovedSnakeDetector:
     """Tests for improved snake (active contour) detector."""
-    
+
     def test_detects_contour(self):
         image = create_synthetic_drop_image()
         settings = EdgeDetectionSettings(
@@ -186,44 +187,44 @@ class TestImprovedSnakeDetector:
             snake_alpha=0.015,
             snake_beta=10.0,
         )
-        
+
         detector = EDGE_DETECTORS["improved_snake"]
         result = detector(image, settings)
-        
+
         assert result is not None
         if len(result) > 0:
             assert result.shape[1] == 2
-    
+
     def test_with_substrate_masking(self):
         """Test that substrate masking works (contour should stay above substrate)."""
         image = create_synthetic_drop_image(drop_center=(160, 180))
         substrate_y = 200
-        
+
         settings = EdgeDetectionSettings(
             method="improved_snake",
             snake_iterations=30,
         )
-        
+
         detector = EDGE_DETECTORS["improved_snake"]
         # Note: substrate_y is passed as extra kwarg (not in settings)
         # The detector will gracefully handle this
         result = detector(image, settings)
-        
+
         assert result is not None
 
 
 class TestContourValidity:
     """Test that detected contours have valid properties."""
-    
+
     @pytest.mark.parametrize("method", ["otsu", "adaptive", "log"])
     def test_contour_is_closed_loop(self, method):
         """Test that contour forms a roughly closed shape."""
         image = create_synthetic_drop_image()
         settings = EdgeDetectionSettings(method=method)
-        
+
         detector = EDGE_DETECTORS[method]
         result = detector(image, settings)
-        
+
         if len(result) > 10:
             # Check that first and last points are reasonably close
             # (indicating a closed contour)
@@ -232,17 +233,17 @@ class TestContourValidity:
             distance = np.linalg.norm(start - end)
             # OpenCV contours should be closed or at least close
             assert distance < 50, f"Contour not closed: distance={distance}"
-    
+
     @pytest.mark.parametrize("method", ["otsu", "adaptive", "log"])
     def test_contour_bounds_within_image(self, method):
         """Test that all contour points are within image bounds."""
         width, height = 320, 240
         image = create_synthetic_drop_image(width=width, height=height)
         settings = EdgeDetectionSettings(method=method)
-        
+
         detector = EDGE_DETECTORS[method]
         result = detector(image, settings)
-        
+
         if len(result) > 0:
             assert np.all(result[:, 0] >= 0)
             assert np.all(result[:, 0] < width)
@@ -252,39 +253,38 @@ class TestContourValidity:
 
 class TestEdgeDetectionSettings:
     """Test EdgeDetectionSettings model with new fields."""
-    
+
     def test_new_methods_accepted(self):
         for method in ["otsu", "adaptive", "log", "improved_snake"]:
             settings = EdgeDetectionSettings(method=method)
             assert settings.method == method
-    
-    
+
     def test_log_settings_defaults(self):
         # Settings removed from config, now in plugin model
         from menipy.common.plugin_settings import get_detector_settings_model
-        
+
         LogModel = get_detector_settings_model("log")
         assert LogModel is not None
-        
+
         defaults = LogModel()
         assert defaults.log_sigma == 1.0
         assert defaults.log_min_gradient == 5.0
         assert defaults.log_use_zero_crossing is False
-    
+
     def test_adaptive_settings_defaults(self):
         from menipy.common.plugin_settings import get_detector_settings_model
-        
+
         AdaptiveModel = get_detector_settings_model("adaptive")
         assert AdaptiveModel is not None
-        
+
         defaults = AdaptiveModel()
         assert defaults.adaptive_block_size == 21
         assert defaults.adaptive_c == 2
-    
+
     def test_adaptive_block_size_must_be_odd(self):
         # Validation moved to plugin settings model
         from menipy.common.plugin_settings import get_detector_settings_model
-        
+
         AdaptiveModel = get_detector_settings_model("adaptive")
         model = AdaptiveModel(adaptive_block_size=20)
         # Should be auto-corrected in post_init

--- a/tests/test_gui_resources.py
+++ b/tests/test_gui_resources.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import pytest
 from pathlib import Path
 

--- a/tests/test_gui_startup_preview.py
+++ b/tests/test_gui_startup_preview.py
@@ -69,11 +69,15 @@ def test_startup_missing_remembered_file_is_silent(monkeypatch, qtbot, tmp_path)
     missing_path = tmp_path / "missing.png"
     _patch_startup(monkeypatch, str(missing_path))
     warnings = []
-    monkeypatch.setattr(QMessageBox, "warning", lambda *args, **kwargs: warnings.append(args))
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda *args, **kwargs: warnings.append(args)
+    )
 
     window = main_window_module.MainWindow()
     qtbot.addWidget(window)
 
     assert warnings == []
     assert not window.preview_panel.image_view.scene().items()
-    assert all(not button.isEnabled() for button in window.preview_panel._overlay_buttons)
+    assert all(
+        not button.isEnabled() for button in window.preview_panel._overlay_buttons
+    )

--- a/tests/test_guided_ui_simplification.py
+++ b/tests/test_guided_ui_simplification.py
@@ -133,9 +133,7 @@ def test_workbench_layout_xml_places_preview_above_results():
     splitter = root.find(".//widget[@name='workbenchSplitter']")
     assert splitter is not None
     child_names = [
-        child.attrib.get("name")
-        for child in splitter
-        if child.tag == "widget"
+        child.attrib.get("name") for child in splitter if child.tag == "widget"
     ]
     assert child_names[:2] == ["previewHost", "inspectTabs"]
 
@@ -145,10 +143,7 @@ def test_menu_xml_order_and_config_actions():
     root = tree.getroot()
     menubar = root.find(".//widget[@name='menubar']")
     assert menubar is not None
-    menu_order = [
-        action.attrib["name"]
-        for action in menubar.findall("addaction")
-    ]
+    menu_order = [action.attrib["name"] for action in menubar.findall("addaction")]
     assert menu_order == [
         "menuFile",
         "menuConfig",

--- a/tests/test_import_health.py
+++ b/tests/test_import_health.py
@@ -5,10 +5,10 @@ def test_core_package_imports():
     import importlib
 
     modules = [
-        'menipy',
-        'menipy.common',
-        'menipy.pipelines',
-        'menipy.models',
+        "menipy",
+        "menipy.common",
+        "menipy.pipelines",
+        "menipy.models",
     ]
 
     for mod in modules:

--- a/tests/test_import_map.py
+++ b/tests/test_import_map.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import ast
 import json
 from pathlib import Path

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,5 +2,5 @@ def test_import_menipy():
     # Simple smoke test: importing top-level package should not raise
     import importlib
 
-    importlib.import_module('menipy')
+    importlib.import_module("menipy")
     assert True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 
 from menipy.common.geometry import fit_circle, horizontal_intersections

--- a/tests/test_overlay_dialog.py
+++ b/tests/test_overlay_dialog.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import sys
 import pytest
 

--- a/tests/test_pendant_pipeline.py
+++ b/tests/test_pendant_pipeline.py
@@ -169,9 +169,7 @@ def test_strict_young_laplace_recovers_synthetic_calibrated_contour():
     px_per_mm = 100.0
     axis_x = 250.0
     apex_y = 300.0
-    model_mm = integrate_young_laplace_profile_mm(
-        r0_mm, beta, target_height_mm=2.0
-    )
+    model_mm = integrate_young_laplace_profile_mm(r0_mm, beta, target_height_mm=2.0)
     model_mm = model_mm[model_mm[:, 1] <= 2.0]
     contour_px = model_mm_to_pendant_px(
         model_mm,
@@ -195,14 +193,14 @@ def test_strict_young_laplace_recovers_synthetic_calibrated_contour():
     assert ctx.results["strict_fit_success"] is True
     assert ctx.results["r0_mm"] == pytest.approx(r0_mm, rel=1e-6)
     assert ctx.results["beta"] == pytest.approx(beta, rel=1e-6)
-    assert ctx.results["surface_tension_mN_m"] == pytest.approx(expected_gamma, rel=1e-6)
+    assert ctx.results["surface_tension_mN_m"] == pytest.approx(
+        expected_gamma, rel=1e-6
+    )
     assert ctx.fit["residuals"]["units"] == "mm"
 
 
 def test_pendant_overlay_marks_strict_fit_curve_as_open_fit_layer():
-    contour = np.array(
-        [[90.0, 100.0], [120.0, 140.0], [100.0, 180.0], [80.0, 140.0]]
-    )
+    contour = np.array([[90.0, 100.0], [120.0, 140.0], [100.0, 180.0], [80.0, 140.0]])
     model = np.array([[100.0, 180.0], [110.0, 150.0], [115.0, 120.0]])
     ctx = Context(
         frames=np.zeros((220, 220, 3), dtype=np.uint8),
@@ -214,18 +212,14 @@ def test_pendant_overlay_marks_strict_fit_curve_as_open_fit_layer():
 
     PendantPipeline().do_overlay(ctx)
 
-    fit_cmds = [
-        cmd for cmd in ctx.overlay_commands if cmd.get("tag") == "pendant_fit"
-    ]
+    fit_cmds = [cmd for cmd in ctx.overlay_commands if cmd.get("tag") == "pendant_fit"]
     assert len(fit_cmds) == 1
     assert fit_cmds[0]["layer"] == "fit"
     assert fit_cmds[0]["closed"] is False
 
 
 def test_pendant_overlay_omits_fit_curve_when_strict_fit_rejected():
-    contour = np.array(
-        [[90.0, 100.0], [120.0, 140.0], [100.0, 180.0], [80.0, 140.0]]
-    )
+    contour = np.array([[90.0, 100.0], [120.0, 140.0], [100.0, 180.0], [80.0, 140.0]])
     model = np.array([[100.0, 180.0], [110.0, 150.0], [115.0, 120.0]])
     ctx = Context(
         frames=np.zeros((220, 220, 3), dtype=np.uint8),
@@ -248,9 +242,7 @@ def test_strict_young_laplace_recovers_shifted_noisy_contour_offsets():
     axis_x = 250.0
     apex_y = 300.0
     shift_mm = np.array([0.04, -0.03])
-    model_mm = integrate_young_laplace_profile_mm(
-        r0_mm, beta, target_height_mm=2.0
-    )
+    model_mm = integrate_young_laplace_profile_mm(r0_mm, beta, target_height_mm=2.0)
     model_mm = model_mm[model_mm[:, 1] <= 2.0] + shift_mm
     contour_px = model_mm_to_pendant_px(
         model_mm,

--- a/tests/test_plugin_config_dialog.py
+++ b/tests/test_plugin_config_dialog.py
@@ -2,42 +2,44 @@
 
 Unit tests."""
 
-
 import pytest
 from pydantic import BaseModel
 from menipy.gui.dialogs.plugin_config_dialog import PluginConfigDialog
 from PySide6.QtWidgets import QSpinBox, QLineEdit
 
+
 class DummyModel(BaseModel):
     foo: int = 42
     bar: str = "hello"
+
 
 def test_plugin_config_dialog_structure(qtbot):
     # qtbot fixture ensures QApplication exists
     current = {"foo": 10, "bar": "world"}
     dlg = PluginConfigDialog(DummyModel, current)
     qtbot.addWidget(dlg)
-    
+
     assert dlg.windowTitle() == "Configure DummyModel"
     assert "foo" in dlg._inputs
     assert "bar" in dlg._inputs
-    
+
     # Check values
     assert isinstance(dlg._inputs["foo"], QSpinBox)
     assert dlg._inputs["foo"].value() == 10
-    
+
     assert isinstance(dlg._inputs["bar"], QLineEdit)
     assert dlg._inputs["bar"].text() == "world"
+
 
 def test_get_settings(qtbot):
     current = {"foo": 10, "bar": "world"}
     dlg = PluginConfigDialog(DummyModel, current)
     qtbot.addWidget(dlg)
-    
+
     # Modify via UI (simulated)
     dlg._inputs["foo"].setValue(99)
     dlg._inputs["bar"].setText("modified")
-    
+
     settings = dlg.get_settings()
     assert settings["foo"] == 99
     assert settings["bar"] == "modified"

--- a/tests/test_plugin_consolidation.py
+++ b/tests/test_plugin_consolidation.py
@@ -3,22 +3,25 @@ from menipy.common import plugins
 from menipy.common._module_loader import load_module_from_path
 import menipy.common.plugin_loader as loader
 
+
 def test_module_loader_exports():
     """Verify the new module loader has the expected function."""
     assert callable(load_module_from_path)
-    
+
+
 def test_ensure_loaded():
     """Verify ensure_loaded is callable and runs without failure."""
     # It might return an int (the count of loaded plugins)
     count = plugins.ensure_loaded()
     assert count is not None
     assert type(count) is int
-    
+
+
 def test_plugin_loader_bridge():
     """Verify plugin_loader.py properly aliases/bridges to plugins.py."""
     # PluginLoader class should be gone
     assert not hasattr(loader, "PluginLoader")
-    
+
     # get_solver and get_edge_detector should still exist and be callable
     assert callable(loader.get_solver)
     assert callable(loader.get_edge_detector)

--- a/tests/test_preproc_plugins.py
+++ b/tests/test_preproc_plugins.py
@@ -23,6 +23,7 @@ from menipy.common.registry import PREPROCESSORS
 
 class MockContext:
     """Mock context for testing preprocessor plugins."""
+
     def __init__(self, pipeline_name: str = "sessile"):
         self.pipeline_name = pipeline_name
         self.auto_detect_features = True
@@ -54,20 +55,20 @@ def create_pendant_test_image(
 
 class TestPluginRegistration:
     """Test that all preprocessor plugins are registered."""
-    
+
     def test_detect_substrate_registered(self):
         assert "detect_substrate" in PREPROCESSORS
-    
+
     def test_detect_needle_registered(self):
         assert "detect_needle" in PREPROCESSORS
-    
+
     def test_detect_drop_registered(self):
         assert "detect_drop" in PREPROCESSORS
-    
+
     def test_detect_roi_registered(self):
         """test_detect_roi_registered."""
         assert "detect_roi" in PREPROCESSORS
-    
+
     def test_auto_detect_registered(self):
         """test_auto_detect_registered."""
         assert "auto_detect" in PREPROCESSORS
@@ -75,14 +76,14 @@ class TestPluginRegistration:
 
 class TestSubstratePreprocessor:
     """Tests for substrate detection preprocessor."""
-    
+
     def test_detects_substrate_line(self):
         """test_detects_substrate_line."""
         ctx = MockContext()
         ctx.image = create_sessile_test_image(substrate_y=380)
-        
+
         ctx = PREPROCESSORS["detect_substrate"](ctx)
-        
+
         assert hasattr(ctx, "substrate_line")
         assert ctx.substrate_line is not None
         p1, p2 = ctx.substrate_line
@@ -92,14 +93,14 @@ class TestSubstratePreprocessor:
 
 class TestNeedlePreprocessor:
     """Tests for needle detection preprocessor."""
-    
+
     def test_detects_sessile_needle(self):
         """test_detects_sessile_needle."""
         ctx = MockContext("sessile")
         ctx.image = create_sessile_test_image()
-        
+
         ctx = PREPROCESSORS["detect_needle"](ctx)
-        
+
         assert hasattr(ctx, "needle_rect")
         if ctx.needle_rect:
             x, y, w, h = ctx.needle_rect
@@ -108,43 +109,43 @@ class TestNeedlePreprocessor:
 
 class TestDropPreprocessor:
     """Tests for drop detection preprocessor."""
-    
+
     def test_detects_sessile_drop(self):
         """test_detects_sessile_drop."""
         ctx = MockContext("sessile")
         ctx.image = create_sessile_test_image()
         ctx.substrate_line = ((0, 400), (640, 400))
-        
+
         ctx = PREPROCESSORS["detect_drop"](ctx)
-        
+
         assert hasattr(ctx, "detected_contour")
         assert ctx.detected_contour is not None
-    
+
     def test_detects_pendant_drop(self):
         """Test_detects_pendant_drop."""
         ctx = MockContext("pendant")
         ctx.image = create_pendant_test_image()
-        
+
         ctx = PREPROCESSORS["detect_drop"](ctx)
-        
+
         assert hasattr(ctx, "detected_contour")
         assert ctx.detected_contour is not None
 
 
 class TestROIPreprocessor:
     """Tests for ROI detection preprocessor."""
-    
+
     def test_computes_sessile_roi(self):
         """Test_computes_sessile_roi."""
         ctx = MockContext("sessile")
         ctx.image = create_sessile_test_image()
         ctx.substrate_line = ((0, 400), (640, 400))
-        ctx.detected_contour = np.array([
-            [240, 350], [320, 300], [400, 350], [320, 400]
-        ], dtype=np.float64)
-        
+        ctx.detected_contour = np.array(
+            [[240, 350], [320, 300], [400, 350], [320, 400]], dtype=np.float64
+        )
+
         ctx = PREPROCESSORS["detect_roi"](ctx)
-        
+
         assert hasattr(ctx, "detected_roi")
         assert ctx.detected_roi is not None
         x, y, w, h = ctx.detected_roi
@@ -153,35 +154,35 @@ class TestROIPreprocessor:
 
 class TestAutoDetectPreprocessor:
     """Tests for combined auto_detect preprocessor."""
-    
+
     def test_sessile_full_detection(self):
         """Test_sessile_full_detection."""
         ctx = MockContext("sessile")
         ctx.image = create_sessile_test_image()
-        
+
         ctx = PREPROCESSORS["auto_detect"](ctx)
-        
+
         assert hasattr(ctx, "substrate_line")
         assert hasattr(ctx, "detected_contour")
         assert hasattr(ctx, "detected_roi")
-    
+
     def test_pendant_full_detection(self):
         """Test_pendant_full_detection."""
         ctx = MockContext("pendant")
         ctx.image = create_pendant_test_image()
-        
+
         ctx = PREPROCESSORS["auto_detect"](ctx)
-        
+
         assert hasattr(ctx, "detected_contour")
         assert hasattr(ctx, "detected_roi")
-    
+
     def test_respects_auto_detect_flag(self):
         """Test_respects_auto_detect_flag."""
         ctx = MockContext("sessile")
         ctx.image = create_sessile_test_image()
         ctx.auto_detect_features = False
-        
+
         ctx = PREPROCESSORS["auto_detect"](ctx)
-        
+
         # Should not detect anything when disabled
         assert not hasattr(ctx, "substrate_line") or ctx.substrate_line is None

--- a/tests/test_preprocessing_compose.py
+++ b/tests/test_preprocessing_compose.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 from menipy.common import preprocessing
 from menipy.models.state import PreprocessingState

--- a/tests/test_preprocessing_helpers.py
+++ b/tests/test_preprocessing_helpers.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 import pytest
 

--- a/tests/test_project_loading.py
+++ b/tests/test_project_loading.py
@@ -2,14 +2,13 @@
 
 Unit tests."""
 
-
-
 import json
 import pytest
 from unittest.mock import MagicMock, patch, mock_open
 from PySide6.QtCore import QSettings
 from menipy.gui.views.adsa_main_window import ADSAMainWindow
 from menipy.gui import theme
+
 
 @pytest.fixture
 def mock_settings():
@@ -28,6 +27,7 @@ def mock_settings():
     settings.setValue.side_effect = set_val
     return settings
 
+
 @pytest.fixture
 def window(mock_settings, qtbot):
     """Create ADSAMainWindow with mocked settings."""
@@ -36,77 +36,86 @@ def window(mock_settings, qtbot):
         # We also need to mock internal components that might require GUI/Hardware
         with patch("menipy.gui.views.adsa_main_window.QStatusBar"):
             win = ADSAMainWindow()
-            win._settings_store = mock_settings # Ensure it uses our instance
+            win._settings_store = mock_settings  # Ensure it uses our instance
             qtbot.addWidget(win)
             return win
+
 
 def test_record_recent_adds_item(window, mock_settings):
     """Test that _record_recent adds items correctly."""
     # Initial state
     mock_settings.store["recent_projects"] = "[]"
-    
+
     window._record_recent(
-        experiment_type="sessile",
-        title="Test Project",
-        path="/path/to/project.adsa"
+        experiment_type="sessile", title="Test Project", path="/path/to/project.adsa"
     )
-    
+
     # Check stored value
     stored_json = mock_settings.store["recent_projects"]
     stored_list = json.loads(stored_json)
-    
+
     assert len(stored_list) == 1
     assert stored_list[0]["filename"] == "Test Project"
     assert stored_list[0]["path"] == "/path/to/project.adsa"
 
+
 def test_record_recent_deduplication(window, mock_settings):
     """Test that duplicate projects are moved to top."""
     initial = [
-        {"filename": "Old", "experiment_type": "sessile", "date_str": "2023", "path": "/p1"},
-        {"filename": "Test Project", "experiment_type": "sessile", "date_str": "2023", "path": "/p2"}
+        {
+            "filename": "Old",
+            "experiment_type": "sessile",
+            "date_str": "2023",
+            "path": "/p1",
+        },
+        {
+            "filename": "Test Project",
+            "experiment_type": "sessile",
+            "date_str": "2023",
+            "path": "/p2",
+        },
     ]
     mock_settings.store["recent_projects"] = json.dumps(initial)
-    
+
     window._record_recent(
-        experiment_type="sessile",
-        title="Test Project", # Same as existing
-        path="/p2"
+        experiment_type="sessile", title="Test Project", path="/p2"  # Same as existing
     )
-    
+
     stored_json = mock_settings.store["recent_projects"]
     stored_list = json.loads(stored_json)
-    
+
     # Should still be 2 items, but "Test Project" is now at index 0
     assert len(stored_list) == 2
     assert stored_list[0]["filename"] == "Test Project"
     assert stored_list[1]["filename"] == "Old"
 
+
 def test_open_project_file_success(window):
     """Test opening a valid project file."""
-    
+
     project_data = {
         "experiment_type": theme.EXPERIMENT_SESSILE,
         "image_path": "/path/to/image.png",
-        "analysis_settings": {"some": "settings"}
+        "analysis_settings": {"some": "settings"},
     }
-    
+
     mock_file_content = json.dumps(project_data)
-    
+
     # Mock show_experiment_window and the target window
     # We mock show_experiment_window on the instance
     window.show_experiment_window = MagicMock()
-    
+
     # We also need window.get_current_experiment_window to return something
     mock_exp_window = MagicMock()
     window.get_current_experiment_window = MagicMock(return_value=mock_exp_window)
-    
+
     with patch("builtins.open", mock_open(read_data=mock_file_content)):
         with patch("os.path.exists", return_value=True):
-             window._open_project_file("/path/to/project.adsa")
-             
-             # Assertions
-             window.show_experiment_window.assert_called_with(theme.EXPERIMENT_SESSILE)
-             
-             # Check that load_image was called on the returned window (detected via logic)
-             # _open_project_file checks for load_image or _image_source_panel
-             mock_exp_window.load_image.assert_called_with("/path/to/image.png")
+            window._open_project_file("/path/to/project.adsa")
+
+            # Assertions
+            window.show_experiment_window.assert_called_with(theme.EXPERIMENT_SESSILE)
+
+            # Check that load_image was called on the returned window (detected via logic)
+            # _open_project_file checks for load_image or _image_source_panel
+            mock_exp_window.load_image.assert_called_with("/path/to/image.png")

--- a/tests/test_sessile_auto_detection.py
+++ b/tests/test_sessile_auto_detection.py
@@ -104,7 +104,9 @@ class TestComputeSessileMetrics:
         assert metrics["diameter_mm"] > 0
         assert metrics["height_mm"] > 0
 
-    @pytest.mark.skip(reason="manual vs auto consistency currently failing; skipping until fixed")
+    @pytest.mark.skip(
+        reason="manual vs auto consistency currently failing; skipping until fixed"
+    )
     def test_manual_vs_auto_consistency(self):
         """Test that manual and auto methods give reasonable results."""
         # Create test contour

--- a/tests/test_sessile_geometry.py
+++ b/tests/test_sessile_geometry.py
@@ -2,19 +2,21 @@
 
 Test module."""
 
-
 import numpy as np
 import pytest
-from menipy.pipelines.sessile.geometry import clip_contour_to_substrate, _segment_intersection
+from menipy.pipelines.sessile.geometry import (
+    clip_contour_to_substrate,
+    _segment_intersection,
+)
 
 """
 Tests for sessile drop geometry utilities.
 Includes tests for segment intersection and contour clipping logic.
 """
 
+
 def test_segment_intersection():
-    """segment intersection.
-    """
+    """segment intersection."""
     # Crossing lines
     p1 = np.array([0, 0])
     p2 = np.array([2, 2])
@@ -43,94 +45,100 @@ def test_segment_intersection():
     # Does it check second segment? Implementation:
     # Line q = q1 + u * u_vec. It doesn't check u.
     # So it intersects LINE q with SEGMENT p.
-    
+
     inter = _segment_intersection(p1, p2, q1, q2)
-    assert inter is None # (2,2) is outside p1-p2
+    assert inter is None  # (2,2) is outside p1-p2
+
 
 def test_clip_contour_simple():
-    """clip contour simple.
-    """
+    """clip contour simple."""
     # Square contour crossing y=0
     # Points: (-1, 2), (-1, -1), (1, -1), (1, 2)
     # Substrate line: y=0
     # Apex: (0, 2)
-    
-    contour = np.array([
-        [-1, 2],
-        [-1, -1], # Crosses here between 0 and 1
-        [1, -1],
-        [1, 2]    # Crosses here between 2 and 3
-    ], dtype=float)
-    
+
+    contour = np.array(
+        [
+            [-1, 2],
+            [-1, -1],  # Crosses here between 0 and 1
+            [1, -1],
+            [1, 2],  # Crosses here between 2 and 3
+        ],
+        dtype=float,
+    )
+
     substrate = ((-2.0, 0.0), (2.0, 0.0))
     apex = (0.0, 2.0)
-    
-    # Expected: 
+
+    # Expected:
     # Starts at apex index (closest to 0,2 is index 0 or 3? Distances:
     # 0: (-1,2)->(0,2) d=1
     # 3: (1,2)->(0,2) d=1
     # Let's say apex_idx=0.
-    
+
     # Walk right (forward): 0->1.
     # 0=(-1,2), 1=(-1,-1). Crosses y=0 at (-1,0).
     # So right_contact should be (-1,0). Arc ends.
-    
+
     # Walk left (backward): 0->3.
     # 0=(-1,2), 3=(1,2). No cross.
     # 3->2. 3=(1,2), 2=(1,-1). Crosses y=0 at (1,0).
     # So left_contact should be (1,0). Arc ends.
-    
+
     # New contour: left_contact, points in arc, right_contact
     # Arc is ... 3, 0 ...
     # So [ (1,0), (1,2), (-1,2), (-1,0) ]
-    
+
     refined, contacts = clip_contour_to_substrate(contour, substrate, apex)
-    
+
     assert contacts is not None
     # Sorting: left-to-right
     left, right = contacts
     np.testing.assert_allclose(left, [-1, 0], atol=1e-5)
     np.testing.assert_allclose(right, [1, 0], atol=1e-5)
-    
+
     # Check refined contour points
     # Logic might produce them in specific order depending on start/end
     # With apex at (-1,2) (idx 0), filtered points should be above y=0
     assert np.all(refined[:, 1] >= -1e-5)
 
+
 def test_clip_contour_tilted():
-    """clip contour tilted.
-    """
+    """clip contour tilted."""
     # Tilted line y = x
     # Apex at (0, 1) (above line)
     # Contour is circle-ish
     # Points: (0, 1), (2, 1), (1, -1)
-    
+
     # Line: (-1, -1) to (3, 3)
     substrate = ((-1.0, -1.0), (3.0, 3.0))
     apex = (0.0, 1.0)
-    
-    contour = np.array([
-        [0, 1],   # Above y=x (0 < 1)
-        [2, 1],   # Below y=x (2 > 1) -> Crossing 1
-        [1, -1],  # Below
-        [-1, 1],  # Above ( -1 < 1) -> Crossing 2
-    ], dtype=float)
-    
+
+    contour = np.array(
+        [
+            [0, 1],  # Above y=x (0 < 1)
+            [2, 1],  # Below y=x (2 > 1) -> Crossing 1
+            [1, -1],  # Below
+            [-1, 1],  # Above ( -1 < 1) -> Crossing 2
+        ],
+        dtype=float,
+    )
+
     # Apex index = 0
     # Forward 0->1: (0,1) to (2,1). Intersects y=x.
     # x = y. Line segment p=(0,1)+t*(2,0) -> (2t, 1).
     # 2t = 1 => t=0.5. Point (1,1).
     # Right contact: (1,1)
-    
+
     # Backward 0->3: (0,1) to (-1,1).
     # (-1, 1) is above y=x (-1 < 1). No cross.
     # 3->2: (-1,1) to (1,-1). Intersects y=x.
     # p=(-1,1) + t*(2, -2). ( -1+2t, 1-2t ).
     # -1+2t = 1-2t => 4t=2 => t=0.5. Point (0,0).
     # Left contact: (0,0)
-    
+
     refined, contacts = clip_contour_to_substrate(contour, substrate, apex)
-    
+
     assert contacts is not None
     # Verify contacts
     c1, c2 = contacts
@@ -138,7 +146,7 @@ def test_clip_contour_tilted():
     # (0,0) and (1,1)
     np.testing.assert_allclose(c1, [0, 0], atol=1e-5)
     np.testing.assert_allclose(c2, [1, 1], atol=1e-5)
-    
+
     # Verify retained points are on "apex side"
     # Apex side: (0,1) vs y=x => y>x.
     # Retained: (0,1), (-1,1). (1,1) is on line. (0,0) is on line.
@@ -146,15 +154,15 @@ def test_clip_contour_tilted():
         # Check y >= x - epsilon
         assert p[1] >= p[0] - 1e-5
 
+
 def test_no_clipping_needed():
-    """no clipping needed.
-    """
+    """no clipping needed."""
     # All points above line
     contour = np.array([[0, 1], [1, 1], [0.5, 2]])
     substrate = ((-1, 0), (2, 0))
     apex = (0.5, 2)
-    
+
     refined, contacts = clip_contour_to_substrate(contour, substrate, apex)
-    
+
     assert len(refined) == 3
     assert contacts is None

--- a/tests/test_setup_panel.py
+++ b/tests/test_setup_panel.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import pytest
 from menipy.gui.main_window import MainWindow
 from menipy.gui.controllers.setup_panel_controller import SetupPanelController

--- a/tests/test_smoke_controller_flows.py
+++ b/tests/test_smoke_controller_flows.py
@@ -71,12 +71,14 @@ class TestSessileControllerFlows:
         mock_window.setupPanel.get_calibration_params.return_value = {
             "needle_length_mm": 0.5,
             "drop_density_kg_m3": 1000.0,
-            "fluid_density_kg_m3": 1.2
+            "fluid_density_kg_m3": 1.2,
         }
 
         # Patch QMessageBox globally for all tests in this class
-        with patch("PySide6.QtWidgets.QMessageBox.critical") as mock_critical, \
-             patch("PySide6.QtWidgets.QMessageBox.warning") as mock_warning:
+        with (
+            patch("PySide6.QtWidgets.QMessageBox.critical") as mock_critical,
+            patch("PySide6.QtWidgets.QMessageBox.warning") as mock_warning,
+        ):
             yield mock_critical, mock_warning
 
     @pytest.fixture
@@ -114,11 +116,10 @@ class TestSessileControllerFlows:
             10, 10, 100, 100
         )
 
-
         with patch("menipy.pipelines.discover.PIPELINE_MAP", PIPELINE_MAP):
             try:
                 controller.run_simple_analysis()
-                
+
                 # Verify pipeline was called and results were updated
                 controller.results_panel.update.assert_called_once()
                 controller.preview_panel.display.assert_called_once()
@@ -196,9 +197,10 @@ class TestSessileControllerFlows:
 
         controller._collect_acquisition_inputs = Mock(return_value=(True, {}))
 
-        with patch.object(controller, "_run_pipeline_direct") as mock_direct, patch(
-            "PySide6.QtWidgets.QMessageBox.critical"
-        ) as mock_critical:
+        with (
+            patch.object(controller, "_run_pipeline_direct") as mock_direct,
+            patch("PySide6.QtWidgets.QMessageBox.critical") as mock_critical,
+        ):
             mock_ctx = Mock()
             mock_ctx.preview = Mock()
             mock_ctx.results = {"diameter_mm": 2.0, "height_mm": 1.5}
@@ -317,10 +319,12 @@ class TestSessileControllerFlows:
                 # Verify that the critical dialog was shown
                 mock_critical.assert_called_once()
 
-    def test_context_population_for_staged_run(self, controller, tmp_path, mock_dialogs):
+    def test_context_population_for_staged_run(
+        self, controller, tmp_path, mock_dialogs
+    ):
         """Test that context is properly populated for staged sessile runs."""
         mock_critical, mock_warning = mock_dialogs
-        
+
         # Create test image
         img = np.zeros((120, 120, 3), dtype=np.uint8)
         cv2.circle(img, (60, 60), 30, (255, 255, 255), -1)
@@ -349,7 +353,7 @@ class TestSessileControllerFlows:
 
             try:
                 controller.run_simple_analysis()
-                
+
                 # Check for errors swallowed by mock_dialogs
                 if mock_critical.called:
                     print(f"\nCRITICAL ERROR CAPTURED: {mock_critical.call_args}")

--- a/tests/test_surface_tension.py
+++ b/tests/test_surface_tension.py
@@ -2,7 +2,6 @@
 
 Unit tests."""
 
-
 import numpy as np
 import pytest
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,55 +4,56 @@ from menipy.common.validation import validate, QAResult
 from menipy.models.context import Context
 from menipy.models.geometry import Contour
 
+
 def test_validate_empty_context():
     ctx = Context()
     res = validate(ctx)
-    
+
     assert isinstance(res, QAResult)
     assert not res.ok
     assert "convergence" in res.checks
     assert "residuals" in res.checks
     assert "contour" in res.checks
-    
+
     assert not res.checks["convergence"].passed
     assert not res.checks["contour"].passed
-    assert res.checks["residuals"].passed # No info = passed
+    assert res.checks["residuals"].passed  # No info = passed
+
 
 def test_validate_success():
     ctx = Context()
-    ctx.fit = {
-        "solver": {"success": True},
-        "residuals": {"rmse": 2.5}
-    }
-    
+    ctx.fit = {"solver": {"success": True}, "residuals": {"rmse": 2.5}}
+
     # 51 points contour
     xy = [[float(i), float(i)] for i in range(51)]
     ctx.contour = Contour(xy=xy)
-    
+
     res = validate(ctx, thresholds={"rmse": 5.0, "min_contour_points": 50})
-    
+
     assert res.ok
     assert res.checks["convergence"].passed
     assert res.checks["residuals"].passed
     assert res.checks["contour"].passed
 
+
 def test_validate_failure():
     ctx = Context()
     ctx.fit = {
         "solver": {"success": True},
-        "residuals": {"rmse": 10.0} # greater than threshold
+        "residuals": {"rmse": 10.0},  # greater than threshold
     }
-    
+
     # 10 points contour (insufficient)
     xy = [[float(i), float(i)] for i in range(10)]
     ctx.contour = Contour(xy=xy)
-    
+
     res = validate(ctx, thresholds={"rmse": 5.0, "min_contour_points": 50})
-    
+
     assert not res.ok
     assert res.checks["convergence"].passed
     assert not res.checks["residuals"].passed
     assert not res.checks["contour"].passed
+
 
 def test_to_dict():
     ctx = Context()

--- a/tests/test_young_laplace_ode.py
+++ b/tests/test_young_laplace_ode.py
@@ -5,58 +5,61 @@ from menipy.pipelines.pendant.strict_young_laplace import (
     integrate_young_laplace_profile_mm,
 )
 
+
 def test_young_laplace_sphere_limit():
     """Test that with beta=0, the shape approaches a circle radius R0."""
     R0 = 5.0
     beta = 0.0
-    
+
     # Generate profile
     profile = young_laplace_ode(np.array([R0, beta]), physics={})
-    
+
     # Expected points should fall on x^2 + (y-R0)^2 = R0^2
     # So r^2 + (z-R0)^2 = R0^2
     # The ODE starts at r=0, z=0 (apex)
-    
+
     r = profile[:, 0]
     z = profile[:, 1]
-    
-    distances_to_center = np.sqrt(r**2 + (z - R0)**2)
-    
+
+    distances_to_center = np.sqrt(r**2 + (z - R0) ** 2)
+
     # At beta=0, it should be a perfect circle
     np.testing.assert_allclose(distances_to_center, R0, rtol=1e-3, atol=1e-3)
+
 
 def test_young_laplace_positive_beta():
     """Test standard pendant drop with positive beta."""
     R0 = 2.0
     beta = 0.3
-    
+
     profile = young_laplace_ode(np.array([R0, beta]), physics={})
-    
+
     assert profile.shape[0] > 0
     assert profile.shape[1] == 2
-    
+
     # The profile should be symmetric
     n = len(profile)
     mid = n // 2
     r_left = profile[:mid, 0]
     r_right = profile[-mid:, 0]
-    
+
     # Check bounds
-    assert np.all(r_left < 1e-5) # Left side is negative or near 0
-    assert np.all(r_right > -1e-5) # Right side is positive or near 0
-    
+    assert np.all(r_left < 1e-5)  # Left side is negative or near 0
+    assert np.all(r_right > -1e-5)  # Right side is positive or near 0
+
     # Apex is approx at mid
     assert abs(profile[mid, 0]) < 1e-2
     assert abs(profile[mid, 1]) < 1e-2
+
 
 def test_young_laplace_single_param_fallback():
     """Test fallback when only R0 is provided."""
     R0 = 5.0
     profile = young_laplace_ode(np.array([R0]), physics={})
-    
+
     r = profile[:, 0]
     z = profile[:, 1]
-    distances = np.sqrt(r**2 + (z - R0)**2)
+    distances = np.sqrt(r**2 + (z - R0) ** 2)
     np.testing.assert_allclose(distances, R0, rtol=1e-3, atol=1e-3)
 
 
@@ -73,9 +76,7 @@ def test_strict_young_laplace_beta_zero_circle():
 
 def test_strict_young_laplace_positive_beta_reaches_target_height():
     """Strict model should be finite, symmetric, and cover the requested height."""
-    profile = integrate_young_laplace_profile_mm(
-        1.2, 0.6, target_height_mm=2.0
-    )
+    profile = integrate_young_laplace_profile_mm(1.2, 0.6, target_height_mm=2.0)
 
     assert profile.shape[0] > 20
     assert profile.shape[1] == 2

--- a/tools/audit_docstrings.py
+++ b/tools/audit_docstrings.py
@@ -8,7 +8,7 @@ Scans all .py and .jl files, collects:
   - Inline comment density
   - TODO/FIXME markers
   - Large commented-out code blocks
-  
+
 Output: JSON report and CSV summary.
 """
 
@@ -23,74 +23,76 @@ from typing import Any
 def count_docstrings_in_file(filepath: Path) -> dict[str, Any]:
     """
     Analyze a Python file for docstrings, comments, and code structure.
-    
+
     Parameters
     ----------
     filepath : Path
         Path to the Python file.
-    
+
     Returns
     -------
     dict
         Metrics including line count, function/class info, docstring coverage, etc.
     """
     try:
-        with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             content = f.read()
-            lines = content.split('\n')
+            lines = content.split("\n")
     except Exception as e:
         return {
-            'error': str(e),
-            'lines': 0,
-            'functions': [],
-            'classes': [],
-            'docstrings': 0,
-            'inline_comments': 0,
-            'todo_fixme': 0,
+            "error": str(e),
+            "lines": 0,
+            "functions": [],
+            "classes": [],
+            "docstrings": 0,
+            "inline_comments": 0,
+            "todo_fixme": 0,
         }
-    
+
     result = {
-        'lines': len(lines),
-        'functions': [],
-        'classes': [],
-        'module_docstring': False,
-        'docstrings': 0,
-        'inline_comments': 0,
-        'todo_fixme': 0,
-        'large_commented_blocks': 0,
-        'has_type_hints': False,
+        "lines": len(lines),
+        "functions": [],
+        "classes": [],
+        "module_docstring": False,
+        "docstrings": 0,
+        "inline_comments": 0,
+        "todo_fixme": 0,
+        "large_commented_blocks": 0,
+        "has_type_hints": False,
     }
-    
+
     # Check for module-level docstring
     triple_quote_pattern = r'^\s*""".*?"""'
     if re.search(triple_quote_pattern, content, re.MULTILINE | re.DOTALL):
-        result['module_docstring'] = True
-    
+        result["module_docstring"] = True
+
     # Count inline comments (lines with #)
-    result['inline_comments'] = sum(1 for line in lines if '#' in line and not line.strip().startswith('#'))
-    
+    result["inline_comments"] = sum(
+        1 for line in lines if "#" in line and not line.strip().startswith("#")
+    )
+
     # Count TODO/FIXME
-    result['todo_fixme'] = len(re.findall(r'(TODO|FIXME)', content, re.IGNORECASE))
-    
+    result["todo_fixme"] = len(re.findall(r"(TODO|FIXME)", content, re.IGNORECASE))
+
     # Detect type hints
-    if 'def ' in content and '->' in content:
-        result['has_type_hints'] = True
-    
+    if "def " in content and "->" in content:
+        result["has_type_hints"] = True
+
     # Find large commented-out code blocks (5+ consecutive lines starting with #)
     commented_lines = 0
     max_block = 0
     for line in lines:
-        if line.strip().startswith('#') and not line.strip().startswith('# '):
+        if line.strip().startswith("#") and not line.strip().startswith("# "):
             commented_lines += 1
             max_block = max(max_block, commented_lines)
         else:
             commented_lines = 0
-    result['large_commented_blocks'] = 1 if max_block >= 5 else 0
-    
+    result["large_commented_blocks"] = 1 if max_block >= 5 else 0
+
     # Extract functions and classes
-    func_pattern = r'^\s*def\s+(\w+)\s*\('
-    class_pattern = r'^\s*class\s+(\w+)[\s\(:]'
-    
+    func_pattern = r"^\s*def\s+(\w+)\s*\("
+    class_pattern = r"^\s*class\s+(\w+)[\s\(:]"
+
     for i, line in enumerate(lines):
         # Check for function
         func_match = re.match(func_pattern, line)
@@ -105,14 +107,16 @@ def count_docstrings_in_file(filepath: Path) -> dict[str, Any]:
                 if next_line.startswith('"""') or next_line.startswith("'''"):
                     has_docstring = True
                 break
-            result['functions'].append({
-                'name': func_name,
-                'line': i + 1,
-                'has_docstring': has_docstring,
-            })
+            result["functions"].append(
+                {
+                    "name": func_name,
+                    "line": i + 1,
+                    "has_docstring": has_docstring,
+                }
+            )
             if has_docstring:
-                result['docstrings'] += 1
-        
+                result["docstrings"] += 1
+
         # Check for class
         class_match = re.match(class_pattern, line)
         if class_match:
@@ -125,137 +129,147 @@ def count_docstrings_in_file(filepath: Path) -> dict[str, Any]:
                 if next_line.startswith('"""') or next_line.startswith("'''"):
                     has_docstring = True
                 break
-            result['classes'].append({
-                'name': class_name,
-                'line': i + 1,
-                'has_docstring': has_docstring,
-            })
+            result["classes"].append(
+                {
+                    "name": class_name,
+                    "line": i + 1,
+                    "has_docstring": has_docstring,
+                }
+            )
             if has_docstring:
-                result['docstrings'] += 1
-    
+                result["docstrings"] += 1
+
     return result
 
 
 def analyze_julia_file(filepath: Path) -> dict[str, Any]:
     """
     Analyze a Julia file for functions, comments, and TODOs.
-    
+
     Parameters
     ----------
     filepath : Path
         Path to the Julia file.
-    
+
     Returns
     -------
     dict
         Metrics for Julia files.
     """
     try:
-        with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             content = f.read()
-            lines = content.split('\n')
+            lines = content.split("\n")
     except Exception as e:
         return {
-            'error': str(e),
-            'lines': 0,
-            'functions': 0,
-            'comments': 0,
-            'todo_fixme': 0,
+            "error": str(e),
+            "lines": 0,
+            "functions": 0,
+            "comments": 0,
+            "todo_fixme": 0,
         }
-    
+
     result = {
-        'lines': len(lines),
-        'functions': len(re.findall(r'^\s*function\s+\w+', content, re.MULTILINE)),
-        'comments': sum(1 for line in lines if '#' in line),
-        'todo_fixme': len(re.findall(r'(TODO|FIXME)', content, re.IGNORECASE)),
+        "lines": len(lines),
+        "functions": len(re.findall(r"^\s*function\s+\w+", content, re.MULTILINE)),
+        "comments": sum(1 for line in lines if "#" in line),
+        "todo_fixme": len(re.findall(r"(TODO|FIXME)", content, re.IGNORECASE)),
     }
-    
+
     return result
 
 
 def audit_repo(repo_root: Path) -> dict[str, Any]:
     """
     Scan entire repo for Python and Julia files and generate audit report.
-    
+
     Parameters
     ----------
     repo_root : Path
         Root directory of the repository.
-    
+
     Returns
     -------
     dict
         Complete audit report with summary metrics and per-file details.
     """
-    py_files = list(repo_root.rglob('*.py'))
-    jl_files = list(repo_root.rglob('*.jl'))
-    
+    py_files = list(repo_root.rglob("*.py"))
+    jl_files = list(repo_root.rglob("*.jl"))
+
     # Exclude certain directories
-    exclude_dirs = {'.git', '__pycache__', '.venv', 'venv', 'build', 'dist', '.pytest_cache'}
-    
+    exclude_dirs = {
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "build",
+        "dist",
+        ".pytest_cache",
+    }
+
     py_files = [f for f in py_files if not any(ex in f.parts for ex in exclude_dirs)]
     jl_files = [f for f in jl_files if not any(ex in f.parts for ex in exclude_dirs)]
-    
+
     report = {
-        'repo_root': str(repo_root),
-        'summary': {
-            'total_python_files': len(py_files),
-            'total_julia_files': len(jl_files),
-            'total_files': len(py_files) + len(jl_files),
-            'total_lines': 0,
-            'total_functions': 0,
-            'total_classes': 0,
-            'total_todo_fixme': 0,
-            'files_with_module_docstring': 0,
-            'avg_docstring_coverage_percent': 0.0,
+        "repo_root": str(repo_root),
+        "summary": {
+            "total_python_files": len(py_files),
+            "total_julia_files": len(jl_files),
+            "total_files": len(py_files) + len(jl_files),
+            "total_lines": 0,
+            "total_functions": 0,
+            "total_classes": 0,
+            "total_todo_fixme": 0,
+            "files_with_module_docstring": 0,
+            "avg_docstring_coverage_percent": 0.0,
         },
-        'python_files': {},
-        'julia_files': {},
+        "python_files": {},
+        "julia_files": {},
     }
-    
+
     # Audit Python files
     total_func_with_docs = 0
     total_funcs = 0
-    
+
     for py_file in sorted(py_files):
         metrics = count_docstrings_in_file(py_file)
         rel_path = py_file.relative_to(repo_root)
-        report['python_files'][str(rel_path)] = metrics
-        
-        report['summary']['total_lines'] += metrics['lines']
-        report['summary']['total_functions'] += len(metrics['functions'])
-        report['summary']['total_classes'] += len(metrics['classes'])
-        report['summary']['total_todo_fixme'] += metrics['todo_fixme']
-        
-        if metrics['module_docstring']:
-            report['summary']['files_with_module_docstring'] += 1
-        
-        total_func_with_docs += metrics['docstrings']
-        total_funcs += len(metrics['functions']) + len(metrics['classes'])
-    
+        report["python_files"][str(rel_path)] = metrics
+
+        report["summary"]["total_lines"] += metrics["lines"]
+        report["summary"]["total_functions"] += len(metrics["functions"])
+        report["summary"]["total_classes"] += len(metrics["classes"])
+        report["summary"]["total_todo_fixme"] += metrics["todo_fixme"]
+
+        if metrics["module_docstring"]:
+            report["summary"]["files_with_module_docstring"] += 1
+
+        total_func_with_docs += metrics["docstrings"]
+        total_funcs += len(metrics["functions"]) + len(metrics["classes"])
+
     # Audit Julia files
     for jl_file in sorted(jl_files):
         metrics = analyze_julia_file(jl_file)
         rel_path = jl_file.relative_to(repo_root)
-        report['julia_files'][str(rel_path)] = metrics
-        
-        report['summary']['total_lines'] += metrics.get('lines', 0)
-        report['summary']['total_functions'] += metrics.get('functions', 0)
-        report['summary']['total_todo_fixme'] += metrics.get('todo_fixme', 0)
-    
+        report["julia_files"][str(rel_path)] = metrics
+
+        report["summary"]["total_lines"] += metrics.get("lines", 0)
+        report["summary"]["total_functions"] += metrics.get("functions", 0)
+        report["summary"]["total_todo_fixme"] += metrics.get("todo_fixme", 0)
+
     # Calculate average coverage
     if total_funcs > 0:
-        report['summary']['avg_docstring_coverage_percent'] = round(
+        report["summary"]["avg_docstring_coverage_percent"] = round(
             (total_func_with_docs / total_funcs) * 100, 2
         )
-    
+
     return report
 
 
 def generate_csv_summary(report: dict[str, Any], output_path: Path) -> None:
     """
     Generate a CSV summary of the audit report.
-    
+
     Parameters
     ----------
     report : dict
@@ -263,72 +277,86 @@ def generate_csv_summary(report: dict[str, Any], output_path: Path) -> None:
     output_path : Path
         Where to save the CSV.
     """
-    with open(output_path, 'w', newline='', encoding='utf-8') as csvfile:
+    with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
         writer = csv.writer(csvfile)
-        writer.writerow([
-            'File', 'Type', 'Lines', 'Functions', 'Classes', 'Module Docstring',
-            'Docstrings', 'Inline Comments', 'TODO/FIXME', 'Type Hints'
-        ])
-        
-        for rel_path, metrics in sorted(report['python_files'].items()):
-            writer.writerow([
-                rel_path,
-                'Python',
-                metrics.get('lines', 0),
-                len(metrics.get('functions', [])),
-                len(metrics.get('classes', [])),
-                'Yes' if metrics.get('module_docstring') else 'No',
-                metrics.get('docstrings', 0),
-                metrics.get('inline_comments', 0),
-                metrics.get('todo_fixme', 0),
-                'Yes' if metrics.get('has_type_hints') else 'No',
-            ])
-        
-        for rel_path, metrics in sorted(report['julia_files'].items()):
-            writer.writerow([
-                rel_path,
-                'Julia',
-                metrics.get('lines', 0),
-                metrics.get('functions', 0),
-                0,
-                'N/A',
-                'N/A',
-                metrics.get('comments', 0),
-                metrics.get('todo_fixme', 0),
-                'N/A',
-            ])
+        writer.writerow(
+            [
+                "File",
+                "Type",
+                "Lines",
+                "Functions",
+                "Classes",
+                "Module Docstring",
+                "Docstrings",
+                "Inline Comments",
+                "TODO/FIXME",
+                "Type Hints",
+            ]
+        )
+
+        for rel_path, metrics in sorted(report["python_files"].items()):
+            writer.writerow(
+                [
+                    rel_path,
+                    "Python",
+                    metrics.get("lines", 0),
+                    len(metrics.get("functions", [])),
+                    len(metrics.get("classes", [])),
+                    "Yes" if metrics.get("module_docstring") else "No",
+                    metrics.get("docstrings", 0),
+                    metrics.get("inline_comments", 0),
+                    metrics.get("todo_fixme", 0),
+                    "Yes" if metrics.get("has_type_hints") else "No",
+                ]
+            )
+
+        for rel_path, metrics in sorted(report["julia_files"].items()):
+            writer.writerow(
+                [
+                    rel_path,
+                    "Julia",
+                    metrics.get("lines", 0),
+                    metrics.get("functions", 0),
+                    0,
+                    "N/A",
+                    "N/A",
+                    metrics.get("comments", 0),
+                    metrics.get("todo_fixme", 0),
+                    "N/A",
+                ]
+            )
 
 
 def main():
     """Run the audit and save results."""
     repo_root = Path(__file__).parent.parent
     print(f"Auditing repository: {repo_root}")
-    
+
     report = audit_repo(repo_root)
-    
+
     # Create output directory
-    output_dir = repo_root / 'doc_audit'
+    output_dir = repo_root / "doc_audit"
     output_dir.mkdir(exist_ok=True)
-    
+
     # Save JSON report
-    json_output = output_dir / 'report.json'
-    with open(json_output, 'w', encoding='utf-8') as f:
+    json_output = output_dir / "report.json"
+    with open(json_output, "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2)
     print(f"✓ Saved JSON report: {json_output}")
-    
+
     # Save CSV summary
-    csv_output = output_dir / 'summary.csv'
+    csv_output = output_dir / "summary.csv"
     generate_csv_summary(report, csv_output)
     print(f"✓ Saved CSV summary: {csv_output}")
-    
+
     # Print summary to console
     print("\n" + "=" * 70)
     print("AUDIT SUMMARY")
     print("=" * 70)
-    for key, value in report['summary'].items():
+    for key, value in report["summary"].items():
         print(f"{key.replace('_', ' ').title()}: {value}")
     print("=" * 70)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/auto_fix_d200.py
+++ b/tools/auto_fix_d200.py
@@ -4,40 +4,49 @@
 This script converts docstrings that use a three-line form
 into a single-line triple-quoted form when safe to do so.
 """
+
 import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-TARGETS = ['src', 'plugins']
+TARGETS = ["src", "plugins"]
 
-PAT_DQ = re.compile(r'(?m)(?P<indent>^[ \t]*)(?:[ruRU]{0,2})"""\n(?P<text>[^\n]*?)\n[ \t]*"""')
-PAT_SQ = re.compile(r"(?m)(?P<indent>^[ \t]*)(?:[ruRU]{0,2})'''\n(?P<text>[^\n]*?)\n[ \t]*'''")
+PAT_DQ = re.compile(
+    r'(?m)(?P<indent>^[ \t]*)(?:[ruRU]{0,2})"""\n(?P<text>[^\n]*?)\n[ \t]*"""'
+)
+PAT_SQ = re.compile(
+    r"(?m)(?P<indent>^[ \t]*)(?:[ruRU]{0,2})'''\n(?P<text>[^\n]*?)\n[ \t]*'''"
+)
 
 
 def fix_text(content):
     changed = False
+
     def _repl(m):
         nonlocal changed
-        text = m.group('text').strip()
-        if '\n' in text:
+        text = m.group("text").strip()
+        if "\n" in text:
             return m.group(0)
         # avoid empty text
         if not text:
             return m.group(0)
         changed = True
-        indent = m.group('indent') or ''
+        indent = m.group("indent") or ""
         return f"{indent}" + '"""' + text + '"""'
+
     content = PAT_DQ.sub(_repl, content)
+
     def _repl2(m):
         nonlocal changed
-        text = m.group('text').strip()
-        if '\n' in text:
+        text = m.group("text").strip()
+        if "\n" in text:
             return m.group(0)
         if not text:
             return m.group(0)
         changed = True
-        indent = m.group('indent') or ''
+        indent = m.group("indent") or ""
         return f"{indent}" + "'''" + text + "'''"
+
     content = PAT_SQ.sub(_repl2, content)
     return content, changed
 
@@ -45,17 +54,18 @@ def fix_text(content):
 def main():
     modified = 0
     for base in TARGETS:
-        for p in Path(base).rglob('*.py'):
+        for p in Path(base).rglob("*.py"):
             try:
-                text = p.read_text(encoding='utf-8')
+                text = p.read_text(encoding="utf-8")
             except Exception:
                 continue
             new_text, changed = fix_text(text)
             if changed:
-                p.write_text(new_text, encoding='utf-8')
+                p.write_text(new_text, encoding="utf-8")
                 modified += 1
-                print(f'Fixed D200-like docstrings in: {p}')
-    print(f'Finished. Modified {modified} files.')
+                print(f"Fixed D200-like docstrings in: {p}")
+    print(f"Finished. Modified {modified} files.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tools/check_indent.py
+++ b/tools/check_indent.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 import tokenize
 from pathlib import Path
 

--- a/tools/generate_detailed_guide.py
+++ b/tools/generate_detailed_guide.py
@@ -16,19 +16,19 @@ from typing import Any
 
 def extract_function_args(content: str, func_name: str) -> list[str]:
     """Extract function argument names from content."""
-    pattern = rf'def {func_name}\s*\((.*?)\)'
+    pattern = rf"def {func_name}\s*\((.*?)\)"
     match = re.search(pattern, content, re.DOTALL)
     if match:
         args_str = match.group(1)
         # Remove type hints and defaults
         args = []
-        for arg in args_str.split(','):
+        for arg in args_str.split(","):
             arg = arg.strip()
-            if arg.startswith('*'):
+            if arg.startswith("*"):
                 continue
             # Remove type hints and defaults
-            arg = re.sub(r':.*?(?==|,|$)', '', arg).split('=')[0].strip()
-            if arg and arg not in ('self', 'cls'):
+            arg = re.sub(r":.*?(?==|,|$)", "", arg).split("=")[0].strip()
+            if arg and arg not in ("self", "cls"):
                 args.append(arg)
         return args
     return []
@@ -37,23 +37,23 @@ def extract_function_args(content: str, func_name: str) -> list[str]:
 def load_file_content(filepath: Path) -> str:
     """Load file content."""
     try:
-        return filepath.read_text(encoding='utf-8', errors='replace')
+        return filepath.read_text(encoding="utf-8", errors="replace")
     except:
         return ""
 
 
 def generate_remediation_guide(repo_root: Path) -> str:
     """Generate detailed remediation guide."""
-    audit_file = repo_root / 'doc_audit' / 'remediation_candidates.json'
-    
+    audit_file = repo_root / "doc_audit" / "remediation_candidates.json"
+
     if not audit_file.exists():
         return "Error: remediation_candidates.json not found"
-    
-    with open(audit_file, 'r', encoding='utf-8') as f:
+
+    with open(audit_file, "r", encoding="utf-8") as f:
         candidates = json.load(f)
-    
-    high_priority = [c for c in candidates if c['priority'] == 'HIGH']
-    
+
+    high_priority = [c for c in candidates if c["priority"] == "HIGH"]
+
     lines = []
     lines.append("""# Detailed Remediation Guide (HIGH Priority)
 
@@ -110,25 +110,31 @@ def example_function(param1, param2):
 ## File-by-File Remediation Details
 
 """)
-    
+
     for i, candidate in enumerate(high_priority[:15], 1):
-        path = candidate['path']
-        metrics = candidate['metrics']
-        
-        undoc_funcs = [f for f in metrics.get('functions', []) if not f['has_docstring']]
-        undoc_classes = [c for c in metrics.get('classes', []) if not c['has_docstring']]
-        
+        path = candidate["path"]
+        metrics = candidate["metrics"]
+
+        undoc_funcs = [
+            f for f in metrics.get("functions", []) if not f["has_docstring"]
+        ]
+        undoc_classes = [
+            c for c in metrics.get("classes", []) if not c["has_docstring"]
+        ]
+
         if not undoc_funcs and not undoc_classes:
             continue
-        
+
         lines.append(f"\n### {i}. {path}\n")
-        lines.append(f"**Status**: {len(undoc_funcs)} functions, {len(undoc_classes)} classes missing docstrings\n")
-        
+        lines.append(
+            f"**Status**: {len(undoc_funcs)} functions, {len(undoc_classes)} classes missing docstrings\n"
+        )
+
         file_path = repo_root / path
         content = load_file_content(file_path)
-        
+
         # Add module docstring recommendation if missing
-        if not metrics.get('module_docstring'):
+        if not metrics.get("module_docstring"):
             lines.append("\n**ACTION: Add Module Docstring**\n\n")
             lines.append("Add this at the very top of the file:\n\n")
             lines.append("```python\n")
@@ -137,21 +143,21 @@ def example_function(param1, param2):
             lines.append("including [main components/responsibilities].\n")
             lines.append('"""\n')
             lines.append("```\n\n")
-        
+
         # List undocumented functions
         if undoc_funcs:
             lines.append(f"\n**Undocumented Functions** ({len(undoc_funcs)}):\n\n")
             for func in undoc_funcs[:3]:
-                fname = func['name']
+                fname = func["name"]
                 args = extract_function_args(content, fname)
                 args_str = ", ".join(args) if args else ""
                 lines.append(f"- `{fname}({args_str})`\n")
-            
+
             if len(undoc_funcs) > 3:
                 lines.append(f"- ... and {len(undoc_funcs) - 3} more\n")
-            
+
             lines.append("\n")
-    
+
     lines.append("\n---\n\n## General Remediation Checklist\n\n")
     lines.append("For each HIGH-priority file:\n\n")
     lines.append("- [ ] Add module-level docstring (3-5 sentences)\n")
@@ -160,26 +166,26 @@ def example_function(param1, param2):
     lines.append("- [ ] Explain any magic numbers with inline comments\n")
     lines.append("- [ ] Remove or explain large commented-out code blocks\n")
     lines.append("- [ ] Ensure type hints on function signatures\n\n")
-    
+
     lines.append("## Coverage Targets After Remediation\n\n")
     lines.append("- **Current avg coverage**: 47.69%\n")
     lines.append("- **Target HIGH priority**: 85%+\n")
     lines.append("- **Target MEDIUM priority**: 70%+\n")
     lines.append("- **Target LOW priority**: 60%+\n")
-    
+
     return "\n".join(lines)
 
 
 def main():
     repo_root = Path(__file__).parent.parent
     guide_content = generate_remediation_guide(repo_root)
-    
-    output_file = repo_root / 'doc_audit' / 'REMEDIATION_GUIDE.md'
-    output_file.write_text(guide_content, encoding='utf-8')
-    
+
+    output_file = repo_root / "doc_audit" / "REMEDIATION_GUIDE.md"
+    output_file.write_text(guide_content, encoding="utf-8")
+
     print(f"✓ Saved detailed remediation guide: {output_file}")
     print(f"✓ File size: {len(guide_content)} bytes")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/generate_remediation_plan.py
+++ b/tools/generate_remediation_plan.py
@@ -13,33 +13,32 @@ from pathlib import Path
 from typing import Any
 import sys
 
-
 PRIORITY_RULES = {
     # HIGH priority: core modules and public API
-    'HIGH': [
-        r'src/menipy/gui/',
-        r'src/menipy/cli.py',
-        r'src/menipy/common/',
-        r'src/menipy/models/',
-        r'plugins/',
-        r'src/menipy/__init__.py',
-        r'src/menipy/__main__.py',
-        r'examples/',
+    "HIGH": [
+        r"src/menipy/gui/",
+        r"src/menipy/cli.py",
+        r"src/menipy/common/",
+        r"src/menipy/models/",
+        r"plugins/",
+        r"src/menipy/__init__.py",
+        r"src/menipy/__main__.py",
+        r"examples/",
     ],
     # MEDIUM priority: pipeline modules, utilities
-    'MEDIUM': [
-        r'src/menipy/pipelines/',
-        r'scripts/',
-        r'geometry.py',
-        r'pendant_detections.py',
+    "MEDIUM": [
+        r"src/menipy/pipelines/",
+        r"scripts/",
+        r"geometry.py",
+        r"pendant_detections.py",
     ],
     # LOW priority: test support, temporary, prototypes
-    'LOW': [
-        r'tests/',
-        r'pruebas/',
-        r'playground/',
-        r'.tmp/',
-    ]
+    "LOW": [
+        r"tests/",
+        r"pruebas/",
+        r"playground/",
+        r".tmp/",
+    ],
 }
 
 
@@ -47,92 +46,99 @@ def classify_priority(rel_path: str) -> str:
     """Classify file priority based on path patterns."""
     for priority, patterns in PRIORITY_RULES.items():
         for pattern in patterns:
-            if pattern.rstrip('/') in rel_path or rel_path.startswith(pattern):
+            if pattern.rstrip("/") in rel_path or rel_path.startswith(pattern):
                 return priority
-    return 'MEDIUM'
+    return "MEDIUM"
 
 
 def calculate_remediation_effort(metrics: dict) -> tuple[int, str]:
     """
     Estimate effort and identify gaps.
-    
+
     Returns: (effort_score, summary_string)
     Effort score: 1-5 (1=easy, 5=hard)
     """
-    lines = metrics.get('lines', 0)
-    funcs = len(metrics.get('functions', []))
-    classes = len(metrics.get('classes', []))
-    docstrings = metrics.get('docstrings', 0)
-    
-    no_module_doc = 0 if metrics.get('module_docstring') else 1
+    lines = metrics.get("lines", 0)
+    funcs = len(metrics.get("functions", []))
+    classes = len(metrics.get("classes", []))
+    docstrings = metrics.get("docstrings", 0)
+
+    no_module_doc = 0 if metrics.get("module_docstring") else 1
     undocumented_funcs = funcs + classes - docstrings
-    
+
     issues = []
-    
+
     if no_module_doc:
-        issues.append('missing_module_docstring')
-    
+        issues.append("missing_module_docstring")
+
     if undocumented_funcs > 0:
         coverage = f"{(docstrings / (funcs + classes) * 100) if (funcs + classes) > 0 else 0:.1f}%"
-        issues.append(f'low_docstring_coverage_{coverage}')
-    
-    if metrics.get('large_commented_blocks'):
-        issues.append('large_commented_blocks')
-    
-    if metrics.get('todo_fixme', 0) > 0:
+        issues.append(f"low_docstring_coverage_{coverage}")
+
+    if metrics.get("large_commented_blocks"):
+        issues.append("large_commented_blocks")
+
+    if metrics.get("todo_fixme", 0) > 0:
         issues.append(f'todo_fixme_x{metrics["todo_fixme"]}')
-    
-    if not metrics.get('has_type_hints') and (funcs + classes) > 5:
-        issues.append('missing_type_hints')
-    
+
+    if not metrics.get("has_type_hints") and (funcs + classes) > 5:
+        issues.append("missing_type_hints")
+
     # Calculate effort as tuple for sorting
-    effort = min(5, (undocumented_funcs // 5) + no_module_doc + (1 if metrics.get('large_commented_blocks') else 0))
-    
-    return effort, ' | '.join(issues)
+    effort = min(
+        5,
+        (undocumented_funcs // 5)
+        + no_module_doc
+        + (1 if metrics.get("large_commented_blocks") else 0),
+    )
+
+    return effort, " | ".join(issues)
 
 
 def generate_remediation_plan(report: dict[str, Any]) -> list[dict]:
     """
     Create prioritized list of files needing remediation.
-    
+
     Returns list of dicts with: path, priority, effort, issues, remediation_steps
     """
     candidates = []
-    
-    for rel_path, metrics in report['python_files'].items():
+
+    for rel_path, metrics in report["python_files"].items():
         # Skip tiny files and test temporaries
-        if metrics.get('lines', 0) < 10:
+        if metrics.get("lines", 0) < 10:
             continue
-        if '.tmp' in rel_path or '__pycache__' in rel_path:
+        if ".tmp" in rel_path or "__pycache__" in rel_path:
             continue
-        
+
         priority = classify_priority(rel_path)
         effort, issues = calculate_remediation_effort(metrics)
-        
+
         if not issues:
             continue  # Skip files with no issues
-        
-        candidates.append({
-            'path': rel_path,
-            'priority': priority,
-            'effort': effort,
-            'issues': issues,
-            'metrics': metrics,
-        })
-    
+
+        candidates.append(
+            {
+                "path": rel_path,
+                "priority": priority,
+                "effort": effort,
+                "issues": issues,
+                "metrics": metrics,
+            }
+        )
+
     # Sort: HIGH first, then by effort (ascending), then by path
-    priority_order = {'HIGH': 0, 'MEDIUM': 1, 'LOW': 2}
+    priority_order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
     candidates.sort(
-        key=lambda x: (priority_order[x['priority']], x['effort'], x['path'])
+        key=lambda x: (priority_order[x["priority"]], x["effort"], x["path"])
     )
-    
+
     return candidates
 
 
 def render_remediation_report(candidates: list[dict], output_path: Path) -> None:
     """
     Write a human-readable remediation report in Markdown.
-    
+
     Parameters
     ----------
     candidates : list[dict]
@@ -140,7 +146,7 @@ def render_remediation_report(candidates: list[dict], output_path: Path) -> None
     output_path : Path
         Where to save the report.
     """
-    with open(output_path, 'w', encoding='utf-8') as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write("""# Docstring & Comment Remediation Plan
 
 ## Summary
@@ -157,35 +163,39 @@ This report identifies files with insufficient docstrings/comments and recommend
 ## Files Requiring Remediation
 
 """)
-        
+
         current_priority = None
         for i, cand in enumerate(candidates, 1):
-            if cand['priority'] != current_priority:
-                current_priority = cand['priority']
+            if cand["priority"] != current_priority:
+                current_priority = cand["priority"]
                 f.write(f"\n### {current_priority} Priority\n\n")
-            
-            path = cand['path']
-            metrics = cand['metrics']
-            effort = cand['effort']
-            issues = cand['issues']
-            
-            funcs = len(metrics.get('functions', []))
-            classes = len(metrics.get('classes', []))
-            docstrings = metrics.get('docstrings', 0)
+
+            path = cand["path"]
+            metrics = cand["metrics"]
+            effort = cand["effort"]
+            issues = cand["issues"]
+
+            funcs = len(metrics.get("functions", []))
+            classes = len(metrics.get("classes", []))
+            docstrings = metrics.get("docstrings", 0)
             total = funcs + classes
             coverage = f"{(docstrings / total * 100):.1f}%" if total > 0 else "N/A"
-            
+
             f.write(f"**{i}. {path}**\n")
-            f.write(f"   - **Effort**: {effort}/5 | **Coverage**: {coverage} ({docstrings}/{total})\n")
+            f.write(
+                f"   - **Effort**: {effort}/5 | **Coverage**: {coverage} ({docstrings}/{total})\n"
+            )
             f.write(f"   - **Issues**: {issues}\n")
-            f.write(f"   - **Lines**: {metrics.get('lines', 0)} | **TODO/FIXME**: {metrics.get('todo_fixme', 0)}\n\n")
-        
+            f.write(
+                f"   - **Lines**: {metrics.get('lines', 0)} | **TODO/FIXME**: {metrics.get('todo_fixme', 0)}\n\n"
+            )
+
         # Statistics
         f.write("\n## Statistics\n\n")
-        high_count = sum(1 for c in candidates if c['priority'] == 'HIGH')
-        medium_count = sum(1 for c in candidates if c['priority'] == 'MEDIUM')
-        low_count = sum(1 for c in candidates if c['priority'] == 'LOW')
-        
+        high_count = sum(1 for c in candidates if c["priority"] == "HIGH")
+        medium_count = sum(1 for c in candidates if c["priority"] == "MEDIUM")
+        low_count = sum(1 for c in candidates if c["priority"] == "LOW")
+
         f.write(f"- **HIGH priority files**: {high_count}\n")
         f.write(f"- **MEDIUM priority files**: {medium_count}\n")
         f.write(f"- **LOW priority files**: {low_count}\n")
@@ -195,36 +205,36 @@ This report identifies files with insufficient docstrings/comments and recommend
 
 def main():
     """Generate remediation plan."""
-    audit_file = Path(__file__).parent.parent / 'doc_audit' / 'report.json'
-    
+    audit_file = Path(__file__).parent.parent / "doc_audit" / "report.json"
+
     if not audit_file.exists():
         print(f"Error: {audit_file} not found. Run audit_docstrings.py first.")
         sys.exit(1)
-    
-    with open(audit_file, 'r', encoding='utf-8') as f:
+
+    with open(audit_file, "r", encoding="utf-8") as f:
         report = json.load(f)
-    
+
     candidates = generate_remediation_plan(report)
-    
+
     # Save remediation plan
     output_dir = audit_file.parent
-    plan_file = output_dir / 'remediation_plan.md'
+    plan_file = output_dir / "remediation_plan.md"
     render_remediation_report(candidates, plan_file)
     print(f"✓ Saved remediation plan: {plan_file}")
-    
+
     # Also save as JSON for programmatic use
-    json_plan = output_dir / 'remediation_candidates.json'
-    with open(json_plan, 'w', encoding='utf-8') as f:
+    json_plan = output_dir / "remediation_candidates.json"
+    with open(json_plan, "w", encoding="utf-8") as f:
         json.dump(candidates, f, indent=2, default=str)
     print(f"✓ Saved remediation candidates (JSON): {json_plan}")
-    
+
     # Print summary
     print("\n" + "=" * 70)
     print("REMEDIATION PLAN SUMMARY")
     print("=" * 70)
-    high = sum(1 for c in candidates if c['priority'] == 'HIGH')
-    medium = sum(1 for c in candidates if c['priority'] == 'MEDIUM')
-    low = sum(1 for c in candidates if c['priority'] == 'LOW')
+    high = sum(1 for c in candidates if c["priority"] == "HIGH")
+    medium = sum(1 for c in candidates if c["priority"] == "MEDIUM")
+    low = sum(1 for c in candidates if c["priority"] == "LOW")
     print(f"HIGH priority: {high}")
     print(f"MEDIUM priority: {medium}")
     print(f"LOW priority: {low}")
@@ -232,5 +242,5 @@ def main():
     print("=" * 70)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/inspect_ui.py
+++ b/tools/inspect_ui.py
@@ -2,7 +2,6 @@
 
 Module implementation."""
 
-
 from importlib import import_module
 from PySide6.QtWidgets import QApplication, QWidget
 import sys

--- a/tools/migrate_datatypes_imports.py
+++ b/tools/migrate_datatypes_imports.py
@@ -244,8 +244,7 @@ def apply_rewrites(planned: Dict[Path, List[Tuple[str, str, str]]]) -> None:
 
 
 def main() -> None:
-    """Entry point.
-    """
+    """Entry point."""
     parser = argparse.ArgumentParser(
         description="Migrate imports from menipy.models.datatypes to new model modules"
     )


### PR DESCRIPTION
## Summary

Fixes all three failing CI workflows on `main`.

---

### 1. CI (test) — `ImportError: libEGL.so.1`

**Root cause:** `pytest-qt` initialises Qt during collection, and the Ubuntu GitHub Actions runner lacks the EGL/Mesa libraries and a display server.

**Fix (`ci.yml`):**
- Install `libegl1`, `libgles2`, `libopengl0`, and the required `libxcb-*` packages before running tests
- Wrap `pytest` with `xvfb-run -a` to provide a virtual framebuffer

### 2. Lint — `black --check` (221 files, exit 123)

**Root cause:** 221 source files were never formatted with Black.

**Fix:** Ran `black .` across `src/`, `tests/`, and `tools/` — 159 files reformatted.

### 3. Lint matrix redundancy

**Fix (`lint.yml`):** Formatting and linting rules are Python-version–independent. Removed the `matrix: python-version: [3.10, 3.11]` and pinned to 3.11. This halves lint CI runtime at no quality cost.

---

### Pre-commit
The pre-commit workflow was failing for the same Black formatting reason. It should pass once the formatted code is on the branch.
